### PR TITLE
fix: polycli abi hangs when no input is provided

### DIFF
--- a/cmd/abi/abi.go
+++ b/cmd/abi/abi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,6 +35,10 @@ go run main.go abi < ../zkevm-node/etherman/smartcontracts/abi/polygonzkevm.abi
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// it would be nice to have a generic reader
+
+		if *inputData == "" && *inputFileName == "" && len(args) == 0 {
+			return errors.New("no contract ABI provided")
+		}
 
 		rawData, err := getInputData(cmd, args)
 		if err != nil {


### PR DESCRIPTION
# Description

`go run main.go abi` hangs without giving any error message.

## Jira / Linear Tickets

x

# Testing

Here's the new behaviour:
```sh
$ go run main.go abi                                                                                               took 4s at 08:55:13
Error: no contract ABI provided
Usage:
  polycli abi Contract.abi [flags]

Flags:
      --data string   Provide input data to be unpacked based on the ABI defintion
      --file string   Provide a filename to read and analyze
  -h, --help          help for abi

Global Flags:
      --config string   config file (default is $HOME/.polygon-cli.yaml)

exit status 1
```

Some regression tests:
- [x] `go run main.go abi < file.abi` works
- [x] `go run main.go abi --file file.abi` also works
- [ ] `go run main.go abi --data < file.abi` works (not tested)
