### PR TITLE
fix: zkevm block order

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -140,11 +140,6 @@ var MonitorCmd = &cobra.Command{
 
 				from := big.NewInt(0)
 
-				// batchSize := *inputBatchSize
-				// if *inputBatchSize > 0 {
-				// 	batchSize = *inputBatchSize
-				// }
-
 				// if the max block is 0, meaning we haven't fetched any blocks, we're going to start with head - batchSize
 				if ms.MaxBlockRetrieved.Cmp(from) == 0 {
 					headBlockMinusBatchSize := new(big.Int).SetUint64(*inputBatchSize + 100 - 1)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -40,6 +40,9 @@ func (a SortableBlocks) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 func (a SortableBlocks) Less(i, j int) bool {
+	if a[i].Time() == a[j].Time() {
+		return a[i].Number().Int64() < a[j].Number().Int64()
+	}
 	return a[i].Time() < a[j].Time()
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -40,10 +40,7 @@ func (a SortableBlocks) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 func (a SortableBlocks) Less(i, j int) bool {
-	if a[i].Time() == a[j].Time() {
-		return a[i].Number().Int64() < a[j].Number().Int64()
-	}
-	return a[i].Time() < a[j].Time()
+	return a[i].Number().Int64() < a[j].Number().Int64()
 }
 
 func GetMeanBlockTime(blocks []rpctypes.PolyBlock) float64 {


### PR DESCRIPTION
# Description

While monitoring the `zkevm` testnet, we noticed that many blocks have the same timestamp. For example, I found that 150 blocks have the same timestamp. Unfortunately, `polycli` compares blocks based on their timestamp but we don't handle the case where blocks have the same timestamp... In this case, we should compare the block numbers.

This is why the blocks are not rendered in the right order.

<img width="1501" alt="not-ordered-blocks" src="https://user-images.githubusercontent.com/28714795/219358465-1b0d88af-2b3d-4761-aa44-dc3f252daf6f.png">


## Jira / Linear Tickets

- [DVT-501]()

# Testing

Blocks are now rendered in the correct order.

<img width="1501" alt="Screenshot 2023-02-16 at 12 54 19" src="https://user-images.githubusercontent.com/28714795/219358249-d24082f1-0d06-41be-90fe-4c20aacb318c.png">


[DVT-501]: https://polygon.atlassian.net/browse/DVT-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ