### PR TITLE
Adding ability to create geth/bor style wallet from hex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ vet: ## Run go vet and shadow against code.
 # https://golangci-lint.run/usage/install/#local-installation
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint against code.
-	golangci-lint run --fix
+	golangci-lint run --fix --timeout 5m
 
 .PHONY: lint
 lint: tidy vet golangci-lint ## Run all the linter tools against code.

--- a/cmd/parseethwallet/parseethwallet.go
+++ b/cmd/parseethwallet/parseethwallet.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"golang.org/x/crypto/sha3"
 	"io"
@@ -15,8 +16,10 @@ import (
 )
 
 var (
-	inputFileName *string
-	inputPassword *string
+	inputFileName          *string
+	inputPassword          *string
+	inputRawHexPrivateKey  *string
+	inputKeyStoreDirectory *string
 )
 
 type plainKeyJSON struct {
@@ -33,9 +36,59 @@ var ParseETHWalletCmd = &cobra.Command{
 	Use:   "parseethwallet --file UTC--2023-03-03T17-26-43.371893268Z--1652e7b47af367372a7a6d7d6fe5037702860c6d",
 	Short: "A simple tool to extract the private key from an eth wallet",
 	Long: `
+This function can take a geth style wallet file and extract the private key as hex. It can also do the opposite
+
+This command would take the private key and import it into a local keystore with no password
+
+$ polycli parseethwallet --hexkey 42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa
+
+$ cat UTC--2023-05-09T22-48-57.582848385Z--85da99c8a7c2c95964c8efd687e95e632fc533d6  | jq '.'
+{
+  "address": "85da99c8a7c2c95964c8efd687e95e632fc533d6",
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "ciphertext": "d0b4377a4ae5ebc9a5bef06ce4be99565d10cb0dedc2f7ff5aaa07ea68e7b597",
+    "cipherparams": {
+      "iv": "8ecd172ff7ace15ed5bc44ea89473d8e"
+    },
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 262144,
+      "p": 1,
+      "r": 8,
+      "salt": "cd6ec772dc43225297412809feaae441d578642c6a67cabf4e29bcaf594f575b"
+    },
+    "mac": "c992128ed466ad15a9648f4112af22929b95f511f065b12a80abcfb7e4d39a79"
+  },
+  "id": "82af329d-2af5-41a6-ae6b-624f3e1c224b",
+  "version": 3
+}
+
+If we wanted to go the opposite direction, we could run a command like this:
+
+polycli parseethwallet --file /tmp/keystore/UTC--2023-05-09T22-48-57.582848385Z--85da99c8a7c2c95964c8efd687e95e632fc533d6  | jq '.'
+{
+  "Address": "0x85da99c8a7c2c95964c8efd687e95e632fc533d6",
+  "PublicKey": "507cf9a75e053cda6922467721ddb10412da9bec30620347d9529cc77fca24334a4cf59685be4a2fdeabf4e7753350e42d2d3a20250fd9dc554d226463c8a3d5",
+  "PrivateKey": "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa"
+}
+
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// it would be nice to have a generic reader
+		if *inputRawHexPrivateKey != "" {
+			ks := keystore.NewKeyStore(*inputKeyStoreDirectory, keystore.StandardScryptN, keystore.StandardScryptP)
+			pk, err := crypto.HexToECDSA(*inputRawHexPrivateKey)
+			if err != nil {
+				return err
+			}
+			_, err = ks.ImportECDSA(pk, *inputPassword)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
 
 		rawData, err := getInputData(cmd, args)
 		if err != nil {
@@ -67,6 +120,8 @@ func init() {
 	flagSet := ParseETHWalletCmd.PersistentFlags()
 	inputFileName = flagSet.String("file", "", "Provide a file with the key information ")
 	inputPassword = flagSet.String("password", "", "An optional password use to unlock the key")
+	inputRawHexPrivateKey = flagSet.String("hexkey", "", "An optional hexkey that would be use to generate a geth style key")
+	inputKeyStoreDirectory = flagSet.String("keystore", "/tmp/keystore", "The directory where keys would be stored when importing a raw hex")
 }
 
 func getInputData(cmd *cobra.Command, args []string) ([]byte, error) {


### PR DESCRIPTION
# Description

Adding a simple method to run the opposite direction as the current `parseethwallet` method. Given a raw hex encoded private key, we should be able to create a keystore.

Additionally as part of the PoS automation, we need a way to export the uncompressed public key, so we're adding a field `HexFullPublicKey` to the `wallet` command which would output the full key which is used by our staking scripts.

[DVT-711](https://polygon.atlassian.net/browse/DVT-711)

# Testing

- [x] Test importing an account
- [x] Test exporting an account
- [x] Test export of uncompressed to to match matic-cli output


[DVT-711]: https://polygon.atlassian.net/browse/DVT-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ