### PR TITLE
[DVT-380] Add block rewards

### DIFF
--- a/cmd/forge/block_reader.go
+++ b/cmd/forge/block_reader.go
@@ -1,0 +1,188 @@
+package forge
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/maticnetwork/polygon-cli/proto/gen/pb"
+	"github.com/maticnetwork/polygon-cli/rpctypes"
+	"google.golang.org/protobuf/proto"
+)
+
+type (
+	BlockReader interface {
+		ReadBlock() (rpctypes.PolyBlock, error)
+	}
+	JSONBlockReader struct {
+		scanner *bufio.Scanner
+	}
+	ProtoBlockReader struct {
+		file   *os.File
+		offset int64
+	}
+)
+
+// OpenBlockReader returns a block reader object which can be used to read the
+// file. It will return a mode specific block reader.
+func OpenBlockReader(file string, mode string) (BlockReader, error) {
+	blockFile, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open %s blocks file: %w", file, err)
+	}
+
+	switch mode {
+	case "json":
+		maxCapacity := 5 * 1024 * 1024
+		buf := make([]byte, maxCapacity)
+		scanner := bufio.NewScanner(blockFile)
+		scanner.Buffer(buf, maxCapacity)
+
+		br := JSONBlockReader{
+			scanner: scanner,
+		}
+		return &br, nil
+
+	case "proto":
+		br := ProtoBlockReader{
+			file: blockFile,
+		}
+		return &br, nil
+
+	default:
+		return nil, fmt.Errorf("invalid mode: %s", mode)
+	}
+}
+
+func (blockReader *JSONBlockReader) ReadBlock() (rpctypes.PolyBlock, error) {
+	if !blockReader.scanner.Scan() {
+		return nil, BlockReadEOF
+	}
+
+	rawBlockBytes := blockReader.scanner.Bytes()
+	var raw rpctypes.RawBlockResponse
+	err := json.Unmarshal(rawBlockBytes, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal file block: %w - %s", err, string(rawBlockBytes))
+	}
+	return rpctypes.NewPolyBlock(&raw), nil
+}
+
+func (blockReader *ProtoBlockReader) ReadBlock() (rpctypes.PolyBlock, error) {
+	// reading the length of the encoded item before reading each item
+	buf := make([]byte, 4)
+	if _, err := blockReader.file.ReadAt(buf, blockReader.offset); err != nil {
+		return nil, err
+	}
+	itemSize := binary.LittleEndian.Uint32(buf)
+	blockReader.offset += 4
+
+	// reading the actual encoded item
+	item := make([]byte, itemSize)
+	if _, err := blockReader.file.ReadAt(item, blockReader.offset); err != nil {
+		return nil, err
+	}
+
+	block := &pb.Block{}
+	if err := proto.Unmarshal(item, block); err != nil {
+		return nil, err
+	}
+
+	blockReader.offset += int64(itemSize)
+
+	txs := []rpctypes.RawTransactionResponse{}
+	for _, tx := range block.Transactions {
+		to := ""
+		if tx.To != nil {
+			to = *tx.To
+		}
+
+		txs = append(txs, rpctypes.RawTransactionResponse{
+			BlockHash:        rpctypes.RawData32Response(tx.BlockHash),
+			BlockNumber:      rpctypes.RawQuantityResponse(tx.BlockNumber),
+			From:             rpctypes.RawData20Response(tx.From),
+			Gas:              rpctypes.RawQuantityResponse(tx.Gas),
+			GasPrice:         rpctypes.RawQuantityResponse(tx.GasPrice),
+			Hash:             rpctypes.RawData32Response(tx.Hash),
+			Input:            rpctypes.RawDataResponse(tx.Input),
+			Nonce:            rpctypes.RawQuantityResponse(tx.Nonce),
+			To:               rpctypes.RawData20Response(to),
+			TransactionIndex: rpctypes.RawQuantityResponse(tx.TransactionIndex),
+			Value:            rpctypes.RawQuantityResponse(tx.Value),
+			V:                rpctypes.RawQuantityResponse(tx.V),
+			R:                rpctypes.RawQuantityResponse(tx.R),
+			S:                rpctypes.RawQuantityResponse(tx.S),
+			Type:             rpctypes.RawQuantityResponse(tx.Type),
+		})
+	}
+
+	uncles := []rpctypes.RawData32Response{}
+	for _, uncle := range block.Uncles {
+		uncles = append(uncles, rpctypes.RawData32Response(uncle))
+	}
+
+	raw := rpctypes.RawBlockResponse{
+		Number:           rpctypes.RawQuantityResponse(block.Number),
+		Hash:             rpctypes.RawData32Response(block.Hash),
+		ParentHash:       rpctypes.RawData32Response(block.ParentHash),
+		Nonce:            rpctypes.RawData8Response(block.Nonce),
+		SHA3Uncles:       rpctypes.RawData32Response(block.Sha3Uncles),
+		LogsBloom:        rpctypes.RawData256Response(block.LogsBloom),
+		TransactionsRoot: rpctypes.RawData32Response(block.TransactionsRoot),
+		StateRoot:        rpctypes.RawData32Response(block.StateRoot),
+		ReceiptsRoot:     rpctypes.RawData32Response(block.ReceiptsRoot),
+		Miner:            rpctypes.RawData20Response(block.Miner),
+		Difficulty:       rpctypes.RawQuantityResponse(block.Difficulty),
+		TotalDifficulty:  rpctypes.RawQuantityResponse(block.TotalDifficulty),
+		ExtraData:        rpctypes.RawDataResponse(block.ExtraData),
+		Size:             rpctypes.RawQuantityResponse(block.Size),
+		GasLimit:         rpctypes.RawQuantityResponse(block.GasLimit),
+		GasUsed:          rpctypes.RawQuantityResponse(block.GasUsed),
+		Timestamp:        rpctypes.RawQuantityResponse(block.Timestamp),
+		Transactions:     txs,
+		Uncles:           uncles,
+		BaseFeePerGas:    rpctypes.RawQuantityResponse(block.BaseFeePerGas),
+	}
+
+	return rpctypes.NewPolyBlock(&raw), nil
+}
+
+func ReadProtoFromFile(filepath string) ([][]byte, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	var offset int64
+	content := make([][]byte, 0)
+
+	for {
+		// reading the length of the encoded item before reading each item
+		buf := make([]byte, 4)
+		if _, err := file.ReadAt(buf, offset); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		itemSize := binary.LittleEndian.Uint32(buf)
+		offset += 4
+
+		// reading the actual encoded item
+		item := make([]byte, itemSize)
+		if _, err := file.ReadAt(item, offset); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		content = append(content, item)
+		offset += int64(itemSize)
+	}
+
+	return content, nil
+}

--- a/cmd/forge/block_reader.go
+++ b/cmd/forge/block_reader.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const maxBufferCapacity = 5 * 1024 * 1024
+
 type (
 	BlockReader interface {
 		ReadBlock() (rpctypes.PolyBlock, error)
@@ -36,10 +38,9 @@ func OpenBlockReader(file string, mode string) (BlockReader, error) {
 
 	switch mode {
 	case "json":
-		maxCapacity := 5 * 1024 * 1024
-		buf := make([]byte, maxCapacity)
+		buf := make([]byte, maxBufferCapacity)
 		scanner := bufio.NewScanner(blockFile)
-		scanner.Buffer(buf, maxCapacity)
+		scanner.Buffer(buf, maxBufferCapacity)
 
 		br := JSONBlockReader{
 			scanner: scanner,

--- a/cmd/forge/forge.go
+++ b/cmd/forge/forge.go
@@ -328,7 +328,6 @@ func readAllBlocksToChain(bh *edgeBlockchainHandle, blockReader BlockReader, rec
 
 		if inputForge.IncludeTxFees {
 			totalGasUsed := big.NewInt(0)
-			totalFee := big.NewInt(0)
 
 			for i := 0; i < len(block.Transactions()); i++ {
 				receipt, err = receiptReader.ReadReceipt()
@@ -349,7 +348,7 @@ func readAllBlocksToChain(bh *edgeBlockchainHandle, blockReader BlockReader, rec
 				}
 
 				totalGasUsed.Add(totalGasUsed, receipt.GasUsed.ToBigInt())
-				totalFee = big.NewInt(0).Mul(totalGasUsed, receipt.EffectiveGasPrice.ToBigInt())
+				totalFee := big.NewInt(0).Mul(totalGasUsed, receipt.EffectiveGasPrice.ToBigInt())
 				minerTips.Add(minerTips, totalFee)
 			}
 

--- a/cmd/forge/receipt_reader.go
+++ b/cmd/forge/receipt_reader.go
@@ -1,0 +1,62 @@
+package forge
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/maticnetwork/polygon-cli/rpctypes"
+)
+
+type (
+	ReceiptReader interface {
+		ReadReceipt() (*rpctypes.RawTransactionResponse, error)
+	}
+	JSONReceiptReader struct {
+		scanner *bufio.Scanner
+	}
+)
+
+// OpenReceiptReader returns a receipt reader object which can be used to read the
+// file. It will return a mode specific receipt reader.
+func OpenReceiptReader(file string, mode string) (ReceiptReader, error) {
+	receiptsFile, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open %s receipts file: %w", file, err)
+	}
+
+	switch mode {
+	case "json":
+		maxCapacity := 1024 * 1024
+		buf := make([]byte, maxCapacity)
+		scanner := bufio.NewScanner(receiptsFile)
+		scanner.Buffer(buf, maxCapacity)
+
+		receiptsReader := JSONReceiptReader{
+			scanner: scanner,
+		}
+		return &receiptsReader, nil
+
+	case "proto":
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("invalid mode: %s", mode)
+	}
+}
+
+func (receiptsReader *JSONReceiptReader) ReadReceipt() (*rpctypes.RawTransactionResponse, error) {
+	if !receiptsReader.scanner.Scan() {
+		return nil, BlockReadEOF
+	}
+
+	rawTxBytes := receiptsReader.scanner.Bytes()
+	var raw rpctypes.RawTransactionResponse
+	err := json.Unmarshal(rawTxBytes, &raw)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal file receipt: %w - %s", err, string(rawTxBytes))
+	}
+
+	return &raw, nil
+}

--- a/cmd/forge/receipt_reader.go
+++ b/cmd/forge/receipt_reader.go
@@ -28,7 +28,6 @@ func OpenReceiptReader(file string, mode string) (ReceiptReader, error) {
 
 	switch mode {
 	case "json":
-		maxCapacity := 1024 * 1024
 		buf := make([]byte, maxCapacity)
 		scanner := bufio.NewScanner(receiptsFile)
 		scanner.Buffer(buf, maxCapacity)

--- a/cmd/forge/receipt_reader.go
+++ b/cmd/forge/receipt_reader.go
@@ -28,9 +28,9 @@ func OpenReceiptReader(file string, mode string) (ReceiptReader, error) {
 
 	switch mode {
 	case "json":
-		buf := make([]byte, maxCapacity)
+		buf := make([]byte, maxBufferCapacity)
 		scanner := bufio.NewScanner(receiptsFile)
-		scanner.Buffer(buf, maxCapacity)
+		scanner.Buffer(buf, maxBufferCapacity)
 
 		receiptsReader := JSONReceiptReader{
 			scanner: scanner,

--- a/cmd/forge/receipt_reader.go
+++ b/cmd/forge/receipt_reader.go
@@ -11,7 +11,7 @@ import (
 
 type (
 	ReceiptReader interface {
-		ReadReceipt() (*rpctypes.RawTransactionResponse, error)
+		ReadReceipt() (*rpctypes.RawTxReceipt, error)
 	}
 	JSONReceiptReader struct {
 		scanner *bufio.Scanner
@@ -38,21 +38,18 @@ func OpenReceiptReader(file string, mode string) (ReceiptReader, error) {
 		}
 		return &receiptsReader, nil
 
-	case "proto":
-		return nil, nil
-
 	default:
 		return nil, fmt.Errorf("invalid mode: %s", mode)
 	}
 }
 
-func (receiptsReader *JSONReceiptReader) ReadReceipt() (*rpctypes.RawTransactionResponse, error) {
+func (receiptsReader *JSONReceiptReader) ReadReceipt() (*rpctypes.RawTxReceipt, error) {
 	if !receiptsReader.scanner.Scan() {
 		return nil, BlockReadEOF
 	}
 
 	rawTxBytes := receiptsReader.scanner.Bytes()
-	var raw rpctypes.RawTransactionResponse
+	var raw rpctypes.RawTxReceipt
 	err := json.Unmarshal(rawTxBytes, &raw)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal file receipt: %w - %s", err, string(rawTxBytes))

--- a/rpctypes/rpctypes.go
+++ b/rpctypes/rpctypes.go
@@ -182,6 +182,9 @@ type (
 		// cumulativeGasUsed : QUANTITY - The total amount of gas used when this transaction was executed in the block.
 		CumulativeGasUsed RawQuantityResponse `json:"cumulativeGasUsed"`
 
+		// effectiveGasPrice : QUANTITY - The total base charge plus tip paid for each unit of gas.
+		EffectiveGasPrice RawQuantityResponse `json:"effectiveGasPrice"`
+
 		// gasUsed : QUANTITY - The amount of gas used by this specific transaction alone.
 		GasUsed RawQuantityResponse `json:"gasUsed"`
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->
- Adds block rewards to `forge`
- Supply a receipts file with `--receipts`
- Set the `--base-block-reward`
- Include transaction fees with `--tx-fees=true`
- Currently only supports `json`

## Jira / Linear Tickets

- [DVT-380](https://polygon.atlassian.net/browse/DVT-380)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

```bash
go run main.go forge --genesis genesis.json --mode json --blocks poa-core.0.to.100k.blocks --count 99999 --tx-fees=true --receipts poa-core.0.to.100k.receipts --base-block-reward 1000000000000000000
```
- Output: `1:17PM TRC blockNumber=55 blockReward=1026960700000000000`
- Verified here: https://blockscout.com/poa/core/block/55/transactions


[DVT-380]: https://polygon.atlassian.net/browse/DVT-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ