### PR TITLE
HTTP / TCP Test Harness for JSON RPC

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/maticnetwork/polygon-cli/cmd/fork"
 	"github.com/maticnetwork/polygon-cli/cmd/parseethwallet"
+	"github.com/maticnetwork/polygon-cli/cmd/testharness"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -87,6 +88,7 @@ func init() {
 	rootCmd.AddCommand(wallet.WalletCmd)
 	rootCmd.AddCommand(fork.ForkCmd)
 	rootCmd.AddCommand(parseethwallet.ParseETHWalletCmd)
+	rootCmd.AddCommand(testharness.TestHarnessCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/testharness/testharness.go
+++ b/cmd/testharness/testharness.go
@@ -2,40 +2,59 @@ package testharness
 
 import (
 	"fmt"
-	"net/http"
-	"os"
-
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"net"
+	"net/http"
+	"os"
 )
 
 var (
 	harnessPort *uint16
 	harnessMode *string
 	activeMode  HarnessMode
+	listenAddr  *string
 )
 
 const (
+	packetSize        = 2<<15 - 1
 	HarnessIdentifier = "Test Harness"
 
-	HarnessMode500 HarnessMode = "500"
-	HarnessMode400 HarnessMode = "400"
+	HarnessMode500    HarnessMode = "500"
+	HarnessMode400    HarnessMode = "400"
+	HarnessModeClosed HarnessMode = "closed"
 )
 
 var modeList = []HarnessMode{
 	HarnessMode500,
 	HarnessMode400,
+	HarnessModeClosed,
 }
 
 type (
 	HarnessHandler interface {
 		StartListener(port uint16) error
 	}
-	HarnessMode string
-	Handler500  struct{}
-	Handler400  struct{}
+	HarnessMode   string
+	Handler500    struct{}
+	Handler400    struct{}
+	HandlerClosed struct{}
 )
+
+func ListenerFactory(mode HarnessMode) (HarnessHandler, error) {
+	switch mode {
+	case HarnessMode500:
+		return Handler500{}, nil
+	case HarnessMode400:
+		return Handler400{}, nil
+	case HarnessModeClosed:
+		return HandlerClosed{}, nil
+	default:
+		return nil, fmt.Errorf("the mode %s isn't supported yet", mode)
+	}
+
+}
 
 var TestHarnessCmd = &cobra.Command{
 	Use:   "testharness --mode [mode] --port [portnumber]",
@@ -55,8 +74,13 @@ var TestHarnessCmd = &cobra.Command{
 		parsedMode, err := stringToHarnessMode(*harnessMode)
 		if err != nil {
 			log.Error().Err(err).Msg("unable to parse mode")
+			return err
 		}
 		activeMode = parsedMode
+		parsedIp := net.ParseIP(*listenAddr)
+		if parsedIp == nil {
+			return fmt.Errorf("the ip %s could not be parsed", *listenAddr)
+		}
 		return nil
 	},
 }
@@ -75,17 +99,7 @@ func init() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	harnessPort = TestHarnessCmd.PersistentFlags().Uint16("port", 11235, "If the mode is tcp level or higher this will set the port that the server listens on ")
 	harnessMode = TestHarnessCmd.PersistentFlags().String("mode", "500", "The mode type that will be used for the harness")
-}
-
-func ListenerFactory(mode HarnessMode) (HarnessHandler, error) {
-	switch mode {
-	case HarnessMode500:
-		return Handler500{}, nil
-	case HarnessMode400:
-		return Handler400{}, nil
-	default:
-		return nil, fmt.Errorf("the mode %s isn't supported yet", mode)
-	}
+	listenAddr = TestHarnessCmd.PersistentFlags().String("listen-ip", "127.0.0.1", "The IP that we'll use to listen")
 
 }
 
@@ -93,15 +107,67 @@ func (m Handler500) StartListener(port uint16) error {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		log.Debug().Msg("handling request")
 		w.WriteHeader(500)
-		w.Write([]byte(HarnessIdentifier))
+		_, _ = w.Write([]byte(HarnessIdentifier))
 	})
-	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	return http.ListenAndServe(fmt.Sprintf("%s:%d", *listenAddr, port), nil)
 }
 func (m Handler400) StartListener(port uint16) error {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		log.Debug().Msg("handling request")
 		w.WriteHeader(400)
-		w.Write([]byte(HarnessIdentifier))
+		_, _ = w.Write([]byte(HarnessIdentifier))
 	})
-	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	return http.ListenAndServe(fmt.Sprintf("%s:%d", *listenAddr, port), nil)
+}
+
+func (m HandlerClosed) StartListener(port uint16) error {
+	addr, err := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%d", *listenAddr, port))
+	if err != nil {
+		log.Error().Err(err).Msg("unable to resolve address")
+		return err
+	}
+	listener, err := net.ListenTCP("tcp4", addr)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to start listening")
+		return err
+	}
+	for {
+		conn, err := listener.AcceptTCP()
+		if err != nil {
+			log.Error().Err(err).Msg("error accepting")
+			continue
+		}
+		log.Debug().
+			Str("RemoteAddr", conn.RemoteAddr().String()).
+			Msg("accepted connection")
+		err = conn.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("Error closing connection")
+		}
+		//sysConn, err := conn.SyscallConn()
+		//if err != nil {
+		//	log.Error().Err(err).Msg("unable to open sysconn")
+		//	conn.Close()
+		//	continue
+		//}
+		//err = sysConn.Read(func(fd uintptr) (done bool) {
+		//	log.Debug().Uint("fd", uint(fd)).Msg("reading?")
+		//	rawConnFile := os.NewFile(uintptr(fd), "test file")
+		//
+		//	data := make([]byte, packetSize)
+		//	var dataAt int64 = 0
+		//	n, err := rawConnFile.ReadAt(data, dataAt)
+		//	if err != nil {
+		//		log.Error().Err(err).Msg("unable to read!?")
+		//		return false
+		//	}
+		//	log.Debug().Int("n", n).Msg("reading")
+		//	return false
+		//})
+		//if err != nil {
+		//	log.Error().Err(err).Msg("error reading sysconn")
+		//}
+		//conn.Close()
+	}
+
 }

--- a/cmd/testharness/testharness.go
+++ b/cmd/testharness/testharness.go
@@ -1,0 +1,107 @@
+package testharness
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	harnessPort *uint16
+	harnessMode *string
+	activeMode  HarnessMode
+)
+
+const (
+	HarnessIdentifier = "Test Harness"
+
+	HarnessMode500 HarnessMode = "500"
+	HarnessMode400 HarnessMode = "400"
+)
+
+var modeList = []HarnessMode{
+	HarnessMode500,
+	HarnessMode400,
+}
+
+type (
+	HarnessHandler interface {
+		StartListener(port uint16) error
+	}
+	HarnessMode string
+	Handler500  struct{}
+	Handler400  struct{}
+)
+
+var TestHarnessCmd = &cobra.Command{
+	Use:   "testharness --mode [mode] --port [portnumber]",
+	Short: "Run a simple test harness on the given port",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Info().Uint16("port", *harnessPort).Str("mode", *harnessMode).Msg("Starting server")
+
+		l, err := ListenerFactory(activeMode)
+		if err != nil {
+			log.Error().Err(err).Msg("Could not start listener")
+			return err
+		}
+		return l.StartListener(*harnessPort)
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		parsedMode, err := stringToHarnessMode(*harnessMode)
+		if err != nil {
+			log.Error().Err(err).Msg("unable to parse mode")
+		}
+		activeMode = parsedMode
+		return nil
+	},
+}
+
+func stringToHarnessMode(inputMode string) (HarnessMode, error) {
+	for _, m := range modeList {
+		if inputMode == string(m) {
+			return m, nil
+		}
+	}
+	return "", fmt.Errorf("the mode %s is unrecognized", inputMode)
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	harnessPort = TestHarnessCmd.PersistentFlags().Uint16("port", 11235, "If the mode is tcp level or higher this will set the port that the server listens on ")
+	harnessMode = TestHarnessCmd.PersistentFlags().String("mode", "500", "The mode type that will be used for the harness")
+}
+
+func ListenerFactory(mode HarnessMode) (HarnessHandler, error) {
+	switch mode {
+	case HarnessMode500:
+		return Handler500{}, nil
+	case HarnessMode400:
+		return Handler400{}, nil
+	default:
+		return nil, fmt.Errorf("the mode %s isn't supported yet", mode)
+	}
+
+}
+
+func (m Handler500) StartListener(port uint16) error {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Debug().Msg("handling request")
+		w.WriteHeader(500)
+		w.Write([]byte(HarnessIdentifier))
+	})
+	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+}
+func (m Handler400) StartListener(port uint16) error {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Debug().Msg("handling request")
+		w.WriteHeader(400)
+		w.Write([]byte(HarnessIdentifier))
+	})
+	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+}


### PR DESCRIPTION
# Description

Creating a basic test harness based on the idea from Release It / Michae Nygard. The goal is to use this while testing our JSON proxies and various blockchain components. Eventually we may want to drop down to an even lower level to handle stuff like sending `RST` packets or fiddling with the controls of TCP.

## Jira / Linear Tickets

- [DVT-581](https://polygon.atlassian.net/browse/DVT-581)


