### PR TITLE
ci: specifying 1.19 since some deps cant handle 1.20 yet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.18.0'
+          go-version: '1.19.7'
       - name: perform cross build and compress binaries
         shell: bash
         run: |


### PR DESCRIPTION
# Description

Minor CI change to avoid moving up to 1.20 until we upgrade our dependencies properly.
