### PR TITLE
Gas limit and price overrides

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -142,7 +142,10 @@ var monitorCmd = &cobra.Command{
 				if from.Cmp(zero) < 0 {
 					from.SetInt64(0)
 				}
-				_ = ms.getBlockRange(ctx, from, ms.HeadBlock, rpc, args[0])
+				err = ms.getBlockRange(ctx, from, ms.HeadBlock, rpc, args[0])
+				if err != nil {
+					log.Error().Err(err).Msg("there was an issue fetching the block range")
+				}
 				if !isUiRendered {
 					go func() {
 						errChan <- renderMonitorUI(ms)
@@ -190,7 +193,7 @@ func (ms *monitorStatus) getBlockRange(ctx context.Context, from, to *big.Int, c
 	}
 	for _, b := range blms {
 		if b.Error != nil {
-			return err
+			return b.Error
 		}
 		pb := rpctypes.NewPolyBlock(b.Result.(*rpctypes.RawBlockResponse))
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -239,7 +239,7 @@ func GetSimpleTxFields(tx rpctypes.PolyTransaction, chainID, baseFee *big.Int) [
 	fields = append(fields, fmt.Sprintf("From: %s", tx.From()))
 	fields = append(fields, fmt.Sprintf("Method: %s", txMethod))
 	fields = append(fields, fmt.Sprintf("Value: %s", tx.Value()))
-	fields = append(fields, fmt.Sprintf("Gas: %d", tx.Gas()))
+	fields = append(fields, fmt.Sprintf("Gas Limit: %d", tx.Gas()))
 	fields = append(fields, fmt.Sprintf("Gas Price: %s", tx.GasPrice()))
 	fields = append(fields, fmt.Sprintf("Nonce: %d", tx.Nonce()))
 	fields = append(fields, fmt.Sprintf("Data Len: %d", len(tx.Data())))


### PR DESCRIPTION
Adding flags to load test to support setting the gas price and gas limit statically. The dynamic calculation can break for edge because it doesn't support the pending header

# Testing

- [x] Run a normal transfer-type load test. This should work
- [x] Run a load test that depends on a contract deployment

`go run main.go loadtest --verbosity 700 --chain-id 100 --concurrency 1 --requests 100 --rate-limit 0.5  --mode t --iterations 2048 http://localhost:10002`

`go run main.go loadtest --verbosity 700 --chain-id 100 --concurrency 1 --requests 100 --rate-limit 0.5  --mode f --function 164 --iterations 2048 http://localhost:10002 --gas-limit 5242880`
