### PR TITLE
DVT-402 Implement summarization performance improvements

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1343,9 +1343,9 @@ func summarizeTransactions(ctx context.Context, c *ethclient.Client, rpc *ethrpc
 	}
 	// TODO: Add some kind of decimation to avoid summarizing for 10 minutes?
 	batchSize := *ltp.BatchSize
-	cpuCount := *ltp.Concurrency
+	goRoutineLimit := *ltp.Concurrency
 	var txGroup sync.WaitGroup
-	threadPool := make(chan bool, cpuCount)
+	threadPool := make(chan bool, goRoutineLimit)
 	log.Trace().Msg("Starting tx receipt capture")
 	rawTxReceipts := make([]*json.RawMessage, 0)
 	var rawTxReceiptsLock sync.Mutex

--- a/util/util.go
+++ b/util/util.go
@@ -99,6 +99,10 @@ func GetReceipts(ctx context.Context, rawBlocks []*json.RawMessage, c *ethrpc.Cl
 		// polycli dumpblocks -c 1 http://127.0.0.1:9209/ 34457958 34458108
 		// To handle this i'm making an exception when start and end are equal to make a single call
 		if start == end {
+			log.Trace().Int("length", len(blmsBlockMap)).Msg("Test Jesse")
+			if len(blmsBlockMap) == int(start) {
+				start = start - 1
+			}
 			err := c.CallContext(ctx, &blms[start].Result, "eth_getTransactionReceipt", blms[start].Args[0])
 			if err != nil {
 				log.Error().Err(err).Uint64("start", start).Uint64("end", end).Msg("rpc issue fetching single receipt")


### PR DESCRIPTION
# Description

find some faster mechanisms to produce the summary. I assume we should be able to one of the following:
- Down sampling to get an approximation
- Batching or parallelization changes
- A different methodology for computing summary
- Perhaps a method that doesn’t fetch the receipts at all

## Jira / Linear Tickets

- [DVT-402](https://polygon.atlassian.net/browse/DVT-402)

# Testing

Steps
1. Start geth
2. Allocate funds
3. Run load test
4. Stop geth
5. Make changes
6. Start geth
7. Run load test

Try setting for loop concurrencies:
set requests=10000 to test out how long the receipt fetching takes. seems like the receipt fetching has to iterate 500 times. tested out with concurrency 1 and with len(rawBlocks).

Try tweaking batch size and thread pool parameters
Increase the batch size... Try batches of like 100, 500, 1000, 2500, 5000... See if that changes anything
Increase the thread pool size, right now it's limited to the number of CPUs, but I think you could probably try 2x, 4x, 8x, 16x the number of cpus to see if it changes anything


[DVT-402]: https://polygon.atlassian.net/browse/DVT-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ