### PR TITLE
fix: remove replace directive in `go.mod`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,5 +103,6 @@ hex_funding_amount := $(shell echo "obase=16; ${LOADTEST_FUNDING_AMOUNT_ETH}*10^
 .PHONY: loadtest
 loadtest: build ## Fund test account with 5k ETH and run loadtest.
 	curl -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "method":"eth_sendTransaction", "params":[{"from": "${eth_coinbase}","to": "${LOADTEST_ACCOUNT}","value": "0x${hex_funding_amount}"}], "id":1}' http://127.0.0.1:8545
+	sleep 2
 	$(BUILD_DIR)/$(BIN_NAME) loadtest --verbosity 700 --chain-id 1337 --concurrency 1 --requests 1000 --rate-limit 5 --mode c http://127.0.0.1:8545
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ hex_funding_amount := $(shell echo "obase=16; ${LOADTEST_FUNDING_AMOUNT_ETH}*10^
 .PHONY: geth-loadtest
 geth-loadtest: build ## Fund test account with 5k ETH and run loadtest against an EVM/Geth chain.
 	curl -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "method":"eth_sendTransaction", "params":[{"from": "${eth_coinbase}","to": "${LOADTEST_ACCOUNT}","value": "0x${hex_funding_amount}"}], "id":1}' http://127.0.0.1:${PORT}
-	sleep 2
+	sleep 5
 	$(BUILD_DIR)/$(BIN_NAME) loadtest --verbosity 700 --chain-id 1337 --concurrency 1 --requests 1000 --rate-limit 5 --mode c http://127.0.0.1:$(PORT)
 
 .PHONY: avail-loadtest

--- a/Makefile
+++ b/Makefile
@@ -119,4 +119,4 @@ geth-loadtest: build ## Fund test account with 5k ETH and run loadtest against a
 
 .PHONY: avail-loadtest
 avail-loadtest: build ## Run loadtest against an Avail chain.
-	$(BUILD_DIR)/$(BIN_NAME) loadtest --data-avail --verbosity 700 --chain-id 1256 --concurrency 1 --requests 1000 --rate-limit 5 --mode c http://127.0.0.1:$(PORT)
+	$(BUILD_DIR)/$(BIN_NAME) loadtest --verbosity 700 --chain-id 1256 --concurrency 1 --requests 1000 --rate-limit 5 --mode t --data-avail http://127.0.0.1:$(PORT)

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ $(BIN_DIR): ## Create the binary folder.
 geth: $(BIN_DIR) ## Start a local geth node.
 	geth --dev --dev.period 2 --http --http.addr localhost --http.port $(PORT) --http.api admin,debug,web3,eth,txpool,personal,miner,net --verbosity 5 --rpc.gascap 50000000  --rpc.txfeecap 0 --miner.gaslimit  10 --miner.gasprice 1 --gpo.blocks 1 --gpo.percentile 1 --gpo.maxprice 10 --gpo.ignoreprice 2 --dev.gaslimit 50000000
 
-AVAIL=$(./out)
 .PHONY: avail
 avail: $(BIN_DIR) ## Start a local avail node.
 	avail --dev --rpc-port $(PORT)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -44,9 +44,9 @@ import (
 	"golang.org/x/text/message"
 	"golang.org/x/text/number"
 
-	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v4"
-	gssignature "github.com/centrifuge/go-substrate-rpc-client/v4/signature"
-	gstypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
+	gsrpc "github.com/leovct/go-substrate-rpc-client/v4"
+	gssignature "github.com/leovct/go-substrate-rpc-client/v4/signature"
+	gstypes "github.com/leovct/go-substrate-rpc-client/v4/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -44,9 +44,9 @@ import (
 	"golang.org/x/text/message"
 	"golang.org/x/text/number"
 
-	gsrpc "github.com/leovct/go-substrate-rpc-client/v4"
-	gssignature "github.com/leovct/go-substrate-rpc-client/v4/signature"
-	gstypes "github.com/leovct/go-substrate-rpc-client/v4/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v4"
+	gssignature "github.com/centrifuge/go-substrate-rpc-client/v4/signature"
+	gstypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -257,7 +257,6 @@ type (
 		ByteCount                           *uint64
 		Seed                                *int64
 		IsAvail                             *bool
-		AvailAppID                          *uint32
 		LtAddress                           *string
 		DelAddress                          *string
 		ContractCallNumberOfBlocksToWaitFor *uint64
@@ -326,7 +325,6 @@ r - random modes
 	ltp.ByteCount = LoadtestCmd.PersistentFlags().Uint64P("byte-count", "b", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
 	ltp.Seed = LoadtestCmd.PersistentFlags().Int64("seed", 123456, "A seed for generating random values and addresses")
 	ltp.IsAvail = LoadtestCmd.PersistentFlags().Bool("data-avail", false, "Is this a test of avail rather than an EVM / Geth Chain")
-	ltp.AvailAppID = LoadtestCmd.PersistentFlags().Uint32("app-id", 0, "The AppID used for avail")
 	ltp.LtAddress = LoadtestCmd.PersistentFlags().String("lt-address", "", "A pre-deployed load test contract address")
 	ltp.DelAddress = LoadtestCmd.PersistentFlags().String("del-address", "", "A pre-deployed delegator contract address")
 	ltp.ContractCallNumberOfBlocksToWaitFor = LoadtestCmd.PersistentFlags().Uint64("contract-call-nb-blocks-to-wait-for", 30, "The number of blocks to wait for before giving up on a contract call")
@@ -1458,7 +1456,6 @@ func loadtestAvailTransfer(ctx context.Context, c *gsrpc.SubstrateAPI, nonce uin
 		SpecVersion:        rv.SpecVersion,
 		Tip:                gstypes.NewUCompactFromUInt(0),
 		TransactionVersion: rv.TransactionVersion,
-		//AppID:              gstypes.NewUCompactFromUInt(uint64(*ltp.AvailAppID)),
 	}
 
 	err = ext.Sign(kp, o)
@@ -1501,7 +1498,6 @@ func loadtestAvailStore(ctx context.Context, c *gsrpc.SubstrateAPI, nonce uint64
 		SpecVersion:        rv.SpecVersion,
 		Tip:                gstypes.NewUCompactFromUInt(100),
 		TransactionVersion: rv.TransactionVersion,
-		//AppID:              gstypes.NewUCompactFromUInt(uint64(*ltp.AvailAppID)),
 	}
 	// Sign the transaction using Alice's default account
 	err = ext.Sign(kp, o)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1430,11 +1430,7 @@ func loadtestAvailTransfer(ctx context.Context, c *gsrpc.SubstrateAPI, nonce uin
 			// For some reason weren't able to read the random data
 			log.Error().Msg("Sending to random is not implemented for substrate yet")
 		} else {
-			toAddr, err = gstypes.NewMultiAddressFromAccountID(pk)
-			if err != nil {
-				log.Error().Msg("Unable to create an address from the account id")
-				return
-			}
+			toAddr = gstypes.NewMultiAddressFromAccountID(pk)
 		}
 
 	}

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1458,7 +1458,7 @@ func loadtestAvailTransfer(ctx context.Context, c *gsrpc.SubstrateAPI, nonce uin
 		SpecVersion:        rv.SpecVersion,
 		Tip:                gstypes.NewUCompactFromUInt(0),
 		TransactionVersion: rv.TransactionVersion,
-		AppID:              gstypes.NewUCompactFromUInt(uint64(*ltp.AvailAppID)),
+		//AppID:              gstypes.NewUCompactFromUInt(uint64(*ltp.AvailAppID)),
 	}
 
 	err = ext.Sign(kp, o)
@@ -1501,7 +1501,7 @@ func loadtestAvailStore(ctx context.Context, c *gsrpc.SubstrateAPI, nonce uint64
 		SpecVersion:        rv.SpecVersion,
 		Tip:                gstypes.NewUCompactFromUInt(100),
 		TransactionVersion: rv.TransactionVersion,
-		AppID:              gstypes.NewUCompactFromUInt(uint64(*ltp.AvailAppID)),
+		//AppID:              gstypes.NewUCompactFromUInt(uint64(*ltp.AvailAppID)),
 	}
 	// Sign the transaction using Alice's default account
 	err = ext.Sign(kp, o)

--- a/go.mod
+++ b/go.mod
@@ -256,5 +256,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )
-
-replace github.com/centrifuge/go-substrate-rpc-client/v4 => github.com/availproject/go-substrate-rpc-client/v4 v4.0.12-avail-1.4.0-rc1-5e286e3

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/0xPolygon/polygon-edge v0.8.0
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+	github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6
 	github.com/coinbase/kryptology v1.8.0
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/gizak/termui/v3 v3.1.0
@@ -25,10 +26,7 @@ require (
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
 )
 
-require (
-	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/leovct/go-substrate-rpc-client/v4 v4.0.0-20230525153913-bfb420a865c0
-)
+require github.com/cenkalti/backoff v2.2.1+incompatible
 
 require (
 	cloud.google.com/go v0.110.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maticnetwork/polygon-cli
 
-go 1.18
+go 1.19
 
 require (
 	github.com/0xPolygon/polygon-edge v0.8.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/0xPolygon/polygon-edge v0.8.0
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
-	github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6
 	github.com/coinbase/kryptology v1.8.0
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/gizak/termui/v3 v3.1.0
@@ -26,7 +25,10 @@ require (
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
 )
 
-require github.com/cenkalti/backoff v2.2.1+incompatible
+require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/leovct/go-substrate-rpc-client/v4 v4.0.0-20230525153913-bfb420a865c0
+)
 
 require (
 	cloud.google.com/go v0.110.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6 h1:Il7zBKEvRwiWN/GHogUjmHzaXfp9TvbbhVAOQ1vVBBQ=
+github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6/go.mod h1:5g1oM4Zu3BOaLpsKQ+O8PAv2kNuq+kPcA1VzFbsSqxE=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6 h1:Il7zBKEvRwiWN/GHogUjmHzaXfp9TvbbhVAOQ1vVBBQ=
+github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6/go.mod h1:5g1oM4Zu3BOaLpsKQ+O8PAv2kNuq+kPcA1VzFbsSqxE=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -506,8 +508,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
-github.com/leovct/go-substrate-rpc-client/v4 v4.0.0-20230525153913-bfb420a865c0 h1:xdPlwE00j0gbRpCb9OFnMR6phVDlBDbw+AIFw3rd3O8=
-github.com/leovct/go-substrate-rpc-client/v4 v4.0.0-20230525153913-bfb420a865c0/go.mod h1:EsX0qY4IhfNXWrhAcop9Fbhyd/f7QATaTji7NHcfV20=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6 h1:Il7zBKEvRwiWN/GHogUjmHzaXfp9TvbbhVAOQ1vVBBQ=
-github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.6/go.mod h1:5g1oM4Zu3BOaLpsKQ+O8PAv2kNuq+kPcA1VzFbsSqxE=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -510,6 +508,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
+github.com/leovct/go-substrate-rpc-client/v4 v4.0.0-20230525153913-bfb420a865c0 h1:xdPlwE00j0gbRpCb9OFnMR6phVDlBDbw+AIFw3rd3O8=
+github.com/leovct/go-substrate-rpc-client/v4 v4.0.0-20230525153913-bfb420a865c0/go.mod h1:EsX0qY4IhfNXWrhAcop9Fbhyd/f7QATaTji7NHcfV20=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,6 @@ github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/availproject/go-substrate-rpc-client/v4 v4.0.12-avail-1.4.0-rc1-5e286e3 h1:9bPK0/Vd+uOQul3vEBSemRXO+rwqi+UXDAvFzNUlG8A=
-github.com/availproject/go-substrate-rpc-client/v4 v4.0.12-avail-1.4.0-rc1-5e286e3/go.mod h1:5g1oM4Zu3BOaLpsKQ+O8PAv2kNuq+kPcA1VzFbsSqxE=
 github.com/aws/aws-sdk-go v1.44.61 h1:NcpLSS3Z0MiVQIYugx4I40vSIEEAXT0baO684ExNRco=
 github.com/aws/aws-sdk-go v1.44.61/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
# Description

The installation of `polycli v0.1.20` fails when using `go install` (see #70).

```bash
$ go install github.com/maticnetwork/polygon-cli@v0.1.20                                                                                                                                
go: downloading github.com/maticnetwork/polygon-cli v0.1.20
go: github.com/maticnetwork/polygon-cli@v0.1.20 (in github.com/maticnetwork/polygon-cli@v0.1.20):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

This PR also bumps the version of go to `1.19` and adds helpers to start an `avail` dev node locally and start load testing.

## Jira / Linear Tickets

x

# Testing

- [x] `go install .`
- [x] `make lint`
- [x] `make test`
- [x] `make build`
- [x] `make geth-loadtest`(against a local geth node, see `make geth`)
- [ ] `make avail-loadtest` (against a local avail node, see `make avail`)
