### PR TITLE
write total difficulty

### DIFF
--- a/p2p/database/database.go
+++ b/p2p/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -13,7 +14,7 @@ import (
 // to. To use another database solution, just implement these methods and
 // update the sensor to use the new connection.
 type Database interface {
-	WriteBlock(context.Context, *enode.Node, *types.Block)
+	WriteBlock(context.Context, *enode.Node, *types.Block, *big.Int)
 	WriteBlockHeaders(context.Context, []*types.Header)
 	WriteBlockHashes(context.Context, *enode.Node, []common.Hash)
 	WriteBlockBody(context.Context, *eth.BlockBody, common.Hash)

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -277,7 +277,7 @@ func (c *Conn) ReadAndServe(db database.Database, count *MessageCount) error {
 
 					dbCh <- struct{}{}
 					go func() {
-						db.WriteBlock(ctx, c.node, msg.Block)
+						db.WriteBlock(ctx, c.node, msg.Block, msg.TD)
 						<-dbCh
 					}()
 				}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->
Looks like total difficulty is just the sum of difficulties from the beginning of the chain. When receiving NewBlocks (not block hashes), you get the total difficulty, but I originally omitted this to prevent a sparsely set field since when receiving block hashes there would be no way to request it. This PR adds that here to allow during analysis to quickly calculate the total difficulty by traversing up the parents. This traversal is not done at the sensor level to prevent incurring additional reads ops.
