### PR TITLE
fix: summarization issue

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1649,14 +1649,10 @@ func printBlockSummary(c *ethclient.Client, bs map[uint64]blockSummary, startNon
 	}
 }
 func getSuccessfulTransactionCount(bs map[uint64]blockSummary) (successful, total int64) {
-	total = 0
-	successful = 0
 	for _, block := range bs {
+		total += int64(len(block.Receipts))
 		for _, receipt := range block.Receipts {
-			total += 1
-			if receipt.Status.ToInt64() == 1 {
-				successful += 1
-			}
+			successful += receipt.Status.ToInt64()
 		}
 	}
 	return

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1473,7 +1473,6 @@ func summarizeTransactions(ctx context.Context, c *ethclient.Client, rpc *ethrpc
 		bs := blockData[bn]
 		if bs.Receipts == nil {
 			log.Error().Uint64("blocknumber", bn).Msg("Block number from receipts does not exist in block data")
-			continue
 		}
 		bs.Receipts[r.TransactionHash.ToHash()] = r
 		blockData[bn] = bs


### PR DESCRIPTION
# Description

The summarization didn’t include all of the transactions for some reason.

To fix this, I removed a `continue` statement when building the block data in order to keep empty receipts. This way, the number of total transactions should be equal to the `samples` number given by the user.

## Jira / Linear Tickets

- [DVT-597]()

# Testing

- [x] Run `polycli loadtest` with summarization against a local geth node to check if everything works fine.
<img width="388" alt="Screenshot 2023-03-30 at 10 56 18" src="https://user-images.githubusercontent.com/28714795/228784234-7ff08771-732f-4ee6-a476-f8c8bcb43373.png">


[DVT-597]: https://polygon.atlassian.net/browse/DVT-597