### PR TITLE
[DVT-299] fix: increase golangci-lint timeout to 3min

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout 3m --verbose
       - name: Install shadow
         run: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
       - name: Run shadow


### PR DESCRIPTION
# Description

The latest `test` job executed on the `main` branch failed because `golangci-lint` exceeded the timeout (see [here](https://github.com/maticnetwork/polygon-cli/actions/runs/3540084689/jobs/5942726319)).
<img width="1107" alt="Screenshot 2022-11-24 at 12 26 03" src="https://user-images.githubusercontent.com/28714795/203772992-0a1a518e-528d-4231-a6e8-bb6bf682c581.png">

By default, `golangci-lint` timeout is set to 1 minute which is not enough - 3 minutes should be enough.
This is an [ongoing issue](https://github.com/golangci/golangci-lint-action/issues/297) in the golangci-lint repository.

## Jira / Linear Tickets

- [DVT-299]

# Testing

The `test` job of this PR didn't fail :)


[DVT-299]: https://polygon.atlassian.net/browse/DVT-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ