### PR TITLE
feat: add the commit number to the version when building polycli manually with make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run: ## Run the go program.
 
 .PHONY: build
 build: $(BUILD_DIR) ## Build go binary.
-	go build -o $(BUILD_DIR)/$(BIN_NAME) main.go
+	go build -ldflags "-s -w -X \"github.com/maticnetwork/polygon-cli/cmd/version.Version=dev ($(GIT_SHA))\"" -o $(BUILD_DIR)/$(BIN_NAME) main.go
 
 .PHONY: cross
 cross: $(BUILD_DIR) ## Cross-compile go binaries using CGO.


### PR DESCRIPTION
# Description

When building `polycli` manually with `make build`, the version is set to `Dev` by default.

```sh
# before
$ make build
$ ./out/polycli version 
Polygon CLI Version dev
```

Instead, I'd like to add the commit number to the version.
```sh
# after
$ git rev-parse HEAD | cut -c1-8
9ad76b67

$ make build
$ ./out/polycli version
Polygon CLI Version dev (9ad76b67)
```
