### PR TITLE
[DVT-604] add adaptive rate limiting feature

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -572,7 +572,7 @@ func updateRateLimit(rl *rate.Limiter, rpc *ethrpc.Client, steadyStateQueueSize 
 		} else if txPoolSize > steadyStateQueueSize {
 			// halve rate limit requests per second if txpool greater than queue steady state
 			rl.SetLimit(rl.Limit() / 2)
-			log.Trace().Interface("New rate limit", rl.Limit()).Interface("Current Tx Pool Size", txPoolSize).Interface("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Backed off rate limit")
+			log.Trace().Interface("New Rate Limit (RPS)", rl.Limit()).Interface("Current Tx Pool Size", txPoolSize).Interface("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Backed off rate limit")
 		}
 	}
 }

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -294,8 +294,8 @@ func init() {
 	ltp.AdaptiveRateLimit = LoadtestCmd.PersistentFlags().Bool("adaptive-rate-limit", true, "Loadtest automatically adjusts request rate to maximize utilization but prevent congestion")
 	ltp.SteadyStateTxPoolSize = LoadtestCmd.PersistentFlags().Uint64("steady-state-tx-pool-size", 1000, "Transaction Pool queue size which we use to either increase/decrease requests per second")
 	ltp.AdaptiveRateLimitStart = LoadtestCmd.PersistentFlags().Uint64("adaptive-rate-limit-start", 2, "Initial rate of requests per second following the slow-start approach of adaptive rate limiting")
-	ltp.AdaptiveRateLimitIncrement = LoadtestCmd.PersistentFlags().Uint64("adaptive-rate-limit-increment", 10, "Additive increment to rate of requests per second if tx pool below steady state size")
-	ltp.AdaptiveCycleDuration = LoadtestCmd.PersistentFlags().Uint64("adaptive-cycle-duration-seconds", 20, "Duration in seconeds that adaptive load test will review tx pool and determine whether to increase/decrease rate limit")
+	ltp.AdaptiveRateLimitIncrement = LoadtestCmd.PersistentFlags().Uint64("adaptive-rate-limit-increment", 10, "Additive increment to rate of requests if txpool below steady state size")
+	ltp.AdaptiveCycleDuration = LoadtestCmd.PersistentFlags().Uint64("adaptive-cycle-duration-seconds", 20, "Duration in seconeds that adaptive load test will review txpool and determine whether to increase/decrease rate limit")
 	ltp.Mode = LoadtestCmd.PersistentFlags().StringP("mode", "m", "t", `The testing mode to use. It can be multiple like: "tcdf"
 t - sending transactions
 d - deploy contract

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -513,27 +513,27 @@ func printResults(lts []loadTestSample) {
 }
 
 func updateRateLimit(rl *rate.Limiter, errChan chan error, cycleDuration time.Duration) {
-    ticker := time.NewTicker(cycleDuration)
-    defer ticker.Stop()
+	ticker := time.NewTicker(cycleDuration)
+	defer ticker.Stop()
 
-    for {
-        select {
-        case <-ticker.C:
-            if len(errChan) == 0 {
-								// double rate limit if no errors encountered last cycle
-                rl.SetLimit(rl.Limit() * 2)
-								fmt.Println("doubled rate limit to:", rl)
-            } else {
-								// halve rate limit if errors encountered last cycle
-                rl.SetLimit(rl.Limit() / 2)
-								fmt.Println("halved rate limit to:", rl)
-                // Clear the error channel each cycle
-                for len(errChan) > 0 {
-                    <-errChan
-                }
-            }
-        }
-    }
+	for {
+		select {
+		case <-ticker.C:
+			if len(errChan) == 0 {
+				// double rate limit if no errors encountered last cycle
+				rl.SetLimit(rl.Limit() * 2)
+				fmt.Println("doubled rate limit to:", rl)
+			} else {
+				// halve rate limit if errors encountered last cycle
+				rl.SetLimit(rl.Limit() / 2)
+				fmt.Println("halved rate limit to:", rl)
+				// Clear the error channel each cycle
+				for len(errChan) > 0 {
+					<-errChan
+				}
+			}
+		}
+	}
 }
 
 func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) error {
@@ -550,7 +550,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	adaptiveRateLimit := 1
 	adaptiveRateLimitCycle := 20 // in seconds
 	var rl *rate.Limiter
-	
+
 	if *ltp.AdaptiveRateLimit {
 		// slow-start to begin and increase rate limit as loadtest progresses via updateRateLimit
 		rl = rate.NewLimiter(rate.Limit(adaptiveRateLimit), 1)
@@ -560,11 +560,11 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	if *ltp.RateLimit <= 0.0 {
 		rl = nil
 	}
-	
+
 	// run updateRateLimit in background to dynamically adjust limit per feedback loop
 	errChan := make(chan error, routines*requests)
 	if rl != nil && *ltp.AdaptiveRateLimit {
-			go updateRateLimit(rl, errChan, time.Duration(adaptiveRateLimitCycle)*time.Second)
+		go updateRateLimit(rl, errChan, time.Duration(adaptiveRateLimitCycle)*time.Second)
 	}
 
 	tops, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -522,8 +522,8 @@ func printResults(lts []loadTestSample) {
 }
 
 func cleanHex(hexStr string) string {
-	// remove 0x suffix if found in the input string
-	return strings.Replace(hexStr, "0x", "", -1)
+	// remove 0x prefix if found in the input string
+	return strings.TrimPrefix(hexStr, "0x")
 }
 
 func getTxPoolSize(rpc *ethrpc.Client) (uint64, error) {
@@ -568,11 +568,11 @@ func updateRateLimit(rl *rate.Limiter, rpc *ethrpc.Client, steadyStateQueueSize 
 			// additively increment requests per second if txpool less than queue steady state
 			newRateLimit := rate.Limit(float64(rl.Limit()) + float64(rateLimitIncrement))
 			rl.SetLimit(newRateLimit)
-			log.Trace().Interface("New Rate Limit (RPS)", rl.Limit()).Interface("Current Tx Pool Size", txPoolSize).Interface("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Increased rate limit")
+			log.Trace().Float64("New Rate Limit (RPS)", float64(rl.Limit())).Uint64("Current Tx Pool Size", txPoolSize).Uint64("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Increased rate limit")
 		} else if txPoolSize > steadyStateQueueSize {
 			// halve rate limit requests per second if txpool greater than queue steady state
 			rl.SetLimit(rl.Limit() / 2)
-			log.Trace().Interface("New Rate Limit (RPS)", rl.Limit()).Interface("Current Tx Pool Size", txPoolSize).Interface("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Backed off rate limit")
+			log.Trace().Float64("New Rate Limit (RPS)", float64(rl.Limit())).Uint64("Current Tx Pool Size", txPoolSize).Uint64("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Backed off rate limit")
 		}
 	}
 }

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -31,6 +31,7 @@ import (
 	"os/signal"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -226,34 +227,38 @@ type (
 	}
 	loadTestParams struct {
 		// inputs
-		Requests             *int64
-		Concurrency          *int64
-		BatchSize            *uint64
-		TimeLimit            *int64
-		Verbosity            *int64
-		PrettyLogs           *bool
-		ToRandom             *bool
-		URL                  *url.URL
-		ChainID              *uint64
-		PrivateKey           *string
-		ToAddress            *string
-		HexSendAmount        *string
-		RateLimit            *float64
-		AdaptiveRateLimit    *bool
-		Mode                 *string
-		Function             *uint64
-		Iterations           *uint64
-		ByteCount            *uint64
-		Seed                 *int64
-		IsAvail              *bool
-		AvailAppID           *uint32
-		LtAddress            *string
-		DelAddress           *string
-		ForceContractDeploy  *bool
-		ForceGasLimit        *uint64
-		ForceGasPrice        *uint64
-		ShouldProduceSummary *bool
-		SummaryOutputMode    *string
+		Requests                   *int64
+		Concurrency                *int64
+		BatchSize                  *uint64
+		TimeLimit                  *int64
+		Verbosity                  *int64
+		PrettyLogs                 *bool
+		ToRandom                   *bool
+		URL                        *url.URL
+		ChainID                    *uint64
+		PrivateKey                 *string
+		ToAddress                  *string
+		HexSendAmount              *string
+		RateLimit                  *float64
+		AdaptiveRateLimit          *bool
+		SteadyStateTxPoolSize      *uint64
+		AdaptiveRateLimitStart     *uint64
+		AdaptiveRateLimitIncrement *uint64
+		AdaptiveCycleDuration      *uint64
+		Mode                       *string
+		Function                   *uint64
+		Iterations                 *uint64
+		ByteCount                  *uint64
+		Seed                       *int64
+		IsAvail                    *bool
+		AvailAppID                 *uint32
+		LtAddress                  *string
+		DelAddress                 *string
+		ForceContractDeploy        *bool
+		ForceGasLimit              *uint64
+		ForceGasPrice              *uint64
+		ShouldProduceSummary       *bool
+		SummaryOutputMode          *string
 
 		// Computed
 		CurrentGas      *big.Int
@@ -287,6 +292,10 @@ func init() {
 	ltp.HexSendAmount = LoadtestCmd.PersistentFlags().String("send-amount", "0x38D7EA4C68000", "The amount of wei that we'll send every transaction")
 	ltp.RateLimit = LoadtestCmd.PersistentFlags().Float64("rate-limit", 4, "An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together")
 	ltp.AdaptiveRateLimit = LoadtestCmd.PersistentFlags().Bool("adaptive-rate-limit", true, "Loadtest automatically adjusts request rate to maximize utilization but prevent congestion")
+	ltp.SteadyStateTxPoolSize = LoadtestCmd.PersistentFlags().Uint64("steady-state-tx-pool-size", 1000, "Transaction Pool queue size which we use to either increase/decrease requests per second")
+	ltp.AdaptiveRateLimitStart = LoadtestCmd.PersistentFlags().Uint64("adaptive-rate-limit-start", 2, "Initial rate of requests per second following the slow-start approach of adaptive rate limiting")
+	ltp.AdaptiveRateLimitIncrement = LoadtestCmd.PersistentFlags().Uint64("adaptive-rate-limit-increment", 10, "Additive increment to rate of requests per second if tx pool below steady state size")
+	ltp.AdaptiveCycleDuration = LoadtestCmd.PersistentFlags().Uint64("adaptive-cycle-duration-seconds", 20, "Duration in seconeds that adaptive load test will review tx pool and determine whether to increase/decrease rate limit")
 	ltp.Mode = LoadtestCmd.PersistentFlags().StringP("mode", "m", "t", `The testing mode to use. It can be multiple like: "tcdf"
 t - sending transactions
 d - deploy contract
@@ -512,25 +521,60 @@ func printResults(lts []loadTestSample) {
 	log.Info().Uint64("numErrors", numErrors).Msg("Num errors")
 }
 
-func updateRateLimit(rl *rate.Limiter, errChan chan error, cycleDuration time.Duration) {
+func cleanHex(hexStr string) string {
+	// remove 0x suffix if found in the input string
+	return strings.Replace(hexStr, "0x", "", -1)
+}
+
+func getTxPoolSize(rpc *ethrpc.Client) (uint64, error) {
+	var status map[string]interface{}
+	err := rpc.Call(&status, "txpool_status")
+	if err != nil {
+		return 0, err
+	}
+	pendingHex, ok := status["pending"].(string)
+	if !ok {
+		return 0, fmt.Errorf("unable to read pending txpool size")
+	}
+	queuedHex, ok := status["queued"].(string)
+	if !ok {
+		return 0, fmt.Errorf("unable to read queued txpool size")
+	}
+
+	pendingTxPoolSize, err := strconv.ParseUint(cleanHex(pendingHex), 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse pending txpool size: %v", err)
+	}
+	queuedTxPoolSize, err := strconv.ParseUint(cleanHex(queuedHex), 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse queued txpool size: %v", err)
+	}
+
+	return (pendingTxPoolSize + queuedTxPoolSize), nil
+}
+
+func updateRateLimit(rl *rate.Limiter, rpc *ethrpc.Client, steadyStateQueueSize uint64, rateLimitIncrement uint64, cycleDuration time.Duration) {
 	ticker := time.NewTicker(cycleDuration)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			if len(errChan) == 0 {
-				// double rate limit if no errors encountered last cycle
-				rl.SetLimit(rl.Limit() * 2)
-				fmt.Println("doubled rate limit to:", rl)
-			} else {
-				// halve rate limit if errors encountered last cycle
+			txPoolSize, err := getTxPoolSize(rpc)
+			if err != nil {
+				log.Error().Err(err).Msg("Error getting txpool size")
+				return
+			}
+
+			if txPoolSize < steadyStateQueueSize {
+				// additively increment requests per second if txpool less than queue steady state
+				newRateLimit := rate.Limit(float64(rl.Limit()) + float64(rateLimitIncrement))
+				rl.SetLimit(newRateLimit)
+				log.Trace().Interface("New Rate Limit (RPS)", rl.Limit()).Interface("Current Tx Pool Size", txPoolSize).Interface("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Increased rate limit")
+			} else if txPoolSize > steadyStateQueueSize {
+				// halve rate limit requests per second if txpool greater than queue steady state
 				rl.SetLimit(rl.Limit() / 2)
-				fmt.Println("halved rate limit to:", rl)
-				// Clear the error channel each cycle
-				for len(errChan) > 0 {
-					<-errChan
-				}
+				log.Trace().Interface("New rate limit", rl.Limit()).Interface("Current Tx Pool Size", txPoolSize).Interface("Steady State Tx Pool Size", steadyStateQueueSize).Msg("Backed off rate limit")
 			}
 		}
 	}
@@ -547,24 +591,23 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	chainID := new(big.Int).SetUint64(*ltp.ChainID)
 	privateKey := ltp.ECDSAPrivateKey
 	mode := *ltp.Mode
-	adaptiveRateLimit := 1
-	adaptiveRateLimitCycle := 20 // in seconds
+	steadyStateTxPoolSize := *ltp.SteadyStateTxPoolSize
+	adaptiveRateLimitIncrement := *ltp.AdaptiveRateLimitIncrement
 	var rl *rate.Limiter
 
 	if *ltp.AdaptiveRateLimit {
-		// slow-start to begin and increase rate limit as loadtest progresses via updateRateLimit
-		rl = rate.NewLimiter(rate.Limit(adaptiveRateLimit), 1)
+		// start slow with adaptive rate limiting and we'll increase limit per feedback loop
+		rl = rate.NewLimiter(rate.Limit(*ltp.AdaptiveRateLimitStart), 1)
 	} else {
 		rl = rate.NewLimiter(rate.Limit(*ltp.RateLimit), 1)
 	}
-	if *ltp.RateLimit <= 0.0 {
+
+	if *ltp.RateLimit <= 0.0 || *ltp.AdaptiveRateLimitStart <= 0.0 {
 		rl = nil
 	}
 
-	// run updateRateLimit in background to dynamically adjust limit per feedback loop
-	errChan := make(chan error, routines*requests)
 	if rl != nil && *ltp.AdaptiveRateLimit {
-		go updateRateLimit(rl, errChan, time.Duration(adaptiveRateLimitCycle)*time.Second)
+		go updateRateLimit(rl, rpc, steadyStateTxPoolSize, adaptiveRateLimitIncrement, time.Duration(*ltp.AdaptiveCycleDuration)*time.Second)
 	}
 
 	tops, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
@@ -755,8 +798,6 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 					err = rl.Wait(ctx)
 					if err != nil {
 						log.Error().Err(err).Msg("Encountered a rate limiting error")
-						// activate backoff logic for adaptive rate limiter
-						errChan <- err
 					}
 				}
 
@@ -825,7 +866,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 		log.Error().Err(err).Msg("there was an issue waiting for all transactions to be mined")
 	}
 
-	lightSummary(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)
+	lightSummary(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce, rl)
 	if *ltp.ShouldProduceSummary {
 		err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)
 		if err != nil {
@@ -835,7 +876,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	return nil
 }
 
-func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, startBlockNumber, startNonce, endBlockNumber, endNonce uint64) {
+func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, startBlockNumber, startNonce, endBlockNumber, endNonce uint64, rl *rate.Limiter) {
 	startBlock, err := c.BlockByNumber(ctx, new(big.Int).SetUint64(startBlockNumber))
 	if err != nil {
 		log.Error().Err(err).Msg("unable to get start block for light summary")
@@ -858,6 +899,7 @@ func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, 
 		Int("transactionCount", len(loadTestResults)).
 		Float64("testDuration", testDuration.Seconds()).
 		Float64("tps", tps).
+		Float64("final rate limit", float64(rl.Limit())).
 		Msg("rough test summary (ignores errors)")
 }
 


### PR DESCRIPTION
# Description

adds dynamic rate limiting in the [AIMD fashion](https://ocw.mit.edu/courses/6-033-computer-system-engineering-spring-2018/d071f3da1e8e5b646e220525783eb2ba_MIT6_033S18lec11.pdf). more specifically, we periodically query the rpc tx_pool status to gauge whether we should increase or back off our loadtest request rate. 

## Jira / Linear Tickets

https://polygon.atlassian.net/browse/DVT-604

# Testing

**successfully builds and running against dev geth locally via following cmd:**
`polycli loadtest --verbosity 700 --chain-id 1337 --concurrency 1 --requests 2000 --adaptive-rate-limit=true --steady-state-tx-pool-size 100 --adaptive-rate-limit-start 5 --adaptive-rate-limit-increment 10 --adaptive-cycle-duration-seconds 20 --mode t http://127.0.0.1:8545

**log sample results:**

> 1:54PM DBG Starting main loadtest loop currentNonce=6476
1:54PM TRC Request mode=t nonce=6476 request=0 routine=0
...
1:55PM TRC Request mode=t nonce=6576 request=100 routine=0
1:55PM TRC Increased rate limit Current Tx Pool Size=20 New Rate Limit (RPS)=15 Steady State Tx Pool Size=100
1:55PM TRC Request mode=t nonce=6577 request=101 routine=0
...
1:55PM TRC Request mode=t nonce=6874 request=398 routine=0
1:55PM TRC Increased rate limit Current Tx Pool Size=59 New Rate Limit (RPS)=25 Steady State Tx Pool Size=100
1:55PM TRC Request mode=t nonce=6875 request=399 routine=0
...
1:55PM TRC Request mode=t nonce=7374 request=898 routine=0
1:55PM TRC Increased rate limit Current Tx Pool Size=99 New Rate Limit (RPS)=35 Steady State Tx Pool Size=100
1:55PM TRC Request mode=t nonce=7375 request=899 routine=0
...
1:56PM TRC Request mode=t nonce=8074 request=1598 routine=0
1:56PM TRC Backed off rate limit Current Tx Pool Size=138 New rate limit=17.5 Steady State Tx Pool Size=100
1:56PM TRC Request mode=t nonce=8075 request=1599 routine=0
...
1:56PM TRC Request mode=t nonce=8424 request=1948 routine=0
1:56PM TRC Increased rate limit Current Tx Pool Size=69 New Rate Limit (RPS)=27.5 Steady State Tx Pool Size=100
1:56PM TRC Request mode=t nonce=8425 request=1949 routine=0
...
1:56PM INF rough test summary (ignores errors) final rate limit=27.5 firstBlockTime=2023-04-04T13:54:54-05:00 lastBlockTime=2023-04-04T13:56:42-05:00 testDuration=108 tps=18.51851851851852 transactionCount=2000
