### PR TITLE
feat: allow to configure the number of tries when making a contract call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,11 @@ test: lint ## Run tests.
 	go test ./... -coverprofile=coverage.out
 	go tool cover -func coverage.out
 
+.PHONY: geth
+geth: ## Start geth.
+	geth --dev --dev.period 2 --http --http.addr localhost --http.port 8545 --http.api admin,debug,web3,eth,txpool,personal,miner,net --verbosity 5 --rpc.gascap 50000000  --rpc.txfeecap 0 --miner.gaslimit  10 --miner.gasprice 1 --gpo.blocks 1 --gpo.percentile 1 --gpo.maxprice 10 --gpo.ignoreprice 2 --dev.gaslimit 50000000
+
+.PHONY: loadtest
+loadtest: build ## Run simple loadtest.
+	./out/polycli loadtest --verbosity 700 --chain-id 1337 --concurrency 1 --requests 1000 --rate-limit 5 --mode c http://127.0.0.1:8545
+

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,13 @@ test: lint ## Run tests.
 geth: ## Start geth.
 	geth --dev --dev.period 2 --http --http.addr localhost --http.port 8545 --http.api admin,debug,web3,eth,txpool,personal,miner,net --verbosity 5 --rpc.gascap 50000000  --rpc.txfeecap 0 --miner.gaslimit  10 --miner.gasprice 1 --gpo.blocks 1 --gpo.percentile 1 --gpo.maxprice 10 --gpo.ignoreprice 2 --dev.gaslimit 50000000
 
+LOADTEST_ACCOUNT=0x85da99c8a7c2c95964c8efd687e95e632fc533d6
+LOADTEST_FUNDING_AMOUNT_ETH=5000
+eth_coinbase := $(shell curl -s -H 'Content-Type: application/json' -d '{"jsonrpc": "2.0", "id": 2, "method": "eth_coinbase", "params": []}' http://127.0.0.1:8545 | jq -r ".result")
+hex_funding_amount := $(shell echo "obase=16; ${LOADTEST_FUNDING_AMOUNT_ETH}*10^18" | bc)
+
 .PHONY: loadtest
-loadtest: build ## Run simple loadtest.
-	./out/polycli loadtest --verbosity 700 --chain-id 1337 --concurrency 1 --requests 1000 --rate-limit 5 --mode c http://127.0.0.1:8545
+loadtest: build ## Fund test account with 5k ETH and run loadtest.
+	curl -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "method":"eth_sendTransaction", "params":[{"from": "${eth_coinbase}","to": "${LOADTEST_ACCOUNT}","value": "0x${hex_funding_amount}"}], "id":1}' http://127.0.0.1:8545
+	$(BUILD_DIR)/$(BIN_NAME) loadtest --verbosity 700 --chain-id 1337 --concurrency 1 --requests 1000 --rate-limit 5 --mode c http://127.0.0.1:8545
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -927,7 +927,7 @@ func blockUntilSuccessful(ctx context.Context, f func() error, waitingTime, inte
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	log.Trace().Dur("waitingTime", waitingTime).Msg("Starting blocking loop")
+	log.Trace().Dur("waitingTimeSeconds", waitingTime).Msg("Starting blocking loop")
 	start := time.Now()
 	for {
 		select {
@@ -941,11 +941,11 @@ func blockUntilSuccessful(ctx context.Context, f func() error, waitingTime, inte
 
 			elapsed := time.Since(start)
 			if elapsed >= waitingTime {
-				log.Error().Err(err).Dur("elapsedTime", elapsed).Msg("Exhausted waiting period")
+				log.Error().Err(err).Dur("elapsedTimeSeconds", elapsed).Msg("Exhausted waiting period")
 				return err
 			}
 
-			log.Trace().Err(err).Dur("elapsedTime", elapsed).Msg("Waiting for successful function execution...")
+			log.Trace().Err(err).Dur("elapsedTimeSeconds", elapsed).Msg("Waiting for successful function execution...")
 		}
 	}
 }

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -920,7 +920,7 @@ func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, 
 		Msg("rough test summary (ignores errors)")
 }
 
-func blockUntilSuccessful(f func() error, waitingTime time.Duration, interval time.Duration) error {
+func blockUntilSuccessful(f func() error, waitingTime, interval time.Duration) error {
 	log.Trace().Dur("waitingTime", waitingTime).Msg("Starting blocking loop")
 	start := time.Now()
 	for {

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -923,18 +923,17 @@ func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, 
 }
 
 func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, f func() error, numberOfBlocksToWaitFor, blockInterval uint64) error {
+	start := time.Now()
 	startBlockNumber, err := c.BlockNumber(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Error getting block number")
 		return err
 	}
-
 	log.Trace().
 		Uint64("startBlockNumber", startBlockNumber).
 		Uint64("numberOfBlocksToWaitFor", numberOfBlocksToWaitFor).
 		Uint64("blockInterval", blockInterval).
 		Msg("Starting blocking loop")
-	start := time.Now()
 	var lastBlockNumber, currentBlockNumber uint64
 	var lock bool
 	for {

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -163,6 +163,9 @@ var LoadtestCmd = &cobra.Command{
 	},
 	Args: func(cmd *cobra.Command, args []string) error {
 		setLogLevel(inputLoadTestParams)
+		zerolog.DurationFieldUnit = time.Second
+		zerolog.DurationFieldInteger = true
+
 		if len(args) != 1 {
 			return fmt.Errorf("expected exactly one argument")
 		}

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -180,7 +180,7 @@ var LoadtestCmd = &cobra.Command{
 			return fmt.Errorf("the mode %s is not recognized", *inputLoadTestParams.Mode)
 		}
 		if *inputLoadTestParams.AdaptiveBackoffFactor <= 0.0 {
-			return fmt.Errorf("The backoff factor needs to be non-zero positive")
+			return fmt.Errorf("the backoff factor needs to be non-zero positive")
 		}
 		return nil
 	},
@@ -230,38 +230,40 @@ type (
 	}
 	loadTestParams struct {
 		// inputs
-		Requests                   *int64
-		Concurrency                *int64
-		BatchSize                  *uint64
-		TimeLimit                  *int64
-		Verbosity                  *int64
-		PrettyLogs                 *bool
-		ToRandom                   *bool
-		URL                        *url.URL
-		ChainID                    *uint64
-		PrivateKey                 *string
-		ToAddress                  *string
-		HexSendAmount              *string
-		RateLimit                  *float64
-		AdaptiveRateLimit          *bool
-		SteadyStateTxPoolSize      *uint64
-		AdaptiveRateLimitIncrement *uint64
-		AdaptiveCycleDuration      *uint64
-		AdaptiveBackoffFactor      *float64
-		Mode                       *string
-		Function                   *uint64
-		Iterations                 *uint64
-		ByteCount                  *uint64
-		Seed                       *int64
-		IsAvail                    *bool
-		AvailAppID                 *uint32
-		LtAddress                  *string
-		DelAddress                 *string
-		ForceContractDeploy        *bool
-		ForceGasLimit              *uint64
-		ForceGasPrice              *uint64
-		ShouldProduceSummary       *bool
-		SummaryOutputMode          *string
+		Requests                     *int64
+		Concurrency                  *int64
+		BatchSize                    *uint64
+		TimeLimit                    *int64
+		Verbosity                    *int64
+		PrettyLogs                   *bool
+		ToRandom                     *bool
+		URL                          *url.URL
+		ChainID                      *uint64
+		PrivateKey                   *string
+		ToAddress                    *string
+		HexSendAmount                *string
+		RateLimit                    *float64
+		AdaptiveRateLimit            *bool
+		SteadyStateTxPoolSize        *uint64
+		AdaptiveRateLimitIncrement   *uint64
+		AdaptiveCycleDuration        *uint64
+		AdaptiveBackoffFactor        *float64
+		Mode                         *string
+		Function                     *uint64
+		Iterations                   *uint64
+		ByteCount                    *uint64
+		Seed                         *int64
+		IsAvail                      *bool
+		AvailAppID                   *uint32
+		LtAddress                    *string
+		DelAddress                   *string
+		ContractCallWaitingDuration  *uint64
+		ContractCallIntervalDuration *uint64
+		ForceContractDeploy          *bool
+		ForceGasLimit                *uint64
+		ForceGasPrice                *uint64
+		ShouldProduceSummary         *bool
+		SummaryOutputMode            *string
 
 		// Computed
 		CurrentGas      *big.Int
@@ -324,6 +326,8 @@ r - random modes
 	ltp.AvailAppID = LoadtestCmd.PersistentFlags().Uint32("app-id", 0, "The AppID used for avail")
 	ltp.LtAddress = LoadtestCmd.PersistentFlags().String("lt-address", "", "A pre-deployed load test contract address")
 	ltp.DelAddress = LoadtestCmd.PersistentFlags().String("del-address", "", "A pre-deployed delegator contract address")
+	ltp.ContractCallWaitingDuration = LoadtestCmd.PersistentFlags().Uint64("contract-call-waiting-duration", 30, "The number of seconds to wait before giving up on a contract call")
+	ltp.ContractCallIntervalDuration = LoadtestCmd.PersistentFlags().Uint64("contract-call-interval-duration", 1, "The number of seconds to wait between contract calls")
 	ltp.ForceContractDeploy = LoadtestCmd.PersistentFlags().Bool("force-contract-deploy", false, "Some loadtest modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --del-address and --il-address flags.")
 	ltp.ForceGasLimit = LoadtestCmd.PersistentFlags().Uint64("gas-limit", 0, "In environments where the gas limit can't be computed on the fly, we can specify it manually")
 	ltp.ForceGasPrice = LoadtestCmd.PersistentFlags().Uint64("gas-price", 0, "In environments where the gas price can't be estimated, we can specify it manually")
@@ -631,6 +635,8 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	// deploy and instantiate the load tester contract
 	var ltAddr ethcommon.Address
 	var ltContract *contracts.LoadTester
+	waitingTime := time.Duration(*inputLoadTestParams.ContractCallWaitingDuration) * time.Second
+	interval := time.Duration(*inputLoadTestParams.ContractCallIntervalDuration) * time.Second
 	if strings.ContainsAny(mode, "rcfislpas") || *inputLoadTestParams.ForceContractDeploy {
 		if *inputLoadTestParams.LtAddress == "" {
 			ltAddr, _, _, err = contracts.DeployLoadTester(tops, c)
@@ -654,7 +660,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 		err = blockUntilSuccessful(func() error {
 			_, err = ltContract.GetCallCounter(cops)
 			return err
-		}, 30)
+		}, waitingTime, interval)
 
 		if err != nil {
 			return err
@@ -680,7 +686,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 		err = blockUntilSuccessful(func() error {
 			_, err = erc20Contract.BalanceOf(cops, *ltp.FromETHAddress)
 			return err
-		}, 30)
+		}, waitingTime, interval)
 		if err != nil {
 			return err
 		}
@@ -707,7 +713,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 				return err
 			}
 			return nil
-		}, 30)
+		}, waitingTime, interval)
 		if err != nil {
 			return err
 		}
@@ -733,7 +739,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 		err = blockUntilSuccessful(func() error {
 			_, err = erc721Contract.BalanceOf(cops, *ltp.FromETHAddress)
 			return err
-		}, 30)
+		}, waitingTime, interval)
 		if err != nil {
 			return err
 		}
@@ -745,7 +751,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 		err = blockUntilSuccessful(func() error {
 			_, err = erc721Contract.MintBatch(tops, *ltp.FromETHAddress, new(big.Int).SetUint64(1))
 			return err
-		}, 30)
+		}, waitingTime, interval)
 		if err != nil {
 			return err
 		}
@@ -777,7 +783,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 		err = blockUntilSuccessful(func() error {
 			_, err = delegatorContract.Call(tops, ltAddr, []byte{0x12, 0x87, 0xa6, 0x8c})
 			return err
-		}, 30)
+		}, waitingTime, interval)
 		if err != nil {
 			return err
 		}
@@ -914,24 +920,24 @@ func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, 
 		Msg("rough test summary (ignores errors)")
 }
 
-func blockUntilSuccessful(f func() error, tries int) error {
-	log.Trace().Int("tries", tries).Msg("Starting blocking loop")
-	waitCounter := tries
+func blockUntilSuccessful(f func() error, waitingTime time.Duration, interval time.Duration) error {
+	log.Trace().Dur("waitingTime", waitingTime).Msg("Starting blocking loop")
+	start := time.Now()
 	for {
 		err := f()
-		if err != nil {
-			if waitCounter < 1 {
-				log.Error().Err(err).Int("tries", waitCounter).Msg("Exhausted waiting period")
-				return err
-			}
-			log.Trace().Err(err).Msg("Waiting for successful function execution")
-			time.Sleep(time.Second)
-			waitCounter = waitCounter - 1
-			continue
+		if err == nil {
+			return nil
 		}
-		break
+
+		elapsed := time.Since(start)
+		if elapsed >= waitingTime {
+			log.Error().Err(err).Dur("elapsedTime", elapsed).Msg("Exhausted waiting period")
+			return err
+		}
+
+		log.Trace().Err(err).Dur("elapsedTime", elapsed).Msg("Waiting for successful function execution...")
+		time.Sleep(interval)
 	}
-	return nil
 }
 
 func loadtestTransaction(ctx context.Context, c *ethclient.Client, nonce uint64) (t1 time.Time, t2 time.Time, err error) {


### PR DESCRIPTION
# Description

The number of contract call tries was hardcoded to 30 in `polycli` (around 30 seconds). In certain scenario, we'd like to specify a longer waiting time. Instead of relying on time durations, we'll use block numbers which makes more sense in the context of blockchains.

This PR introduces two new parameters, `contract-call-nb-blocks-to-wait-for` which defines the number of blocks to wait for before giving up on a contract call (default: 30 blocks) and `contract-call-block-interval` which defines the number of blocks to wait between contract calls (default: 1 block). This PR also updates the logic of `blockUntilSuccessful` including the support of `context` to allow the function to be canceled early.

## Jira / Linear Tickets

- [DVT-502](https://polygon.atlassian.net/browse/DVT-502)

# Testing
- [x] Show options in help

```sh
$ polycli loadtest -h | grep contract-call
  --contract-call-block-interval uint          The number of blocks to wait between contract calls (default 1)
  --contract-call-nb-blocks-to-wait-for uint   The number of blocks to wait for before giving up on a contract call (default 30)
```

- [x] Run load test with default parameters

```sh
$ polycli loadtest --verbosity 700 --chain-id 1337 --requests 1000 --mode c http://127.0.0.1:8545
1:01PM DBG Starting logger in console mode
1:01PM DBG Starting Loadtest
1:01PM INF Starting Load Test
1:01PM INF Starting Load Test
1:01PM INF Connecting with RPC endpoint to initialize load test parameters
1:01PM TRC Retreived current gas price gasprice=8
1:01PM TRC Current Block Number blocknumber=473
1:01PM TRC Current account balance balance=4999999472918152683345
1:01PM TRC Hex of odd length original=38D7EA4C68000
1:01PM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"AvailAppID":0,"AvailRuntime":null,"BatchSize":999,"ByteCount":1024,"ChainID":1337,"Concurrency":1,"ContractCallBlockInterval":1,"ContractCallNumberOfBlocksToWaitFor":30,"CurrentGas":8,"CurrentNonce":426,"DelAddress":"","ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":30175782965061331201157137042014122781558886384910785332752666033589853463034,"X":36405839969746785076083915005678656647806951607600131854360360806126023484467,"Y":33607126158016649181688023362411565996635601901352589004706892696521135399893},"ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"FromAvailAddress":null,"FromETHAddress":"0x85da99c8a7c2c95964c8efd687e95e632fc533d6","Function":1,"HexSendAmount":"0x38D7EA4C68000","IsAvail":false,"Iterations":100,"LtAddress":"","Mode":"c","PrettyLogs":true,"PrivateKey":"42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa","RateLimit":4,"Requests":1000,"Seed":123456,"SendAmount":1000000000000000,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToAvailAddress":null,"ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false,"URL":{"ForceQuery":false,"Fragment":"","Host":"127.0.0.1:8545","OmitHost":false,"Opaque":"","Path":"","RawFragment":"","RawPath":"","RawQuery":"","Scheme":"http","User":null},"Verbosity":700}
1:01PM TRC Load test contract address contractaddress=0x3a960fe1991a611e4a08526b23088c02324c6155
1:01PM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=473
1:01PM TRC New block newBlock=473
1:01PM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
1:01PM TRC New block newBlock=474
1:01PM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=1
1:01PM TRC New block newBlock=474
1:01PM TRC New block newBlock=475
1:01PM TRC Function executed successfuly elapsedTimeSeconds=3
1:01PM DBG Starting main loadtest loop currentNonce=427
1:01PM TRC Starting Thread routine=0
1:01PM TRC Finished starting go routines. Waiting..
1:01PM TRC Executing contract method method=TestXOR
1:01PM TRC Request mode=c nonce=427 request=0 routine=0
1:01PM TRC Executing contract method method=TestRETURNDATASIZE
1:01PM TRC Request mode=c nonce=428 request=1 routine=0
1:01PM TRC Executing contract method method=TestLOG3
1:01PM TRC Request mode=c nonce=429 request=2 routine=0
^C1:01PM INF Interrupted.. Stopping load test
1:01PM INF * Results
1:01PM INF Samples samples=3
1:01PM INF Start startTime=2023-05-04T13:01:27+02:00
1:01PM INF End endTime=2023-05-04T13:01:28+02:00
1:01PM INF Mean Wait meanWait=0.016420708333333336
1:01PM INF Num errors numErrors=0
1:01PM INF Finished
```

- [x] Run load test with custom parameters (waiting time and interval)

```sh
$ polycli loadtest --verbosity 700 --chain-id 1337 --requests 1000 --mode c --contract-call-nb-blocks-to-wait-for 60 --contract-call-block-interval 5 http://127.0.0.1:8545
1:02PM DBG Starting logger in console mode
1:02PM DBG Starting Loadtest
1:02PM INF Starting Load Test
1:02PM INF Starting Load Test
1:02PM INF Connecting with RPC endpoint to initialize load test parameters
1:02PM TRC Retreived current gas price gasprice=8
1:02PM TRC Current Block Number blocknumber=505
1:02PM TRC Current account balance balance=4999999472918129346601
1:02PM TRC Hex of odd length original=38D7EA4C68000
1:02PM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"AvailAppID":0,"AvailRuntime":null,"BatchSize":999,"ByteCount":1024,"ChainID":1337,"Concurrency":1,"ContractCallBlockInterval":5,"ContractCallNumberOfBlocksToWaitFor":60,"CurrentGas":8,"CurrentNonce":430,"DelAddress":"","ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":30175782965061331201157137042014122781558886384910785332752666033589853463034,"X":36405839969746785076083915005678656647806951607600131854360360806126023484467,"Y":33607126158016649181688023362411565996635601901352589004706892696521135399893},"ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"FromAvailAddress":null,"FromETHAddress":"0x85da99c8a7c2c95964c8efd687e95e632fc533d6","Function":1,"HexSendAmount":"0x38D7EA4C68000","IsAvail":false,"Iterations":100,"LtAddress":"","Mode":"c","PrettyLogs":true,"PrivateKey":"42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa","RateLimit":4,"Requests":1000,"Seed":123456,"SendAmount":1000000000000000,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToAvailAddress":null,"ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false,"URL":{"ForceQuery":false,"Fragment":"","Host":"127.0.0.1:8545","OmitHost":false,"Opaque":"","Path":"","RawFragment":"","RawPath":"","RawQuery":"","Scheme":"http","User":null},"Verbosity":700}
1:02PM TRC Load test contract address contractaddress=0x2e6cfaf3981795c9b7a8f9ef703262bfd4321986
1:02PM TRC Starting blocking loop blockInterval=5 numberOfBlocksToWaitFor=60 startBlockNumber=505
1:02PM TRC New block newBlock=505
1:02PM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
1:02PM TRC New block newBlock=506
1:02PM TRC New block newBlock=506
1:02PM TRC New block newBlock=507
1:02PM TRC New block newBlock=507
1:02PM TRC New block newBlock=508
1:02PM TRC New block newBlock=508
1:02PM TRC New block newBlock=509
1:02PM TRC New block newBlock=509
1:02PM TRC New block newBlock=510
1:02PM TRC Function executed successfuly elapsedTimeSeconds=9
1:02PM DBG Starting main loadtest loop currentNonce=431
1:02PM TRC Starting Thread routine=0
1:02PM TRC Finished starting go routines. Waiting..
1:02PM TRC Executing contract method method=TestXOR
1:02PM TRC Request mode=c nonce=431 request=0 routine=0
1:02PM TRC Executing contract method method=TestRETURNDATASIZE
1:02PM TRC Request mode=c nonce=432 request=1 routine=0
1:02PM TRC Executing contract method method=TestLOG3
1:02PM TRC Request mode=c nonce=433 request=2 routine=0
1:02PM TRC Executing contract method method=TestGASPRICE
1:02PM TRC Request mode=c nonce=434 request=3 routine=0
1:02PM TRC Executing contract method method=TestXOR
1:02PM TRC Request mode=c nonce=435 request=4 routine=0
^C1:02PM INF Interrupted.. Stopping load test
1:02PM INF * Results
1:02PM INF Samples samples=5
1:02PM INF Start startTime=2023-05-04T13:02:37+02:00
1:02PM INF End endTime=2023-05-04T13:02:38+02:00
1:02PM INF Mean Wait meanWait=0.010890908000000001
1:02PM INF Num errors numErrors=0
1:02PM INF Finished
```

- [x] Simulate an exhaustion of the waiting period

```sh
$ polycli --verbosity 700 --chain-id 1337 --requests 1000 --mode c --contract-call-nb-blocks-to-wait-for 3 --contract-call-block-interval 5 http://127.0.0.1:8545 
1:03PM DBG Starting logger in console mode
1:03PM DBG Starting Loadtest
1:03PM INF Starting Load Test
1:03PM INF Starting Load Test
1:03PM INF Connecting with RPC endpoint to initialize load test parameters
1:03PM TRC Retreived current gas price gasprice=8
1:03PM TRC Current Block Number blocknumber=541
1:03PM TRC Current account balance balance=4999999472918105474369
1:03PM TRC Hex of odd length original=38D7EA4C68000
1:03PM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"AvailAppID":0,"AvailRuntime":null,"BatchSize":999,"ByteCount":1024,"ChainID":1337,"Concurrency":1,"ContractCallBlockInterval":5,"ContractCallNumberOfBlocksToWaitFor":3,"CurrentGas":8,"CurrentNonce":436,"DelAddress":"","ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":30175782965061331201157137042014122781558886384910785332752666033589853463034,"X":36405839969746785076083915005678656647806951607600131854360360806126023484467,"Y":33607126158016649181688023362411565996635601901352589004706892696521135399893},"ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"FromAvailAddress":null,"FromETHAddress":"0x85da99c8a7c2c95964c8efd687e95e632fc533d6","Function":1,"HexSendAmount":"0x38D7EA4C68000","IsAvail":false,"Iterations":100,"LtAddress":"","Mode":"c","PrettyLogs":true,"PrivateKey":"42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa","RateLimit":4,"Requests":1000,"Seed":123456,"SendAmount":1000000000000000,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToAvailAddress":null,"ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false,"URL":{"ForceQuery":false,"Fragment":"","Host":"127.0.0.1:8545","OmitHost":false,"Opaque":"","Path":"","RawFragment":"","RawPath":"","RawQuery":"","Scheme":"http","User":null},"Verbosity":700}
1:03PM TRC Load test contract address contractaddress=0xd8239501135a2e89f3dcbfb97840bd862a771cd9
1:03PM TRC Starting blocking loop blockInterval=5 numberOfBlocksToWaitFor=3 startBlockNumber=541
1:03PM TRC New block newBlock=541
1:03PM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
1:03PM TRC New block newBlock=541
1:03PM TRC New block newBlock=542
1:03PM TRC New block newBlock=542
1:03PM TRC New block newBlock=543
1:03PM TRC New block newBlock=543
1:03PM TRC New block newBlock=544
1:03PM TRC New block newBlock=544
1:03PM TRC New block newBlock=545
1:03PM ERR Exhausted waiting period elapsedTimeSeconds=9
1:03PM DBG Starting main loadtest loop currentNonce=437
1:03PM TRC Starting Thread routine=0
1:03PM TRC Finished starting go routines. Waiting..
1:03PM TRC Executing contract method method=TestXOR
1:03PM TRC Request mode=c nonce=437 request=0 routine=0
1:03PM TRC Executing contract method method=TestRETURNDATASIZE
1:03PM TRC Request mode=c nonce=438 request=1 routine=0
1:03PM TRC Executing contract method method=TestLOG3
1:03PM TRC Request mode=c nonce=439 request=2 routine=0
1:03PM TRC Executing contract method method=TestGASPRICE
1:03PM TRC Request mode=c nonce=440 request=3 routine=0
1:03PM TRC Executing contract method method=TestXOR
1:03PM TRC Request mode=c nonce=441 request=4 routine=0
^C1:03PM INF Interrupted.. Stopping load test
1:03PM INF * Results
1:03PM INF Samples samples=5
1:03PM INF Start startTime=2023-05-04T13:03:48+02:00
1:03PM INF End endTime=2023-05-04T13:03:49+02:00
1:03PM INF Mean Wait meanWait=0.012256125000000001
1:03PM INF Num errors numErrors=0
1:03PM INF There are still oustanding transactions. There might be issues restarting with the same sending key until those transactions clear pending=4
1:03PM INF Finished
```

[DVT-502]: https://polygon.atlassian.net/browse/DVT-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ