### PR TITLE
ETH JSON RPC Conformance Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ out/
 coverage.out
 
 .vscode
-*.json

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/maticnetwork/polygon-cli/cmd/monitor"
 	"github.com/maticnetwork/polygon-cli/cmd/nodekey"
 	"github.com/maticnetwork/polygon-cli/cmd/rpc"
+	"github.com/maticnetwork/polygon-cli/cmd/rpcfuzz"
 	"github.com/maticnetwork/polygon-cli/cmd/version"
 	"github.com/maticnetwork/polygon-cli/cmd/wallet"
 )
@@ -75,21 +76,22 @@ func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.SetOut(os.Stdout)
 
+	rootCmd.AddCommand(abi.ABICmd)
 	rootCmd.AddCommand(dumpblocks.DumpblocksCmd)
 	rootCmd.AddCommand(forge.ForgeCmd)
+	rootCmd.AddCommand(fork.ForkCmd)
 	rootCmd.AddCommand(hash.HashCmd)
 	rootCmd.AddCommand(loadtest.LoadtestCmd)
 	rootCmd.AddCommand(metricsToDash.MetricsToDashCmd)
-	rootCmd.AddCommand(monitor.MonitorCmd)
 	rootCmd.AddCommand(mnemonic.MnemonicCmd)
+	rootCmd.AddCommand(monitor.MonitorCmd)
 	rootCmd.AddCommand(nodekey.NodekeyCmd)
+	rootCmd.AddCommand(p2p.P2pCmd)
+	rootCmd.AddCommand(parseethwallet.ParseETHWalletCmd)
 	rootCmd.AddCommand(rpc.RpcCmd)
-	rootCmd.AddCommand(abi.ABICmd)
+	rootCmd.AddCommand(rpcfuzz.RPCFuzzCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(wallet.WalletCmd)
-	rootCmd.AddCommand(fork.ForkCmd)
-	rootCmd.AddCommand(parseethwallet.ParseETHWalletCmd)
-	rootCmd.AddCommand(p2p.P2pCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -997,9 +997,7 @@ func ArgsBlockFilterID(ctx context.Context, rpcClient *rpc.Client, extraArgs ...
 		log.Trace().Str("filterid", filterId).Msg("Created filter")
 
 		args := []interface{}{filterId}
-		for _, v := range extraArgs {
-			args = append(args, v)
-		}
+		args = append(args, extraArgs...)
 		return args
 	}
 }
@@ -1017,9 +1015,7 @@ func ArgsFilterID(ctx context.Context, rpcClient *rpc.Client, filterArgs RPCTest
 		log.Trace().Str("filterid", filterId).Msg("Created filter")
 
 		args := []interface{}{filterId}
-		for _, v := range extraArgs {
-			args = append(args, v)
-		}
+		args = append(args, extraArgs...)
 		return args
 	}
 }

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -32,8 +32,16 @@ var (
 		Validator: ValidateRegexString(`^\d*$`),
 	}
 
+	// cast rpc --rpc-url localhost:8545 web3_clientVersion
+	RPCTestWeb3ClientVersion = RPCTestGeneric{
+		Method:    "web3_clientVersion",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^[[:print:]]*$`),
+	}
+
 	allTests = []RPCTest{
 		&RPCTestNetVersion,
+		&RPCTestWeb3ClientVersion,
 	}
 )
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -875,7 +875,7 @@ func ValidateExactJSON(expected string) func(result interface{}) error {
 	return func(result interface{}) error {
 		jsonResult, err := json.Marshal(result)
 		if err != nil {
-			return fmt.Errorf("Unable to json marshal test result: %w")
+			return fmt.Errorf("Unable to json marshal test result: %w", err)
 		}
 
 		if expected != string(jsonResult) {

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -112,7 +112,9 @@ var (
 	allTests          = make([]RPCTest, 0)
 )
 
+// setupTests will add all of the `RPCTests` to the `allTests` slice.
 func setupTests(ctx context.Context, rpcClient *rpc.Client) {
+
 	// cast rpc --rpc-url localhost:8545 net_version
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestNetVersion",
@@ -581,6 +583,36 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Validator: RequireAny(ValidateJSONSchema(rpctypes.RPCSchemaEthBlock), ValidateExact(nil)),
 	})
 
+	// cast rpc --rpc-url localhost:8545 eth_getCompilers
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthGetCompilers",
+		IsError:   true,
+		Method:    "eth_getCompilers",
+		Args:      []interface{}{},
+		Validator: ValidateError(`method eth_getCompilers does not exist`),
+	})
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthCompileSolidity",
+		IsError:   true,
+		Method:    "eth_compileSolidity",
+		Args:      []interface{}{},
+		Validator: ValidateError(`method eth_compileSolidity does not exist`),
+	})
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthCompileLLL",
+		IsError:   true,
+		Method:    "eth_compileLLL",
+		Args:      []interface{}{},
+		Validator: ValidateError(`method eth_compileLLL does not exist`),
+	})
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthCompileSerpent",
+		IsError:   true,
+		Method:    "eth_compileSerpent",
+		Args:      []interface{}{},
+		Validator: ValidateError(`method eth_compileSerpent does not exist`),
+	})
+
 	uniqueTests := make(map[RPCTest]struct{})
 	uniqueTestNames := make(map[string]struct{})
 	for _, v := range allTests {
@@ -1030,7 +1062,7 @@ in dev mode:
 
 # ./build/bin/geth --dev --dev.period 5 --http --http.addr localhost \
     --http.port 8545 \
-    --http.api admin,debug,web3,eth,txpool,personal,miner,net \
+    --http.api 'admin,debug,web3,eth,txpool,personal,clique,miner,net' \
     --verbosity 5 --rpc.gascap 50000000  --rpc.txfeecap 0 \
     --miner.gaslimit  10 --miner.gasprice 1 --gpo.blocks 1 \
     --gpo.percentile 1 --gpo.maxprice 10 --gpo.ignoreprice 2 \

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -732,6 +732,18 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		}),
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthFilter),
 	})
+	// cast rpc --rpc-url localhost:8545 eth_getLogs '{"fromBlock": "earliest", "toBlock": "latest", "address": "0x6fda56c57b0acadb96ed5624ac500c0429d59429", "topics": [null, null, "0x00000000000000000000000085da99c8a7c2c95964c8efd687e95e632fc533d6"]}'
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:   "RPCTestGetLogs",
+		Method: "eth_getLogs",
+		Args: []interface{}{RPCTestFilterArgs{
+			FromBlock: "earliest",
+			ToBlock:   "latest",
+			Address:   *testContractAddress,
+			Topics:    []interface{}{nil, nil, "0x000000000000000000000000" + testEthAddress.String()[2:]},
+		}},
+		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthFilter),
+	})
 
 	uniqueTests := make(map[RPCTest]struct{})
 	uniqueTestNames := make(map[string]struct{})

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -559,6 +559,14 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthTransaction),
 	})
 
+	// eth_getTransactionReceipt
+	allTests = append(allTests, &RPCTestDynamicArgs{
+		Name:      "RPCTestGetTransactionReceipt",
+		Method:    "eth_getTransactionReceipt",
+		Args:      ArgsTransactionHash(ctx, rpcClient, &RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0xa0712d680000000000000000000000000000000000000000000000000000000000002710", MaxFeePerGas: defaultMaxFeePerGas, MaxPriorityFeePerGas: defaultMaxPriorityFeePerGas, Gas: "0x10000"}),
+		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthReceipt),
+	})
+
 	uniqueTests := make(map[RPCTest]struct{})
 	uniqueTestNames := make(map[string]struct{})
 	for _, v := range allTests {

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -45,28 +45,32 @@ var (
 )
 
 var (
-	RPCTestNetVersion              RPCTestGeneric
-	RPCTestWeb3ClientVersion       RPCTestGeneric
-	RPCTestWeb3SHA3                RPCTestGeneric
-	RPCTestWeb3SHA3Error           RPCTestGeneric
-	RPCTestNetListening            RPCTestGeneric
-	RPCTestNetPeerCount            RPCTestGeneric
-	RPCTestEthProtocolVersion      RPCTestGeneric
-	RPCTestEthSyncing              RPCTestGeneric
-	RPCTestEthCoinbase             RPCTestGeneric
-	RPCTestEthChainID              RPCTestGeneric
-	RPCTestEthMining               RPCTestGeneric
-	RPCTestEthHashrate             RPCTestGeneric
-	RPCTestEthGasPrice             RPCTestGeneric
-	RPCTestEthAccounts             RPCTestGeneric
-	RPCTestEthBlockNumber          RPCTestGeneric
-	RPCTestEthGetBalanceLatest     RPCTestGeneric
-	RPCTestEthGetBalanceEarliest   RPCTestGeneric
-	RPCTestEthGetBalancePending    RPCTestGeneric
-	RPCTestEthGetStorageAtLatest   RPCTestGeneric
-	RPCTestEthGetStorageAtEarliest RPCTestGeneric
-	RPCTestEthGetStorageAtPending  RPCTestGeneric
-	RPCTestEthBlockByNumber        RPCTestGeneric
+	RPCTestNetVersion                       RPCTestGeneric
+	RPCTestWeb3ClientVersion                RPCTestGeneric
+	RPCTestWeb3SHA3                         RPCTestGeneric
+	RPCTestWeb3SHA3Error                    RPCTestGeneric
+	RPCTestNetListening                     RPCTestGeneric
+	RPCTestNetPeerCount                     RPCTestGeneric
+	RPCTestEthProtocolVersion               RPCTestGeneric
+	RPCTestEthSyncing                       RPCTestGeneric
+	RPCTestEthCoinbase                      RPCTestGeneric
+	RPCTestEthChainID                       RPCTestGeneric
+	RPCTestEthMining                        RPCTestGeneric
+	RPCTestEthHashrate                      RPCTestGeneric
+	RPCTestEthGasPrice                      RPCTestGeneric
+	RPCTestEthAccounts                      RPCTestGeneric
+	RPCTestEthBlockNumber                   RPCTestGeneric
+	RPCTestEthGetBalanceLatest              RPCTestGeneric
+	RPCTestEthGetBalanceEarliest            RPCTestGeneric
+	RPCTestEthGetBalancePending             RPCTestGeneric
+	RPCTestEthGetStorageAtLatest            RPCTestGeneric
+	RPCTestEthGetStorageAtEarliest          RPCTestGeneric
+	RPCTestEthGetStorageAtPending           RPCTestGeneric
+	RPCTestEthGetTransactionCountAtLatest   RPCTestGeneric
+	RPCTestEthGetTransactionCountAtEarliest RPCTestGeneric
+	RPCTestEthGetTransactionCountAtPending  RPCTestGeneric
+
+	RPCTestEthBlockByNumber RPCTestGeneric
 
 	allTests = make([]RPCTest, 0)
 )
@@ -238,6 +242,26 @@ func setupTests() {
 		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetStorageAtPending)
+
+	// cast rpc --rpc-url localhost:8545 eth_getTransactionCount 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 latest
+	RPCTestEthGetTransactionCountAtLatest = RPCTestGeneric{
+		Method:    "eth_getTransactionCount",
+		Args:      []interface{}{testEthAddress.String(), "latest"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetTransactionCountAtLatest)
+	RPCTestEthGetTransactionCountAtEarliest = RPCTestGeneric{
+		Method:    "eth_getTransactionCount",
+		Args:      []interface{}{testEthAddress.String(), "earliest"},
+		Validator: ValidateRegexString(`^0x0$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetTransactionCountAtEarliest)
+	RPCTestEthGetTransactionCountAtPending = RPCTestGeneric{
+		Method:    "eth_getTransactionCount",
+		Args:      []interface{}{testEthAddress.String(), "pending"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetTransactionCountAtPending)
 
 	// spacing this thing out
 	// spacing this thing out

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -80,7 +80,6 @@ var (
 		Validator: ValidatorError(`method eth_protocolVersion does not exist`),
 	}
 
-	// https://www.liquid-technologies.com/online-json-to-schema-converter
 	// cast rpc --rpc-url localhost:8545 eth_syncing
 	RPCTestEthSyncing = RPCTestGeneric{
 		Method: "eth_syncing",
@@ -212,6 +211,7 @@ var RPCFuzzCmd = &cobra.Command{
 - https://ethereum.github.io/execution-apis/api-documentation/
 - https://ethereum.org/en/developers/docs/apis/json-rpc/
 - https://json-schema.org/
+- https://www.liquid-technologies.com/online-json-to-schema-converter
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -110,6 +110,10 @@ var (
 	RPCTestEthGetBlockTransactionCountByNumberZero     RPCTestGeneric
 	RPCTestEthGetUncleCountByBlockHash                 RPCTestDynamicArgs
 	RPCTestEthGetUncleCountByBlockHashMissing          RPCTestGeneric
+	RPCTestEthGetUncleCountByBlockNumberLatest         RPCTestGeneric
+	RPCTestEthGetUncleCountByBlockNumberEarliest       RPCTestGeneric
+	RPCTestEthGetUncleCountByBlockNumberPending        RPCTestGeneric
+	RPCTestEthGetUncleCountByBlockNumberZero           RPCTestGeneric
 	RPCTestEthBlockByNumber                            RPCTestGeneric
 
 	allTests = make([]RPCTest, 0)
@@ -409,6 +413,36 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Validator: ValidateExact(nil),
 	}
 	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockHashMissing)
+
+	// cast rpc --rpc-url localhost:8545 eth_getUncleCountByNumber 0x1
+	RPCTestEthGetUncleCountByBlockNumberLatest = RPCTestGeneric{
+		Name:      "RPCTestEthGetUncleCountByBlockNumberLatest",
+		Method:    "eth_getUncleCountByBlockNumber",
+		Args:      []interface{}{"latest"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberLatest)
+	RPCTestEthGetUncleCountByBlockNumberEarliest = RPCTestGeneric{
+		Name:      "RPCTestEthGetUncleCountByBlockNumberEarliest",
+		Method:    "eth_getUncleCountByBlockNumber",
+		Args:      []interface{}{"earliest"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberEarliest)
+	RPCTestEthGetUncleCountByBlockNumberPending = RPCTestGeneric{
+		Name:      "RPCTestEthGetUncleCountByBlockNumberPending",
+		Method:    "eth_getUncleCountByBlockNumber",
+		Args:      []interface{}{"pending"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberPending)
+	RPCTestEthGetUncleCountByBlockNumberZero = RPCTestGeneric{
+		Name:      "RPCTestEthGetUncleCountByBlockNumberZero",
+		Method:    "eth_getUncleCountByBlockNumber",
+		Args:      []interface{}{"0x0"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberZero)
 
 	// spacing this thing out
 	// spacing this thing out

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -102,133 +102,69 @@ var (
 )
 
 var (
-	RPCTestNetVersion                                  RPCTestGeneric
-	RPCTestWeb3ClientVersion                           RPCTestGeneric
-	RPCTestWeb3SHA3                                    RPCTestGeneric
-	RPCTestWeb3SHA3Error                               RPCTestGeneric
-	RPCTestNetListening                                RPCTestGeneric
-	RPCTestNetPeerCount                                RPCTestGeneric
-	RPCTestEthProtocolVersion                          RPCTestGeneric
-	RPCTestEthSyncing                                  RPCTestGeneric
-	RPCTestEthCoinbase                                 RPCTestGeneric
-	RPCTestEthChainID                                  RPCTestGeneric
-	RPCTestEthMining                                   RPCTestGeneric
-	RPCTestEthHashrate                                 RPCTestGeneric
-	RPCTestEthGasPrice                                 RPCTestGeneric
-	RPCTestEthAccounts                                 RPCTestGeneric
-	RPCTestEthBlockNumber                              RPCTestGeneric
-	RPCTestEthGetBalanceLatest                         RPCTestGeneric
-	RPCTestEthGetBalanceEarliest                       RPCTestGeneric
-	RPCTestEthGetBalancePending                        RPCTestGeneric
-	RPCTestEthGetBalanceZero                           RPCTestGeneric
-	RPCTestEthGetStorageAtLatest                       RPCTestGeneric
-	RPCTestEthGetStorageAtEarliest                     RPCTestGeneric
-	RPCTestEthGetStorageAtPending                      RPCTestGeneric
-	RPCTestEthGetStorageAtZero                         RPCTestGeneric
-	RPCTestEthGetTransactionCountAtLatest              RPCTestGeneric
-	RPCTestEthGetTransactionCountAtEarliest            RPCTestGeneric
-	RPCTestEthGetTransactionCountAtPending             RPCTestGeneric
-	RPCTestEthGetTransactionCountAtZero                RPCTestGeneric
-	RPCTestEthGetBlockTransactionCountByHash           RPCTestDynamicArgs
-	RPCTestEthGetBlockTransactionCountByHashMissing    RPCTestGeneric
-	RPCTestEthGetBlockTransactionCountByNumberLatest   RPCTestGeneric
-	RPCTestEthGetBlockTransactionCountByNumberEarliest RPCTestGeneric
-	RPCTestEthGetBlockTransactionCountByNumberPending  RPCTestGeneric
-	RPCTestEthGetBlockTransactionCountByNumberZero     RPCTestGeneric
-	RPCTestEthGetUncleCountByBlockHash                 RPCTestDynamicArgs
-	RPCTestEthGetUncleCountByBlockHashMissing          RPCTestGeneric
-	RPCTestEthGetUncleCountByBlockNumberLatest         RPCTestGeneric
-	RPCTestEthGetUncleCountByBlockNumberEarliest       RPCTestGeneric
-	RPCTestEthGetUncleCountByBlockNumberPending        RPCTestGeneric
-	RPCTestEthGetUncleCountByBlockNumberZero           RPCTestGeneric
-	RPCTestEthGetCodeLatest                            RPCTestGeneric
-	RPCTestEthGetCodePending                           RPCTestGeneric
-	RPCTestEthGetCodeEarliest                          RPCTestGeneric
-	RPCTestEthSign                                     RPCTestDynamicArgs
-	RPCTestEthSignFail                                 RPCTestGeneric
-	RPCTestEthSignTransaction                          RPCTestDynamicArgs
-	RPCTestEthSendTransaction                          RPCTestDynamicArgs
-	RPCTestEthSendRawTransaction                       RPCTestDynamicArgs
-	RPCTestEthCallLatest                               RPCTestGeneric
-	RPCTestEthCallEarliest                             RPCTestGeneric
-	RPCTestEthCallPending                              RPCTestGeneric
-	RPCTestEthCallZero                                 RPCTestGeneric
-	RPCTestEthEstimateGas                              RPCTestGeneric
-	RPCTestEthGetBlockByHash                           RPCTestDynamicArgs
-	RPCTestEthGetBlockByHashNoTx                       RPCTestDynamicArgs
-	RPCTestEthGetBlockByHashZero                       RPCTestGeneric
-
-	allTests                = make([]RPCTest, 0)
-	RPCTestEthBlockByNumber RPCTestGeneric
+	allTests = make([]RPCTest, 0)
 )
 
 func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 	// cast rpc --rpc-url localhost:8545 net_version
-	RPCTestNetVersion = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestNetVersion",
 		Method:    "net_version",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^\d*$`),
-	}
-	allTests = append(allTests, &RPCTestNetVersion)
+	})
 
 	// cast rpc --rpc-url localhost:8545 web3_clientVersion
-	RPCTestWeb3ClientVersion = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestWeb3ClientVersion",
 		Method:    "web3_clientVersion",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^[[:print:]]*$`),
-	}
-	allTests = append(allTests, &RPCTestWeb3ClientVersion)
+	})
 
 	// cast rpc --rpc-url localhost:8545 web3_sha3 0x68656c6c6f20776f726c64
-	RPCTestWeb3SHA3 = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestWeb3SHA3",
 		Method:    "web3_sha3",
 		Args:      []interface{}{"0x68656c6c6f20776f726c64"},
 		Validator: ValidateRegexString(`0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad`),
-	}
-	allTests = append(allTests, &RPCTestWeb3SHA3)
+	})
 
-	RPCTestWeb3SHA3Error = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestWeb3SHA3Error",
 		IsError:   true,
 		Method:    "web3_sha3",
 		Args:      []interface{}{"68656c6c6f20776f726c64"},
 		Validator: ValidateError(`cannot unmarshal hex string without 0x prefix`),
-	}
-	allTests = append(allTests, &RPCTestWeb3SHA3Error)
+	})
 
 	// cast rpc --rpc-url localhost:8545 net_listening
-	RPCTestNetListening = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestNetListening",
 		Method:    "net_listening",
 		Args:      []interface{}{},
 		Validator: ValidateExact(true),
-	}
-	allTests = append(allTests, &RPCTestNetListening)
+	})
 
 	// cast rpc --rpc-url localhost:8545 net_peerCount
-	RPCTestNetPeerCount = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestNetPeerCount",
 		Method:    "net_peerCount",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]*$`),
-	}
-	allTests = append(allTests, &RPCTestNetPeerCount)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_protocolVersion
-	RPCTestEthProtocolVersion = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthProtocolVersion",
 		IsError:   true,
 		Method:    "eth_protocolVersion",
 		Args:      []interface{}{},
 		Validator: ValidateError(`method eth_protocolVersion does not exist`),
-	}
-	allTests = append(allTests, &RPCTestEthProtocolVersion)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_syncing
-	RPCTestEthSyncing = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:   "RPCTestEthSyncing",
 		Method: "eth_syncing",
 		Args:   []interface{}{},
@@ -236,30 +172,27 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 			ValidateExact(false),
 			ValidateJSONSchema(rpctypes.RPCSchemaEthSyncing),
 		),
-	}
-	allTests = append(allTests, &RPCTestEthSyncing)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_coinbase
-	RPCTestEthCoinbase = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:           "RPCTestEthCoinbase",
 		Method:         "eth_coinbase",
 		Args:           []interface{}{},
 		Validator:      ValidateRegexString(`^0x[[:xdigit:]]{40}$`),
 		RequiresUnlock: true,
-	}
-	allTests = append(allTests, &RPCTestEthCoinbase)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_chainId
-	RPCTestEthChainID = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthChainID",
 		Method:    "eth_chainId",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthChainID)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_mining
-	RPCTestEthMining = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:   "RPCTestEthMining",
 		Method: "eth_mining",
 		Args:   []interface{}{},
@@ -267,372 +200,326 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 			ValidateExact(true),
 			ValidateExact(false),
 		),
-	}
-	allTests = append(allTests, &RPCTestEthMining)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_hashrate
-	RPCTestEthHashrate = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthHashrate",
 		Method:    "eth_hashrate",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthHashrate)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_gasPrice
-	RPCTestEthGasPrice = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGasPrice",
 		Method:    "eth_gasPrice",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGasPrice)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_accounts
-	RPCTestEthAccounts = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:           "RPCTestEthAccounts",
 		Method:         "eth_accounts",
 		Args:           []interface{}{},
 		Validator:      ValidateJSONSchema(rpctypes.RPCSchemaAccountList),
 		RequiresUnlock: true,
-	}
-	allTests = append(allTests, &RPCTestEthAccounts)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_blockNumber
-	RPCTestEthBlockNumber = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthBlockNumber",
 		Method:    "eth_blockNumber",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthBlockNumber)
+	})
 
 	// cast balance --rpc-url localhost:8545 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
-	RPCTestEthGetBalanceLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalanceLatest",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "latest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBalanceLatest)
-	RPCTestEthGetBalanceEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalanceEarliest",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "earliest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBalanceEarliest)
-	RPCTestEthGetBalancePending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalancePending",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "pending"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBalancePending)
-	RPCTestEthGetBalanceZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalanceZero",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "0x0"},
 		Validator: ValidateRegexString(`^0x0$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBalanceZero)
+	})
 
 	// cast storage --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429 3
-	RPCTestEthGetStorageAtLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetStorageAtLatest",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "latest"},
 		Validator: ValidateRegexString(`^0x536f6c6964697479206279204578616d706c6500000000000000000000000026$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetStorageAtLatest)
-	RPCTestEthGetStorageAtEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetStorageAtEarliest",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "earliest"},
 		Validator: ValidateRegexString(`^0x0{64}`),
-	}
-	allTests = append(allTests, &RPCTestEthGetStorageAtEarliest)
-	RPCTestEthGetStorageAtPending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetStorageAtPending",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "pending"},
 		Validator: ValidateRegexString(`^0x536f6c6964697479206279204578616d706c6500000000000000000000000026$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetStorageAtZero)
-	RPCTestEthGetStorageAtZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetStorageAtZero",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "0x0"},
 		Validator: ValidateRegexString(`^0x0{64}`),
-	}
-	allTests = append(allTests, &RPCTestEthGetStorageAtPending)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getTransactionCount 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 latest
-	RPCTestEthGetTransactionCountAtLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetTransactionCountAtLatest",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "latest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetTransactionCountAtLatest)
-	RPCTestEthGetTransactionCountAtEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetTransactionCountAtEarliest",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "earliest"},
 		Validator: ValidateRegexString(`^0x0$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetTransactionCountAtEarliest)
-	RPCTestEthGetTransactionCountAtPending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetTransactionCountAtPending",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "pending"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetTransactionCountAtPending)
-	RPCTestEthGetTransactionCountAtZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetTransactionCountAtZero",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "0x0"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetTransactionCountAtZero)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getBlockTransactionCountByHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
-	RPCTestEthGetBlockTransactionCountByHash = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestEthGetBlockTransactionCountByHash",
 		Method:    "eth_getBlockTransactionCountByHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient),
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByHash)
-	RPCTestEthGetBlockTransactionCountByHashMissing = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByHashMissing",
 		Method:    "eth_getBlockTransactionCountByHash",
 		Args:      []interface{}{"0x0000000000000000000000000000000000000000000000000000000000000000"},
 		Validator: ValidateExact(nil),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByHashMissing)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getBlockTransactionCountByNumber 0x1
-	RPCTestEthGetBlockTransactionCountByNumberLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberLatest",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"latest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberLatest)
-	RPCTestEthGetBlockTransactionCountByNumberEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberEarliest",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"earliest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberEarliest)
-	RPCTestEthGetBlockTransactionCountByNumberPending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberPending",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"pending"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberPending)
-	RPCTestEthGetBlockTransactionCountByNumberZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberZero",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"0x0"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberZero)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getUncleCountByBlockHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
-	RPCTestEthGetUncleCountByBlockHash = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestEthGetUncleCountByBlockHash",
 		Method:    "eth_getUncleCountByBlockHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient),
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockHash)
-	RPCTestEthGetUncleCountByBlockHashMissing = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockHashMissing",
 		Method:    "eth_getUncleCountByBlockHash",
 		Args:      []interface{}{"0x0000000000000000000000000000000000000000000000000000000000000000"},
 		Validator: ValidateExact(nil),
-	}
-	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockHashMissing)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getUncleCountByBlockNumber 0x1
-	RPCTestEthGetUncleCountByBlockNumberLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberLatest",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"latest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberLatest)
-	RPCTestEthGetUncleCountByBlockNumberEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberEarliest",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"earliest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberEarliest)
-	RPCTestEthGetUncleCountByBlockNumberPending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberPending",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"pending"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberPending)
-	RPCTestEthGetUncleCountByBlockNumberZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberZero",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"0x0"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockNumberZero)
+	})
 
 	// cast code --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429
-	RPCTestEthGetCodeLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetCodeLatest",
 		Method:    "eth_getCode",
 		Args:      []interface{}{*testContractAddress, "latest"},
 		Validator: ValidateHashedResponse("e39381f1654cf6a3b7eac2a789b9adf7319312cb"),
-	}
-	allTests = append(allTests, &RPCTestEthGetCodeLatest)
-	RPCTestEthGetCodePending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetCodePending",
 		Method:    "eth_getCode",
 		Args:      []interface{}{*testContractAddress, "pending"},
 		Validator: ValidateHashedResponse("e39381f1654cf6a3b7eac2a789b9adf7319312cb"),
-	}
-	allTests = append(allTests, &RPCTestEthGetCodePending)
-	RPCTestEthGetCodeEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetCodeEarliest",
 		Method:    "eth_getCode",
 		Args:      []interface{}{*testContractAddress, "earliest"},
 		Validator: ValidateRegexString(`^0x$`),
-	}
-	allTests = append(allTests, &RPCTestEthGetCodeEarliest)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_sign "0xb9b1cf51a65b50f74ed8bcb258413c02cba2ec57" "0xdeadbeaf"
-	RPCTestEthSign = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:           "RPCTestEthSign",
 		Method:         "eth_sign",
 		Args:           ArgsCoinbase(cxt, rpcClient, "0xdeadbeef"),
 		Validator:      ValidateRegexString(`^0x[[:xdigit:]]{72,}$`),
 		RequiresUnlock: true,
-	}
-	allTests = append(allTests, &RPCTestEthSign)
-	RPCTestEthSignFail = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:           "RPCTestEthSignFail",
 		Method:         "eth_sign",
 		Args:           []interface{}{testEthAddress.String(), "0xdeadbeef"},
 		Validator:      ValidateError(`unknown account`),
 		IsError:        true,
 		RequiresUnlock: true,
-	}
-	allTests = append(allTests, &RPCTestEthSignFail)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_signTransaction '{"from": "0xb9b1cf51a65b50f74ed8bcb258413c02cba2ec57", "to": "0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6", "data": "0x", "gas": "0x5208", "gasPrice": "0x1", "nonce": "0x1"}'
-	RPCTestEthSignTransaction = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:           "RPCTestEthSignTransaction",
 		Method:         "eth_signTransaction",
 		Args:           ArgsCoinbaseTransaction(cxt, rpcClient, &RPCTestTransactionArgs{To: testEthAddress.String(), Value: "0x123", Gas: "0x5208", Data: "0x", MaxFeePerGas: "0x6FC23AC00", MaxPriorityFeePerGas: "0x1", Nonce: "0x1"}),
 		Validator:      ValidateJSONSchema(rpctypes.RPCSchemaSignTxResponse),
 		RequiresUnlock: true,
-	}
-	allTests = append(allTests, &RPCTestEthSignTransaction)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_sendTransaction '{"from": "0xb9b1cf51a65b50f74ed8bcb258413c02cba2ec57", "to": "0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6", "data": "0x", "gas": "0x5208", "gasPrice": "0x1", "nonce": "0x1"}'
-	RPCTestEthSendTransaction = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:           "RPCTestEthSendTransaction",
 		Method:         "eth_sendTransaction",
 		Args:           ArgsCoinbaseTransaction(cxt, rpcClient, &RPCTestTransactionArgs{To: testEthAddress.String(), Value: "0x123", Gas: "0x5208", Data: "0x", MaxFeePerGas: "0x6FC23AC00", MaxPriorityFeePerGas: "0x1"}),
 		Validator:      ValidateRegexString(`^0x[[:xdigit:]]{64}$`),
 		RequiresUnlock: true,
-	}
-	allTests = append(allTests, &RPCTestEthSendTransaction)
+	})
 
 	// cast rpc --rpc-url localhost:8545 eth_sendRawTransaction '{"from": "0xb9b1cf51a65b50f74ed8bcb258413c02cba2ec57", "to": "0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6", "data": "0x", "gas": "0x5208", "gasPrice": "0x1", "nonce": "0x1"}'
-	RPCTestEthSendRawTransaction = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestEthSendRawTransaction",
 		Method:    "eth_sendRawTransaction",
 		Args:      ArgsSignTransaction(cxt, rpcClient, &RPCTestTransactionArgs{To: testEthAddress.String(), Value: "0x123", Gas: "0x5208", Data: "0x", MaxFeePerGas: "0x6FC23AC00", MaxPriorityFeePerGas: "0x1"}),
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{64}$`),
-	}
-	allTests = append(allTests, &RPCTestEthSendRawTransaction)
+	})
 
 	// cat contracts/ERC20.abi| go run main.go abi
 	// cast call --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429  'function name() view returns(string)'
-	RPCTestEthCallLatest = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthCallLatest",
 		Method:    "eth_call",
 		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "latest"},
 		Validator: ValidateRegexString(`536f6c6964697479206279204578616d706c65`),
-	}
-	allTests = append(allTests, &RPCTestEthCallLatest)
-	RPCTestEthCallPending = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthCallPending",
 		Method:    "eth_call",
 		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "pending"},
 		Validator: ValidateRegexString(`536f6c6964697479206279204578616d706c65`),
-	}
-	allTests = append(allTests, &RPCTestEthCallPending)
-	RPCTestEthCallEarliest = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthCallEarliest",
 		Method:    "eth_call",
 		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "earliest"},
 		Validator: ValidateRegexString(`^0x$`),
-	}
-	allTests = append(allTests, &RPCTestEthCallEarliest)
-	RPCTestEthCallZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthCallZero",
 		Method:    "eth_call",
 		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "0x0"},
 		Validator: ValidateRegexString(`^0x$`),
-	}
-	allTests = append(allTests, &RPCTestEthCallZero)
+	})
 
 	// cat contracts/ERC20.abi| go run main.go abi
 	// cast estimate --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429  'function mint(uint256 amount) returns()' 10000
 	// cast abi-encode 'function mint(uint256 amount) returns()' 10000
-	RPCTestEthEstimateGas = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthEstimateGas",
 		Method:    "eth_estimateGas",
 		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0xa0712d680000000000000000000000000000000000000000000000000000000000002710"}, "latest"},
 		Validator: ValidateRegexString(`0x10b0d`),
-	}
-	allTests = append(allTests, &RPCTestEthEstimateGas)
+	})
 
 	// cast block --rpc-url localhost:8545 latest
-	RPCTestEthGetBlockByHash = RPCTestDynamicArgs{
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestEthGetBlockByHash",
 		Method:    "eth_getBlockByHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient, true),
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthBlock),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockByHash)
-	RPCTestEthGetBlockByHashNoTx = RPCTestDynamicArgs{
+	})
+	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestEthGetBlockByHashNoTx",
 		Method:    "eth_getBlockByHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient, false),
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthBlock),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockByHashNoTx)
-	RPCTestEthGetBlockByHashZero = RPCTestGeneric{
+	})
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockByHashZero",
 		Method:    "eth_getBlockByHash",
 		Args:      []interface{}{"0x0000000000000000000000000000000000000000000000000000000000000000", true},
 		Validator: ValidateExact(nil),
-	}
-	allTests = append(allTests, &RPCTestEthGetBlockByHashZero)
+	})
 
 	// cast block --rpc-url localhost:8545 0
-	RPCTestEthBlockByNumber = RPCTestGeneric{
+	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthBlockByNumber",
 		Method:    "eth_getBlockByNumber",
 		Args:      []interface{}{"0x0", true},
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthBlock),
-	}
-	allTests = append(allTests, &RPCTestEthBlockByNumber)
+	})
 
 	uniqueTests := make(map[RPCTest]struct{})
 	uniqueTestNames := make(map[string]struct{})

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -2,6 +2,10 @@
 // conformance tests
 package rpcfuzz
 
+// TODO add configuration for name space
+// TODO add the open rpc schemas
+// TODO refactor to remove names
+
 import (
 	"context"
 	"crypto/ecdsa"

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -69,6 +69,14 @@ var (
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]*$`),
 	}
 
+	// cast rpc --rpc-url localhost:8545 eth_protocolVersion
+	RPCTestEthProtocolVersion = RPCTestGeneric{
+		IsError:   true,
+		Method:    "eth_protocolVersion",
+		Args:      []interface{}{},
+		Validator: ValidatorError(`method eth_protocolVersion does not exist`),
+	}
+
 	allTests = []RPCTest{
 		&RPCTestNetVersion,
 		&RPCTestWeb3ClientVersion,
@@ -76,6 +84,7 @@ var (
 		&RPCTestWeb3SHA3Error,
 		&RPCTestNetListening,
 		&RPCTestNetPeerCount,
+		&RPCTestEthProtocolVersion,
 	}
 )
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -574,6 +574,12 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Args:      ArgsLatestBlockHash(ctx, rpcClient, "0x0"),
 		Validator: RequireAny(ValidateJSONSchema(rpctypes.RPCSchemaEthBlock), ValidateExact(nil)),
 	})
+	allTests = append(allTests, &RPCTestDynamicArgs{
+		Name:      "RPCTestGetUncleByBlockNumberAndIndex",
+		Method:    "eth_getUncleByBlockNumberAndIndex",
+		Args:      ArgsLatestBlockNumber(ctx, rpcClient, "0x0"),
+		Validator: RequireAny(ValidateJSONSchema(rpctypes.RPCSchemaEthBlock), ValidateExact(nil)),
+	})
 
 	uniqueTests := make(map[RPCTest]struct{})
 	uniqueTestNames := make(map[string]struct{})

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -23,6 +23,9 @@ import (
 type (
 	// RPCTest is the common interface for a test
 	RPCTest interface {
+		// GetName returns a more descriptive name of the test being executed
+		GetName() string
+
 		// GetMethod returns the json rpc method name
 		GetMethod() string
 
@@ -41,6 +44,7 @@ type (
 	// managed by just returning hard coded values for method,
 	// args, validator, and error
 	RPCTestGeneric struct {
+		Name      string
 		Method    string
 		Args      []interface{}
 		Validator func(result interface{}) error
@@ -51,6 +55,7 @@ type (
 	// RPCTest that requires a function for Args which will be
 	// used to generate the args for testing.
 	RPCTestDynamicArgs struct {
+		Name      string
 		Method    string
 		Args      func() []interface{}
 		Validator func(result interface{}) error
@@ -70,33 +75,40 @@ var (
 )
 
 var (
-	RPCTestNetVersion                               RPCTestGeneric
-	RPCTestWeb3ClientVersion                        RPCTestGeneric
-	RPCTestWeb3SHA3                                 RPCTestGeneric
-	RPCTestWeb3SHA3Error                            RPCTestGeneric
-	RPCTestNetListening                             RPCTestGeneric
-	RPCTestNetPeerCount                             RPCTestGeneric
-	RPCTestEthProtocolVersion                       RPCTestGeneric
-	RPCTestEthSyncing                               RPCTestGeneric
-	RPCTestEthCoinbase                              RPCTestGeneric
-	RPCTestEthChainID                               RPCTestGeneric
-	RPCTestEthMining                                RPCTestGeneric
-	RPCTestEthHashrate                              RPCTestGeneric
-	RPCTestEthGasPrice                              RPCTestGeneric
-	RPCTestEthAccounts                              RPCTestGeneric
-	RPCTestEthBlockNumber                           RPCTestGeneric
-	RPCTestEthGetBalanceLatest                      RPCTestGeneric
-	RPCTestEthGetBalanceEarliest                    RPCTestGeneric
-	RPCTestEthGetBalancePending                     RPCTestGeneric
-	RPCTestEthGetStorageAtLatest                    RPCTestGeneric
-	RPCTestEthGetStorageAtEarliest                  RPCTestGeneric
-	RPCTestEthGetStorageAtPending                   RPCTestGeneric
-	RPCTestEthGetTransactionCountAtLatest           RPCTestGeneric
-	RPCTestEthGetTransactionCountAtEarliest         RPCTestGeneric
-	RPCTestEthGetTransactionCountAtPending          RPCTestGeneric
-	RPCTestEthGetBlockTransactionCountByHash        RPCTestDynamicArgs
-	RPCTestEthGetBlockTransactionCountByHashMissing RPCTestGeneric
-	RPCTestEthBlockByNumber                         RPCTestGeneric
+	RPCTestNetVersion                                  RPCTestGeneric
+	RPCTestWeb3ClientVersion                           RPCTestGeneric
+	RPCTestWeb3SHA3                                    RPCTestGeneric
+	RPCTestWeb3SHA3Error                               RPCTestGeneric
+	RPCTestNetListening                                RPCTestGeneric
+	RPCTestNetPeerCount                                RPCTestGeneric
+	RPCTestEthProtocolVersion                          RPCTestGeneric
+	RPCTestEthSyncing                                  RPCTestGeneric
+	RPCTestEthCoinbase                                 RPCTestGeneric
+	RPCTestEthChainID                                  RPCTestGeneric
+	RPCTestEthMining                                   RPCTestGeneric
+	RPCTestEthHashrate                                 RPCTestGeneric
+	RPCTestEthGasPrice                                 RPCTestGeneric
+	RPCTestEthAccounts                                 RPCTestGeneric
+	RPCTestEthBlockNumber                              RPCTestGeneric
+	RPCTestEthGetBalanceLatest                         RPCTestGeneric
+	RPCTestEthGetBalanceEarliest                       RPCTestGeneric
+	RPCTestEthGetBalancePending                        RPCTestGeneric
+	RPCTestEthGetBalanceZero                           RPCTestGeneric
+	RPCTestEthGetStorageAtLatest                       RPCTestGeneric
+	RPCTestEthGetStorageAtEarliest                     RPCTestGeneric
+	RPCTestEthGetStorageAtPending                      RPCTestGeneric
+	RPCTestEthGetStorageAtZero                         RPCTestGeneric
+	RPCTestEthGetTransactionCountAtLatest              RPCTestGeneric
+	RPCTestEthGetTransactionCountAtEarliest            RPCTestGeneric
+	RPCTestEthGetTransactionCountAtPending             RPCTestGeneric
+	RPCTestEthGetTransactionCountAtZero                RPCTestGeneric
+	RPCTestEthGetBlockTransactionCountByHash           RPCTestDynamicArgs
+	RPCTestEthGetBlockTransactionCountByHashMissing    RPCTestGeneric
+	RPCTestEthGetBlockTransactionCountByNumberLatest   RPCTestGeneric
+	RPCTestEthGetBlockTransactionCountByNumberEarliest RPCTestGeneric
+	RPCTestEthGetBlockTransactionCountByNumberPending  RPCTestGeneric
+	RPCTestEthGetBlockTransactionCountByNumberZero     RPCTestGeneric
+	RPCTestEthBlockByNumber                            RPCTestGeneric
 
 	allTests = make([]RPCTest, 0)
 )
@@ -104,6 +116,7 @@ var (
 func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 	// cast rpc --rpc-url localhost:8545 net_version
 	RPCTestNetVersion = RPCTestGeneric{
+		Name:      "RPCTestNetVersion",
 		Method:    "net_version",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^\d*$`),
@@ -112,6 +125,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 web3_clientVersion
 	RPCTestWeb3ClientVersion = RPCTestGeneric{
+		Name:      "RPCTestWeb3ClientVersion",
 		Method:    "web3_clientVersion",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^[[:print:]]*$`),
@@ -120,6 +134,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 web3_sha3 0x68656c6c6f20776f726c64
 	RPCTestWeb3SHA3 = RPCTestGeneric{
+		Name:      "RPCTestWeb3SHA3",
 		Method:    "web3_sha3",
 		Args:      []interface{}{"0x68656c6c6f20776f726c64"},
 		Validator: ValidateRegexString(`0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad`),
@@ -127,6 +142,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 	allTests = append(allTests, &RPCTestWeb3SHA3)
 
 	RPCTestWeb3SHA3Error = RPCTestGeneric{
+		Name:      "RPCTestWeb3SHA3Error",
 		IsError:   true,
 		Method:    "web3_sha3",
 		Args:      []interface{}{"68656c6c6f20776f726c64"},
@@ -136,6 +152,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 net_listening
 	RPCTestNetListening = RPCTestGeneric{
+		Name:      "RPCTestNetListening",
 		Method:    "net_listening",
 		Args:      []interface{}{},
 		Validator: ValidateExact(true),
@@ -144,6 +161,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 net_peerCount
 	RPCTestNetPeerCount = RPCTestGeneric{
+		Name:      "RPCTestNetPeerCount",
 		Method:    "net_peerCount",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]*$`),
@@ -152,6 +170,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_protocolVersion
 	RPCTestEthProtocolVersion = RPCTestGeneric{
+		Name:      "RPCTestEthProtocolVersion",
 		IsError:   true,
 		Method:    "eth_protocolVersion",
 		Args:      []interface{}{},
@@ -161,6 +180,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_syncing
 	RPCTestEthSyncing = RPCTestGeneric{
+		Name:   "RPCTestEthSyncing",
 		Method: "eth_syncing",
 		Args:   []interface{}{},
 		Validator: ChainValidator(
@@ -172,6 +192,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_coinbase
 	RPCTestEthCoinbase = RPCTestGeneric{
+		Name:      "RPCTestEthCoinbase",
 		Method:    "eth_coinbase",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{40}$`),
@@ -180,6 +201,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_chainId
 	RPCTestEthChainID = RPCTestGeneric{
+		Name:      "RPCTestEthChainID",
 		Method:    "eth_chainId",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
@@ -188,6 +210,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_mining
 	RPCTestEthMining = RPCTestGeneric{
+		Name:   "RPCTestEthMining",
 		Method: "eth_mining",
 		Args:   []interface{}{},
 		Validator: ChainValidator(
@@ -199,6 +222,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_hashrate
 	RPCTestEthHashrate = RPCTestGeneric{
+		Name:      "RPCTestEthHashrate",
 		Method:    "eth_hashrate",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
@@ -207,6 +231,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_gasPrice
 	RPCTestEthGasPrice = RPCTestGeneric{
+		Name:      "RPCTestEthGasPrice",
 		Method:    "eth_gasPrice",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
@@ -215,6 +240,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_accounts
 	RPCTestEthAccounts = RPCTestGeneric{
+		Name:      "RPCTestEthAccounts",
 		Method:    "eth_accounts",
 		Args:      []interface{}{},
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaAccountList),
@@ -223,6 +249,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_blockNumber
 	RPCTestEthBlockNumber = RPCTestGeneric{
+		Name:      "RPCTestEthBlockNumber",
 		Method:    "eth_blockNumber",
 		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
@@ -231,77 +258,139 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast balance --rpc-url localhost:8545 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
 	RPCTestEthGetBalanceLatest = RPCTestGeneric{
+		Name:      "RPCTestEthGetBalanceLatest",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "latest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetBalanceLatest)
 	RPCTestEthGetBalanceEarliest = RPCTestGeneric{
+		Name:      "RPCTestEthGetBalanceEarliest",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "earliest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetBalanceEarliest)
 	RPCTestEthGetBalancePending = RPCTestGeneric{
+		Name:      "RPCTestEthGetBalancePending",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "pending"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetBalancePending)
+	RPCTestEthGetBalanceZero = RPCTestGeneric{
+		Name:      "RPCTestEthGetBalanceZero",
+		Method:    "eth_getBalance",
+		Args:      []interface{}{testEthAddress.String(), "0x0"},
+		Validator: ValidateRegexString(`^0x0$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetBalanceZero)
 
 	// cast storage --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429 3
 	RPCTestEthGetStorageAtLatest = RPCTestGeneric{
+		Name:      "RPCTestEthGetStorageAtLatest",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "latest"},
 		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetStorageAtLatest)
 	RPCTestEthGetStorageAtEarliest = RPCTestGeneric{
+		Name:      "RPCTestEthGetStorageAtEarliest",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "earliest"},
 		Validator: ValidateRegexString(`^0x0{64}`),
 	}
 	allTests = append(allTests, &RPCTestEthGetStorageAtEarliest)
 	RPCTestEthGetStorageAtPending = RPCTestGeneric{
+		Name:      "RPCTestEthGetStorageAtPending",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "pending"},
 		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetStorageAtZero)
+	RPCTestEthGetStorageAtZero = RPCTestGeneric{
+		Name:      "RPCTestEthGetStorageAtZero",
+		Method:    "eth_getStorageAt",
+		Args:      []interface{}{*testContractAddress, "0x3", "0x0"},
+		Validator: ValidateRegexString(`^0x0{64}`),
 	}
 	allTests = append(allTests, &RPCTestEthGetStorageAtPending)
 
 	// cast rpc --rpc-url localhost:8545 eth_getTransactionCount 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 latest
 	RPCTestEthGetTransactionCountAtLatest = RPCTestGeneric{
+		Name:      "RPCTestEthGetTransactionCountAtLatest",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "latest"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetTransactionCountAtLatest)
 	RPCTestEthGetTransactionCountAtEarliest = RPCTestGeneric{
+		Name:      "RPCTestEthGetTransactionCountAtEarliest",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "earliest"},
 		Validator: ValidateRegexString(`^0x0$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetTransactionCountAtEarliest)
 	RPCTestEthGetTransactionCountAtPending = RPCTestGeneric{
+		Name:      "RPCTestEthGetTransactionCountAtPending",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "pending"},
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetTransactionCountAtPending)
+	RPCTestEthGetTransactionCountAtZero = RPCTestGeneric{
+		Name:      "RPCTestEthGetTransactionCountAtZero",
+		Method:    "eth_getTransactionCount",
+		Args:      []interface{}{testEthAddress.String(), "0x0"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetTransactionCountAtZero)
 
-	// cast rpc --rpc-url localhost:8545 eth_getTransactionCountByHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
+	// cast rpc --rpc-url localhost:8545 eth_getBlockTransactionCountByHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
 	RPCTestEthGetBlockTransactionCountByHash = RPCTestDynamicArgs{
+		Name:      "RPCTestEthGetBlockTransactionCountByHash",
 		Method:    "eth_getBlockTransactionCountByHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient),
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByHash)
 	RPCTestEthGetBlockTransactionCountByHashMissing = RPCTestGeneric{
+		Name:      "RPCTestEthGetBlockTransactionCountByHashMissing",
 		Method:    "eth_getBlockTransactionCountByHash",
 		Args:      []interface{}{"0x0000000000000000000000000000000000000000000000000000000000000000"},
 		Validator: ValidateExact(nil),
 	}
 	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByHashMissing)
+
+	// cast rpc --rpc-url localhost:8545 eth_getBlockTransactionCountByNumber 0x1
+	RPCTestEthGetBlockTransactionCountByNumberLatest = RPCTestGeneric{
+		Name:      "RPCTestEthGetBlockTransactionCountByNumberLatest",
+		Method:    "eth_getBlockTransactionCountByNumber",
+		Args:      []interface{}{"latest"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberLatest)
+	RPCTestEthGetBlockTransactionCountByNumberEarliest = RPCTestGeneric{
+		Name:      "RPCTestEthGetBlockTransactionCountByNumberEarliest",
+		Method:    "eth_getBlockTransactionCountByNumber",
+		Args:      []interface{}{"earliest"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberEarliest)
+	RPCTestEthGetBlockTransactionCountByNumberPending = RPCTestGeneric{
+		Name:      "RPCTestEthGetBlockTransactionCountByNumberPending",
+		Method:    "eth_getBlockTransactionCountByNumber",
+		Args:      []interface{}{"pending"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberPending)
+	RPCTestEthGetBlockTransactionCountByNumberZero = RPCTestGeneric{
+		Name:      "RPCTestEthGetBlockTransactionCountByNumberZero",
+		Method:    "eth_getBlockTransactionCountByNumber",
+		Args:      []interface{}{"0x0"},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberZero)
 
 	// spacing this thing out
 	// spacing this thing out
@@ -311,11 +400,27 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 	// spacing this thing out
 	// cast block --rpc-url localhost:8545 0
 	RPCTestEthBlockByNumber = RPCTestGeneric{
+		Name:      "RPCTestEthBlockByNumber",
 		Method:    "eth_getBlockByNumber",
 		Args:      []interface{}{"0x0", true},
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthBlock),
 	}
 	allTests = append(allTests, &RPCTestEthBlockByNumber)
+
+	uniqueTests := make(map[RPCTest]struct{})
+	uniqueTestNames := make(map[string]struct{})
+	for _, v := range allTests {
+		_, hasKey := uniqueTests[v]
+		if hasKey {
+			log.Fatal().Str("name", v.GetName()).Str("method", v.GetMethod()).Msg("duplicate test detected")
+		}
+		uniqueTests[v] = struct{}{}
+		_, hasKey = uniqueTestNames[v.GetName()]
+		if hasKey {
+			log.Fatal().Str("name", v.GetName()).Str("method", v.GetMethod()).Msg("duplicate test name detected")
+		}
+		uniqueTestNames[v.GetName()] = struct{}{}
+	}
 
 }
 
@@ -431,6 +536,9 @@ func ArgsLatestBlockHash(cxt context.Context, rpcClient *rpc.Client) func() []in
 func (r *RPCTestGeneric) GetMethod() string {
 	return r.Method
 }
+func (r *RPCTestGeneric) GetName() string {
+	return r.Name
+}
 func (r *RPCTestGeneric) GetArgs() []interface{} {
 	return r.Args
 }
@@ -443,6 +551,9 @@ func (r *RPCTestGeneric) ExpectError() bool {
 
 func (r *RPCTestDynamicArgs) GetMethod() string {
 	return r.Method
+}
+func (r *RPCTestDynamicArgs) GetName() string {
+	return r.Name
 }
 func (r *RPCTestDynamicArgs) GetArgs() []interface{} {
 	return r.Args()
@@ -512,7 +623,7 @@ Once this has been completed this will be the address of the contract:
 		setupTests(cxt, rpcClient)
 
 		for _, t := range allTests {
-			log.Trace().Str("method", t.GetMethod()).Msg("Running Test")
+			log.Trace().Str("name", t.GetName()).Str("method", t.GetMethod()).Msg("Running Test")
 			var result interface{}
 			err = rpcClient.CallContext(cxt, &result, t.GetMethod(), t.GetArgs()...)
 			if err != nil && !t.ExpectError() {

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -745,6 +745,31 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthFilter),
 	})
 
+	// cast rpc --rpc-url localhost:8545 eth_getWork
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestGetWork",
+		Method:    "eth_getWork",
+		Args:      []interface{}{},
+		IsError:   true,
+		Validator: ValidateError(`method eth_getWork does not exist`),
+	})
+	// cast rpc --rpc-url localhost:8545 eth_submitWork 0x0011223344556677 0x00112233445566778899AABBCCDDEEFF 0x00112233445566778899AABBCCDDEEFF
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestSubmitWork",
+		Method:    "eth_submitWork",
+		Args:      []interface{}{"0x0011223344556677", "0x00112233445566778899AABBCCDDEEFF", "0x00112233445566778899AABBCCDDEEFF"},
+		IsError:   true,
+		Validator: ValidateError(`method eth_submitWork does not exist`),
+	})
+	// cast rpc --rpc-url localhost:8545 eth_submitHashrate 0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF 0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestSubmitHashrate",
+		Method:    "eth_submitHashrate",
+		Args:      []interface{}{"0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF", "0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"},
+		IsError:   true,
+		Validator: ValidateError(`method eth_submitHashrate does not exist`),
+	})
+
 	uniqueTests := make(map[RPCTest]struct{})
 	uniqueTestNames := make(map[string]struct{})
 	for _, v := range allTests {

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -543,11 +543,19 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthTransaction),
 	})
 
-	//
+	// cast rpc --rpc-url localhost:8545 eth_getTransactionByBlockHashAndIndex 0x63f86797e33513449350d0e00ef962f172a94a60b990a096a470c1ac1df5ec06 0x0
 	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestEthGetTransactionByBlockHashAndIndex",
 		Method:    "eth_getTransactionByBlockHashAndIndex",
-		Args:      ArgsTransactionBlockHash(ctx, rpcClient, &RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0xa0712d680000000000000000000000000000000000000000000000000000000000002710", MaxFeePerGas: defaultMaxFeePerGas, MaxPriorityFeePerGas: defaultMaxPriorityFeePerGas, Gas: "0x10000"}),
+		Args:      ArgsTransactionBlockHashAndIndex(ctx, rpcClient, &RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0xa0712d680000000000000000000000000000000000000000000000000000000000002710", MaxFeePerGas: defaultMaxFeePerGas, MaxPriorityFeePerGas: defaultMaxPriorityFeePerGas, Gas: "0x10000"}),
+		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthTransaction),
+	})
+
+	// cast rpc --rpc-url localhost:8545 eth_getTransactionByBlockNumberAndIndex 0xd 0x0
+	allTests = append(allTests, &RPCTestDynamicArgs{
+		Name:      "RPCTestEthGetTransactionByBlockNumberAndIndex",
+		Method:    "eth_getTransactionByBlockNumberAndIndex",
+		Args:      ArgsTransactionBlockNumberAndIndex(ctx, rpcClient, &RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0xa0712d680000000000000000000000000000000000000000000000000000000000002710", MaxFeePerGas: defaultMaxFeePerGas, MaxPriorityFeePerGas: defaultMaxPriorityFeePerGas, Gas: "0x10000"}),
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthTransaction),
 	})
 
@@ -816,9 +824,9 @@ func ArgsTransactionHash(ctx context.Context, rpcClient *rpc.Client, tx *RPCTest
 	}
 }
 
-// ArgsTransactionHash will execute the provided transaction and return
+// ArgsTransactionBlockHashAndIndex will execute the provided transaction and return
 // the block hash and index of the given transaction
-func ArgsTransactionBlockHash(ctx context.Context, rpcClient *rpc.Client, tx *RPCTestTransactionArgs) func() []interface{} {
+func ArgsTransactionBlockHashAndIndex(ctx context.Context, rpcClient *rpc.Client, tx *RPCTestTransactionArgs) func() []interface{} {
 	return func() []interface{} {
 		resultHash, receipt, err := prepareAndSendTransaction(ctx, rpcClient, tx)
 		if err != nil {
@@ -827,6 +835,20 @@ func ArgsTransactionBlockHash(ctx context.Context, rpcClient *rpc.Client, tx *RP
 		log.Info().Str("resultHash", resultHash).Msg("Successfully executed transaction")
 
 		return []interface{}{receipt["blockHash"], receipt["transactionIndex"]}
+	}
+}
+
+// ArgsTransactionBlockNumberAndIndex will execute the provided transaction and return
+// the block number and index of the given transaction
+func ArgsTransactionBlockNumberAndIndex(ctx context.Context, rpcClient *rpc.Client, tx *RPCTestTransactionArgs) func() []interface{} {
+	return func() []interface{} {
+		resultHash, receipt, err := prepareAndSendTransaction(ctx, rpcClient, tx)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Unable to execute transaction")
+		}
+		log.Info().Str("resultHash", resultHash).Msg("Successfully executed transaction")
+
+		return []interface{}{receipt["blockNumber"], receipt["transactionIndex"]}
 	}
 }
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -90,7 +90,58 @@ var (
 		),
 	}
 
-	// I probably need to put these giant strings somewhere else
+	// cast rpc --rpc-url localhost:8545 eth_coinbase
+	RPCTestEthCoinbase = RPCTestGeneric{
+		Method:    "eth_coinbase",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{40}$`),
+	}
+
+	// cast rpc --rpc-url localhost:8545 eth_chainId
+	RPCTestEthChainID = RPCTestGeneric{
+		Method:    "eth_chainId",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+
+	// cast rpc --rpc-url localhost:8545 eth_mining
+	RPCTestEthMining = RPCTestGeneric{
+		Method: "eth_mining",
+		Args:   []interface{}{},
+		Validator: ChainValidator(
+			ValidateExact(true),
+			ValidateExact(false),
+		),
+	}
+
+	// cast rpc --rpc-url localhost:8545 eth_hashrate
+	RPCTestEthHashrate = RPCTestGeneric{
+		Method:    "eth_hashrate",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+
+	// cast rpc --rpc-url localhost:8545 eth_gasPrice
+	RPCTestEthGasPrice = RPCTestGeneric{
+		Method:    "eth_gasPrice",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+
+	// cast rpc --rpc-url localhost:8545 eth_accounts
+	RPCTestEthAccounts = RPCTestGeneric{
+		Method:    "eth_accounts",
+		Args:      []interface{}{},
+		Validator: ValidateJSONSchema(rpctypes.RPCSchemaAccountList),
+	}
+
+	// cast rpc --rpc-url localhost:8545 eth_blockNumber
+	RPCTestEthBlockNumber = RPCTestGeneric{
+		Method:    "eth_blockNumber",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+
 	// cast block --rpc-url localhost:8545 0
 	RPCTestEthBlockByNumber = RPCTestGeneric{
 		Method:    "eth_getBlockByNumber",
@@ -107,6 +158,14 @@ var (
 		&RPCTestNetPeerCount,
 		&RPCTestEthProtocolVersion,
 		&RPCTestEthSyncing,
+		&RPCTestEthCoinbase,
+		&RPCTestEthChainID,
+		&RPCTestEthMining,
+		&RPCTestEthHashrate,
+		&RPCTestEthGasPrice,
+		&RPCTestEthAccounts,
+		&RPCTestEthBlockNumber,
+
 		&RPCTestEthBlockByNumber,
 	}
 )

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -1,0 +1,108 @@
+package rpcfuzz
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"os"
+	"regexp"
+)
+
+type (
+	RPCTest interface {
+		GetMethod() string
+		GetArgs() []interface{}
+		Validate(result interface{}) error
+	}
+
+	RPCTestGeneric struct {
+		Method    string
+		Args      []interface{}
+		Validator func(result interface{}) error
+	}
+)
+
+var (
+	// cast rpc --rpc-url localhost:8545 net_version
+	RPCTestNetVersion = RPCTestGeneric{
+		Method:    "net_version",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^\d*$`),
+	}
+
+	allTests = []RPCTest{
+		&RPCTestNetVersion,
+	}
+)
+
+func ValidateRegexString(regEx string) func(result interface{}) error {
+	r := regexp.MustCompile(regEx)
+	return func(result interface{}) error {
+		resultStr, isValid := result.(string)
+		if !isValid {
+			return fmt.Errorf("Invalid result type. Expected string but got %T", result)
+		}
+		if !r.MatchString(resultStr) {
+			return fmt.Errorf("The regex %s failed to match result %s", regEx, resultStr)
+		}
+		return nil
+	}
+}
+
+func (r *RPCTestGeneric) GetMethod() string {
+	return r.Method
+}
+func (r *RPCTestGeneric) GetArgs() []interface{} {
+	return r.Args
+}
+func (r *RPCTestGeneric) Validate(result interface{}) error {
+	return r.Validator(result)
+}
+
+var RPCFuzzCmd = &cobra.Command{
+	Use:   "rpcfuzz http://localhost:8545",
+	Short: "Continually run a variety of RPC calls and fuzzers",
+	Long: `
+beep
+
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cxt := cmd.Context()
+		rpcClient, err := rpc.DialContext(cxt, args[0])
+		if err != nil {
+			return err
+		}
+		for _, t := range allTests {
+			log.Trace().Str("method", t.GetMethod()).Msg("Running Test")
+			var result interface{}
+			err = rpcClient.CallContext(cxt, &result, t.GetMethod(), t.GetArgs()...)
+			if err != nil {
+				log.Error().Err(err).Str("method", t.GetMethod()).Msg("Method test failed")
+				continue
+			}
+			err = t.Validate(result)
+			if err != nil {
+				log.Error().Err(err).Str("method", t.GetMethod()).Msg("Failed to validate")
+				continue
+			}
+			log.Info().Str("method", t.GetMethod()).Msg("Successfully validated")
+		}
+		return nil
+	},
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("Expected 1 argument, but got %d", len(args))
+		}
+		return nil
+	},
+}
+
+func init() {
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	flagSet := RPCFuzzCmd.PersistentFlags()
+	_ = flagSet
+}

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -117,7 +117,11 @@ var (
 	currentChainID        *big.Int
 
 	enabledNamespaces []string
-	allTests          = make([]RPCTest, 0)
+
+	// in the future allTests could be used to for
+	// fuzzing.. E.g. loop over the various tests, and mutate the
+	// Args before sending
+	allTests = make([]RPCTest, 0)
 )
 
 // setupTests will add all of the `RPCTests` to the `allTests` slice.
@@ -661,6 +665,22 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 			Address:   *testContractAddress,
 			Topics:    []interface{}{nil, nil, "0x000000000000000000000000" + testEthAddress.String()[2:]}},
 		},
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
+	})
+
+	// cast rpc --rpc-url localhost:8545 eth_newBlockFilter
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthNewBlockFilter",
+		Method:    "eth_newBlockFilter",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
+	})
+
+	// cast rpc --rpc-url localhost:8545 eth_newPendingTransactionFilter
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthNewPendingTransactionFilter",
+		Method:    "eth_newPendingTransactionFilter",
+		Args:      []interface{}{},
 		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -108,6 +108,8 @@ var (
 	RPCTestEthGetBlockTransactionCountByNumberEarliest RPCTestGeneric
 	RPCTestEthGetBlockTransactionCountByNumberPending  RPCTestGeneric
 	RPCTestEthGetBlockTransactionCountByNumberZero     RPCTestGeneric
+	RPCTestEthGetUncleCountByBlockHash                 RPCTestDynamicArgs
+	RPCTestEthGetUncleCountByBlockHashMissing          RPCTestGeneric
 	RPCTestEthBlockByNumber                            RPCTestGeneric
 
 	allTests = make([]RPCTest, 0)
@@ -391,6 +393,22 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetBlockTransactionCountByNumberZero)
+
+	// cast rpc --rpc-url localhost:8545 eth_getUncleCountByBlockHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
+	RPCTestEthGetUncleCountByBlockHash = RPCTestDynamicArgs{
+		Name:      "RPCTestEthGetUncleCountByBlockHash",
+		Method:    "eth_getUncleCountByBlockHash",
+		Args:      ArgsLatestBlockHash(cxt, rpcClient),
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+	}
+	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockHash)
+	RPCTestEthGetUncleCountByBlockHashMissing = RPCTestGeneric{
+		Name:      "RPCTestEthGetUncleCountByBlockHashMissing",
+		Method:    "eth_getUncleCountByBlockHash",
+		Args:      []interface{}{"0x0000000000000000000000000000000000000000000000000000000000000000"},
+		Validator: ValidateExact(nil),
+	}
+	allTests = append(allTests, &RPCTestEthGetUncleCountByBlockHashMissing)
 
 	// spacing this thing out
 	// spacing this thing out

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -62,12 +62,20 @@ var (
 		Validator: ValidateExact(true),
 	}
 
+	// cast rpc --rpc-url localhost:8545 net_peerCount
+	RPCTestNetPeerCount = RPCTestGeneric{
+		Method:    "net_peerCount",
+		Args:      []interface{}{},
+		Validator: ValidateRegexString(`^0x[[:xdigit:]]*$`),
+	}
+
 	allTests = []RPCTest{
 		&RPCTestNetVersion,
 		&RPCTestWeb3ClientVersion,
 		&RPCTestWeb3SHA3,
 		&RPCTestWeb3SHA3Error,
 		&RPCTestNetListening,
+		&RPCTestNetPeerCount,
 	}
 )
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -933,9 +933,7 @@ func ArgsLatestBlockHash(ctx context.Context, rpcClient *rpc.Client, extraArgs .
 		log.Trace().Str("blockHash", strHash).Msg("Got latest blockhash")
 
 		args := []interface{}{strHash}
-		for _, v := range extraArgs {
-			args = append(args, v)
-		}
+		args = append(args, extraArgs...)
 		return args
 	}
 }
@@ -957,9 +955,7 @@ func ArgsLatestBlockNumber(ctx context.Context, rpcClient *rpc.Client, extraArgs
 		log.Trace().Str("blockNumber", hexNumber).Msg("Got latest blockNumber")
 
 		args := []interface{}{hexNumber}
-		for _, v := range extraArgs {
-			args = append(args, v)
-		}
+		args = append(args, extraArgs...)
 		return args
 	}
 }
@@ -983,9 +979,7 @@ func ArgsCoinbase(ctx context.Context, rpcClient *rpc.Client, extraArgs ...inter
 		log.Trace().Str("coinbase", coinbase).Msg("Got coinbase")
 
 		args := []interface{}{coinbase}
-		for _, v := range extraArgs {
-			args = append(args, v)
-		}
+		args = append(args, extraArgs...)
 		return args
 	}
 }

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/maticnetwork/polygon-cli/rpctypes"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -86,132 +87,16 @@ var (
 		Args:   []interface{}{},
 		Validator: ChainValidator(
 			ValidateExact(false),
-			ValidateJSONSchema(`
-{
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-    "startingBlock": {
-      "type": "string"
-    },
-    "currentBlock": {
-      "type": "string"
-    },
-    "highestBlock": {
-      "type": "string"
-    }
-  },
-  "required": [
-    "startingBlock",
-    "currentBlock",
-    "highestBlock"
-  ]
-}
-`),
+			ValidateJSONSchema(rpctypes.RPCSchemaEthSyncing),
 		),
 	}
 
 	// I probably need to put these giant strings somewhere else
 	// cast block --rpc-url localhost:8545 0
 	RPCTestEthBlockByNumber = RPCTestGeneric{
-		Method: "eth_getBlockByNumber",
-		Args:   []interface{}{"0x0", true},
-		Validator: ValidateJSONSchema(`
-{
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
-  "properties": {
-    "baseFeePerGas": {
-      "type": "string"
-    },
-    "difficulty": {
-      "type": "string"
-    },
-    "extraData": {
-      "type": "string"
-    },
-    "gasLimit": {
-      "type": "string"
-    },
-    "gasUsed": {
-      "type": "string"
-    },
-    "hash": {
-      "type": "string"
-    },
-    "logsBloom": {
-      "type": "string"
-    },
-    "miner": {
-      "type": "string"
-    },
-    "mixHash": {
-      "type": "string"
-    },
-    "nonce": {
-      "type": "string"
-    },
-    "number": {
-      "type": "string"
-    },
-    "parentHash": {
-      "type": "string"
-    },
-    "receiptsRoot": {
-      "type": "string"
-    },
-    "sha3Uncles": {
-      "type": "string"
-    },
-    "size": {
-      "type": "string"
-    },
-    "stateRoot": {
-      "type": "string"
-    },
-    "timestamp": {
-      "type": "string"
-    },
-    "totalDifficulty": {
-      "type": "string"
-    },
-    "transactions": {
-      "type": "array",
-      "items": {}
-    },
-    "transactionsRoot": {
-      "type": "string"
-    },
-    "uncles": {
-      "type": "array",
-      "items": {}
-    }
-  },
-  "required": [
-    "baseFeePerGas",
-    "difficulty",
-    "extraData",
-    "gasLimit",
-    "gasUsed",
-    "hash",
-    "logsBloom",
-    "miner",
-    "mixHash",
-    "nonce",
-    "number",
-    "parentHash",
-    "receiptsRoot",
-    "sha3Uncles",
-    "size",
-    "stateRoot",
-    "timestamp",
-    "totalDifficulty",
-    "transactions",
-    "transactionsRoot",
-    "uncles"
-  ]
-}
-`),
+		Method:    "eth_getBlockByNumber",
+		Args:      []interface{}{"0x0", true},
+		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthBlock),
 	}
 
 	allTests = []RPCTest{
@@ -323,7 +208,10 @@ var RPCFuzzCmd = &cobra.Command{
 	Use:   "rpcfuzz http://localhost:8545",
 	Short: "Continually run a variety of RPC calls and fuzzers",
 	Long: `
-beep
+
+- https://ethereum.github.io/execution-apis/api-documentation/
+- https://ethereum.org/en/developers/docs/apis/json-rpc/
+- https://json-schema.org/
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -416,7 +416,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:           "RPCTestEthSign",
 		Method:         "eth_sign",
 		Args:           ArgsCoinbase(cxt, rpcClient, "0xdeadbeef"),
-		Validator:      ValidateRegexString(`^0x[[:xdigit:]]{72,}$`),
+		Validator:      ValidateRegexString(`^0x[[:xdigit:]]{130}$`),
 		RequiresUnlock: true,
 	})
 	allTests = append(allTests, &RPCTestGeneric{

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -4,7 +4,8 @@ package rpcfuzz
 
 // TODO add configuration for name space
 // TODO add the open rpc schemas
-// TODO refactor to remove names
+// TODO used the schema validator on all responses
+// TODO change the chain validator to use AND type logic
 
 import (
 	"context"

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -23,7 +23,6 @@ import (
 	"math/big"
 	"os"
 	"regexp"
-	"strings"
 )
 
 type (
@@ -335,7 +334,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetStorageAtLatest",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "latest"},
-		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
+		Validator: ValidateRegexString(`^0x536f6c6964697479206279204578616d706c6500000000000000000000000026$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetStorageAtLatest)
 	RPCTestEthGetStorageAtEarliest = RPCTestGeneric{
@@ -349,7 +348,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetStorageAtPending",
 		Method:    "eth_getStorageAt",
 		Args:      []interface{}{*testContractAddress, "0x3", "pending"},
-		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
+		Validator: ValidateRegexString(`^0x536f6c6964697479206279204578616d706c6500000000000000000000000026$`),
 	}
 	allTests = append(allTests, &RPCTestEthGetStorageAtZero)
 	RPCTestEthGetStorageAtZero = RPCTestGeneric{
@@ -487,14 +486,14 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetCodeLatest",
 		Method:    "eth_getCode",
 		Args:      []interface{}{*testContractAddress, "latest"},
-		Validator: ValidateHashedResponse("b3f345904d7d1c34ca0d1b815edd2f33baa48b3d"),
+		Validator: ValidateHashedResponse("e39381f1654cf6a3b7eac2a789b9adf7319312cb"),
 	}
 	allTests = append(allTests, &RPCTestEthGetCodeLatest)
 	RPCTestEthGetCodePending = RPCTestGeneric{
 		Name:      "RPCTestEthGetCodePending",
 		Method:    "eth_getCode",
 		Args:      []interface{}{*testContractAddress, "pending"},
-		Validator: ValidateHashedResponse("b3f345904d7d1c34ca0d1b815edd2f33baa48b3d"),
+		Validator: ValidateHashedResponse("e39381f1654cf6a3b7eac2a789b9adf7319312cb"),
 	}
 	allTests = append(allTests, &RPCTestEthGetCodePending)
 	RPCTestEthGetCodeEarliest = RPCTestGeneric{
@@ -553,33 +552,33 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 	}
 	allTests = append(allTests, &RPCTestEthSendRawTransaction)
 
-	// cat ~/code/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json | jq '.abi' | go run main.go abi
-	// cast call --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429 'function owner() view returns(address)'
+	// cat contracts/ERC20.abi| go run main.go abi
+	// cast call --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429  'function name() view returns(string)'
 	RPCTestEthCallLatest = RPCTestGeneric{
 		Name:      "RPCTestEthCallLatest",
 		Method:    "eth_call",
-		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x8da5cb5b"}, "latest"},
-		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
+		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "latest"},
+		Validator: ValidateRegexString(`536f6c6964697479206279204578616d706c65`),
 	}
 	allTests = append(allTests, &RPCTestEthCallLatest)
 	RPCTestEthCallPending = RPCTestGeneric{
 		Name:      "RPCTestEthCallPending",
 		Method:    "eth_call",
-		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x8da5cb5b"}, "pending"},
-		Validator: ValidateRegexString(`^0x000000000000000000000000` + strings.ToLower(testEthAddress.String())[2:] + `$`),
+		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "pending"},
+		Validator: ValidateRegexString(`536f6c6964697479206279204578616d706c65`),
 	}
 	allTests = append(allTests, &RPCTestEthCallPending)
 	RPCTestEthCallEarliest = RPCTestGeneric{
 		Name:      "RPCTestEthCallEarliest",
 		Method:    "eth_call",
-		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x8da5cb5b"}, "earliest"},
+		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "earliest"},
 		Validator: ValidateRegexString(`^0x$`),
 	}
 	allTests = append(allTests, &RPCTestEthCallEarliest)
 	RPCTestEthCallZero = RPCTestGeneric{
 		Name:      "RPCTestEthCallZero",
 		Method:    "eth_call",
-		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x8da5cb5b"}, "0x0"},
+		Args:      []interface{}{&RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0x06fdde03"}, "0x0"},
 		Validator: ValidateRegexString(`^0x$`),
 	}
 	allTests = append(allTests, &RPCTestEthCallZero)
@@ -894,16 +893,17 @@ for testing
     0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
 
 Then we might want to deploy some test smart contracts. For the
-purposes of testing we'll use Uniswap v3 at this hash
-d8b1c635c275d2a9450bd6a78f3fa2484fef73eb
+purposes of testing we'll our ERC20 contract:
 
 # cast send --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
     --private-key 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa \
     --rpc-url localhost:8545 --create \
-    "$(jq -r '.bytecode' ~/code/v3-core/artifacts/contracts/UniswapV3Factory.sol/UniswapV3Factory.json)"
+    "$(cat ./contracts/ERC20.bin)"
 
 Once this has been completed this will be the address of the contract:
 0x6fda56c57b0acadb96ed5624ac500c0429d59429
+
+# docker run -v $PWD/contracts:/contracts ethereum/solc:stable --storage-layout /contracts/ERC20.sol
 
 - https://ethereum.github.io/execution-apis/api-documentation/
 - https://ethereum.org/en/developers/docs/apis/json-rpc/

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -186,7 +186,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthChainID",
 		Method:    "eth_chainId",
 		Args:      []interface{}{},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_mining
@@ -205,7 +205,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthHashrate",
 		Method:    "eth_hashrate",
 		Args:      []interface{}{},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_gasPrice
@@ -213,7 +213,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGasPrice",
 		Method:    "eth_gasPrice",
 		Args:      []interface{}{},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_accounts
@@ -230,7 +230,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthBlockNumber",
 		Method:    "eth_blockNumber",
 		Args:      []interface{}{},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast balance --rpc-url localhost:8545 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
@@ -238,19 +238,19 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetBalanceLatest",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "latest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalanceEarliest",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "earliest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalancePending",
 		Method:    "eth_getBalance",
 		Args:      []interface{}{testEthAddress.String(), "pending"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBalanceZero",
@@ -290,7 +290,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetTransactionCountAtLatest",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "latest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetTransactionCountAtEarliest",
@@ -302,13 +302,13 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetTransactionCountAtPending",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "pending"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetTransactionCountAtZero",
 		Method:    "eth_getTransactionCount",
 		Args:      []interface{}{testEthAddress.String(), "0x0"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getBlockTransactionCountByHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
@@ -316,7 +316,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetBlockTransactionCountByHash",
 		Method:    "eth_getBlockTransactionCountByHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient),
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByHashMissing",
@@ -330,25 +330,25 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberLatest",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"latest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberEarliest",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"earliest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberPending",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"pending"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetBlockTransactionCountByNumberZero",
 		Method:    "eth_getBlockTransactionCountByNumber",
 		Args:      []interface{}{"0x0"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_getUncleCountByBlockHash 0x9300b64619e167e7dbc1b41a6a6e7a8de7d6b99427dceefbd58014e328bd7f92
@@ -356,7 +356,7 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetUncleCountByBlockHash",
 		Method:    "eth_getUncleCountByBlockHash",
 		Args:      ArgsLatestBlockHash(cxt, rpcClient),
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockHashMissing",
@@ -370,25 +370,25 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthGetUncleCountByBlockNumberLatest",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"latest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberEarliest",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"earliest"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberPending",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"pending"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestEthGetUncleCountByBlockNumberZero",
 		Method:    "eth_getUncleCountByBlockNumber",
 		Args:      []interface{}{"0x0"},
-		Validator: ValidateRegexString(`^0x[[:xdigit:]]{1,}$`),
+		Validator: ValidateRegexString(`^0x([1-9a-f]+[0-9a-f]*|0)$`),
 	})
 
 	// cast code --rpc-url localhost:8545 0x6fda56c57b0acadb96ed5624ac500c0429d59429

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -140,6 +140,7 @@ var (
 	RPCTestEthSign                                     RPCTestDynamicArgs
 	RPCTestEthSignFail                                 RPCTestGeneric
 	RPCTestEthSignTransaction                          RPCTestDynamicArgs
+	RPCTestEthSendTransaction                          RPCTestDynamicArgs
 
 	allTests                = make([]RPCTest, 0)
 	RPCTestEthBlockByNumber RPCTestGeneric
@@ -523,6 +524,16 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 		RequiresUnlock: true,
 	}
 	allTests = append(allTests, &RPCTestEthSignTransaction)
+
+	// cast rpc --rpc-url localhost:8545 eth_sendTransaction '{"from": "0xb9b1cf51a65b50f74ed8bcb258413c02cba2ec57", "to": "0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6", "data": "0x", "gas": "0x5208", "gasPrice": "0x1", "nonce": "0x1"}'
+	RPCTestEthSendTransaction = RPCTestDynamicArgs{
+		Name:           "RPCTestEthSendTransaction",
+		Method:         "eth_sendTransaction",
+		Args:           ArgsCoinbaseTransaction(cxt, rpcClient, &RPCTestTransactionArgs{To: testEthAddress.String(), Value: "0x123", Gas: "0x5208", Data: "0x", MaxFeePerGas: "0x1", MaxPriorityFeePerGas: "0x1"}),
+		Validator:      ValidateRegexString(`^0x[[:xdigit:]]{64}$`),
+		RequiresUnlock: true,
+	}
+	allTests = append(allTests, &RPCTestEthSendTransaction)
 
 	// spacing this thing out
 	// spacing this thing out

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -559,12 +559,20 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthTransaction),
 	})
 
-	// eth_getTransactionReceipt
+	// cast receipt --rpc-url localhost:8545 0x1bd4ec642302aa22906360af6493c230ecc41df10fffcdedc85caeb22cbb6b58
 	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:      "RPCTestGetTransactionReceipt",
 		Method:    "eth_getTransactionReceipt",
 		Args:      ArgsTransactionHash(ctx, rpcClient, &RPCTestTransactionArgs{To: *testContractAddress, Value: "0x0", Data: "0xa0712d680000000000000000000000000000000000000000000000000000000000002710", MaxFeePerGas: defaultMaxFeePerGas, MaxPriorityFeePerGas: defaultMaxPriorityFeePerGas, Gas: "0x10000"}),
 		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthReceipt),
+	})
+
+	// This RPC can be validated pretty easily, but it's not clear how to create an uncle in a reproducible away in order to test this method reliably
+	allTests = append(allTests, &RPCTestDynamicArgs{
+		Name:      "RPCTestGetUncleByBlockHashAndIndex",
+		Method:    "eth_getUncleByBlockHashAndIndex",
+		Args:      ArgsLatestBlockHash(ctx, rpcClient, "0x0"),
+		Validator: RequireAny(ValidateJSONSchema(rpctypes.RPCSchemaEthBlock), ValidateExact(nil)),
 	})
 
 	uniqueTests := make(map[RPCTest]struct{})

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -55,13 +55,30 @@ var (
 		Validator: ValidatorError(`cannot unmarshal hex string without 0x prefix`),
 	}
 
+	// cast rpc --rpc-url localhost:8545 net_listening
+	RPCTestNetListening = RPCTestGeneric{
+		Method:    "net_listening",
+		Args:      []interface{}{},
+		Validator: ValidateExact(true),
+	}
+
 	allTests = []RPCTest{
 		&RPCTestNetVersion,
 		&RPCTestWeb3ClientVersion,
 		&RPCTestWeb3SHA3,
 		&RPCTestWeb3SHA3Error,
+		&RPCTestNetListening,
 	}
 )
+
+func ValidateExact(expected interface{}) func(result interface{}) error {
+	return func(result interface{}) error {
+		if expected != result {
+			return fmt.Errorf("Expected %v and got %v", expected, result)
+		}
+		return nil
+	}
+}
 
 func ValidateRegexString(regEx string) func(result interface{}) error {
 	r := regexp.MustCompile(regEx)

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -166,13 +166,10 @@ func setupTests(cxt context.Context, rpcClient *rpc.Client) {
 
 	// cast rpc --rpc-url localhost:8545 eth_syncing
 	allTests = append(allTests, &RPCTestGeneric{
-		Name:   "RPCTestEthSyncing",
-		Method: "eth_syncing",
-		Args:   []interface{}{},
-		Validator: ChainValidator(
-			ValidateExact(false),
-			ValidateJSONSchema(rpctypes.RPCSchemaEthSyncing),
-		),
+		Name:      "RPCTestEthSyncing",
+		Method:    "eth_syncing",
+		Args:      []interface{}{},
+		Validator: ValidateJSONSchema(rpctypes.RPCSchemaEthSyncing),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_coinbase

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -111,6 +111,109 @@ var (
 		),
 	}
 
+	// I probably need to put these giant strings somewhere else
+	// cast block --rpc-url localhost:8545 0
+	RPCTestEthBlockByNumber = RPCTestGeneric{
+		Method: "eth_getBlockByNumber",
+		Args:   []interface{}{"0x0", true},
+		Validator: ValidateJSONSchema(`
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "baseFeePerGas": {
+      "type": "string"
+    },
+    "difficulty": {
+      "type": "string"
+    },
+    "extraData": {
+      "type": "string"
+    },
+    "gasLimit": {
+      "type": "string"
+    },
+    "gasUsed": {
+      "type": "string"
+    },
+    "hash": {
+      "type": "string"
+    },
+    "logsBloom": {
+      "type": "string"
+    },
+    "miner": {
+      "type": "string"
+    },
+    "mixHash": {
+      "type": "string"
+    },
+    "nonce": {
+      "type": "string"
+    },
+    "number": {
+      "type": "string"
+    },
+    "parentHash": {
+      "type": "string"
+    },
+    "receiptsRoot": {
+      "type": "string"
+    },
+    "sha3Uncles": {
+      "type": "string"
+    },
+    "size": {
+      "type": "string"
+    },
+    "stateRoot": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "totalDifficulty": {
+      "type": "string"
+    },
+    "transactions": {
+      "type": "array",
+      "items": {}
+    },
+    "transactionsRoot": {
+      "type": "string"
+    },
+    "uncles": {
+      "type": "array",
+      "items": {}
+    }
+  },
+  "required": [
+    "baseFeePerGas",
+    "difficulty",
+    "extraData",
+    "gasLimit",
+    "gasUsed",
+    "hash",
+    "logsBloom",
+    "miner",
+    "mixHash",
+    "nonce",
+    "number",
+    "parentHash",
+    "receiptsRoot",
+    "sha3Uncles",
+    "size",
+    "stateRoot",
+    "timestamp",
+    "totalDifficulty",
+    "transactions",
+    "transactionsRoot",
+    "uncles"
+  ]
+}
+`),
+	}
+
 	allTests = []RPCTest{
 		&RPCTestNetVersion,
 		&RPCTestWeb3ClientVersion,
@@ -120,6 +223,7 @@ var (
 		&RPCTestNetPeerCount,
 		&RPCTestEthProtocolVersion,
 		&RPCTestEthSyncing,
+		&RPCTestEthBlockByNumber,
 	}
 )
 
@@ -154,6 +258,7 @@ func ValidateJSONSchema(schema string) func(result interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Unable to run json validation: %w", err)
 		}
+		// fmt.Println(string(jsonBytes))
 		if !validatorResult.Valid() {
 			errStr := ""
 			for _, desc := range validatorResult.Errors() {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,10 @@ require (
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
 )
 
-require github.com/cenkalti/backoff v2.2.1+incompatible
+require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/xeipuuv/gojsonschema v1.2.0
+)
 
 require (
 	cloud.google.com/go v0.110.0 // indirect
@@ -148,6 +151,8 @@ require (
 	github.com/valyala/fasthttp v1.37.0 // indirect
 	github.com/valyala/fastjson v1.6.3 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -875,6 +875,12 @@ github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYp
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/rpctypes/schemas.go
+++ b/rpctypes/schemas.go
@@ -18,3 +18,6 @@ var RPCSchemaSignTxResponse string
 
 //go:embed schemas/rpcschemaethtransaction.json
 var RPCSchemaEthTransaction string
+
+//go:embed schemas/rpcschemaethreceipt.json
+var RPCSchemaEthReceipt string

--- a/rpctypes/schemas.go
+++ b/rpctypes/schemas.go
@@ -15,3 +15,6 @@ var RPCSchemaAccountList string
 
 //go:embed schemas/rpcschemasigntxresponse.json
 var RPCSchemaSignTxResponse string
+
+//go:embed schemas/rpcschemaethtransaction.json
+var RPCSchemaEthTransaction string

--- a/rpctypes/schemas.go
+++ b/rpctypes/schemas.go
@@ -21,3 +21,6 @@ var RPCSchemaEthTransaction string
 
 //go:embed schemas/rpcschemaethreceipt.json
 var RPCSchemaEthReceipt string
+
+//go:embed schemas/rpcschemafilterchanges.json
+var RPCSchemaEthFilter string

--- a/rpctypes/schemas.go
+++ b/rpctypes/schemas.go
@@ -12,3 +12,6 @@ var RPCSchemaEthBlock string
 
 //go:embed schemas/rpcschemaaccountlist.json
 var RPCSchemaAccountList string
+
+//go:embed schemas/rpcschemasigntxresponse.json
+var RPCSchemaSignTxResponse string

--- a/rpctypes/schemas.go
+++ b/rpctypes/schemas.go
@@ -1,0 +1,11 @@
+package rpctypes
+
+import (
+	_ "embed"
+)
+
+//go:embed schemas/rpcschemaethsyncing.json
+var RPCSchemaEthSyncing string
+
+//go:embed schemas/rpcschemaethblock.json
+var RPCSchemaEthBlock string

--- a/rpctypes/schemas.go
+++ b/rpctypes/schemas.go
@@ -9,3 +9,6 @@ var RPCSchemaEthSyncing string
 
 //go:embed schemas/rpcschemaethblock.json
 var RPCSchemaEthBlock string
+
+//go:embed schemas/rpcschemaaccountlist.json
+var RPCSchemaAccountList string

--- a/rpctypes/schemas/README.org
+++ b/rpctypes/schemas/README.org
@@ -1,0 +1,17 @@
+The openrpc.json file comes from this repo:
+https://github.com/ethereum/execution-apis
+
+In order to build it, we run:
+
+#+BEGIN_SRC bash
+npm install
+npm run build
+#+END_SRC
+
+Rather than keeping a unique schema per method, we'll try to decompose
+into unique schemas for simplicity.
+
+#+BEGIN_SRC bash
+cat openrpc.json | jq '.methods[].name' | sort
+cat openrpc.json | jq '.methods[] | select(.name == "eth_syncing") | .result.schema'
+#+END_SRC

--- a/rpctypes/schemas/openrpc.json
+++ b/rpctypes/schemas/openrpc.json
@@ -1,0 +1,5873 @@
+{
+	"openrpc": "1.2.4",
+	"info": {
+		"title": "Ethereum JSON-RPC Specification",
+		"description": "A specification of the standard interface for Ethereum clients.",
+		"license": {
+			"name": "CC0-1.0",
+			"url": "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
+		},
+		"version": "0.0.0"
+	},
+	"methods": [
+		{
+			"name": "eth_getBlockByHash",
+			"summary": "Returns information about a block by hash.",
+			"params": [
+				{
+					"name": "Block hash",
+					"required": true,
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				},
+				{
+					"name": "Hydrated transactions",
+					"required": true,
+					"schema": {
+						"title": "hydrated",
+						"type": "boolean"
+					}
+				}
+			],
+			"result": {
+				"name": "Block information",
+				"schema": {
+					"title": "Block object",
+					"type": "object",
+					"required": [
+						"parentHash",
+						"sha3Uncles",
+						"miner",
+						"stateRoot",
+						"transactionsRoot",
+						"receiptsRoot",
+						"logsBloom",
+						"number",
+						"gasLimit",
+						"gasUsed",
+						"timestamp",
+						"extraData",
+						"mixHash",
+						"nonce",
+						"size",
+						"transactions",
+						"uncles"
+					],
+					"properties": {
+						"parentHash": {
+							"title": "Parent block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"sha3Uncles": {
+							"title": "Ommers hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"miner": {
+							"title": "Coinbase",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"stateRoot": {
+							"title": "State root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactionsRoot": {
+							"title": "Transactions root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"receiptsRoot": {
+							"title": "Receipts root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"logsBloom": {
+							"title": "Bloom filter",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{512}$"
+						},
+						"difficulty": {
+							"title": "Difficulty",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]*$"
+						},
+						"number": {
+							"title": "Number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"gasLimit": {
+							"title": "Gas limit",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"gasUsed": {
+							"title": "Gas used",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"timestamp": {
+							"title": "Timestamp",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"extraData": {
+							"title": "Extra data",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]*$"
+						},
+						"mixHash": {
+							"title": "Mix hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"nonce": {
+							"title": "Nonce",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{16}$"
+						},
+						"totalDifficulty": {
+							"title": "Total difficulty",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"baseFeePerGas": {
+							"title": "Base fee per gas",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"withdrawalsRoot": {
+							"title": "Withdrawals root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"size": {
+							"title": "Block size",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"transactions": {
+							"anyOf": [
+								{
+									"title": "Transaction hashes",
+									"type": "array",
+									"items": {
+										"title": "32 byte hex value",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									}
+								},
+								{
+									"title": "Full transactions",
+									"type": "array",
+									"items": {
+										"oneOf": [
+											{
+												"title": "Signed 1559 Transaction",
+												"type": "object",
+												"required": [
+													"accessList",
+													"chainId",
+													"gas",
+													"input",
+													"maxFeePerGas",
+													"maxPriorityFeePerGas",
+													"nonce",
+													"r",
+													"s",
+													"type",
+													"value",
+													"yParity"
+												],
+												"properties": {
+													"type": {
+														"title": "type",
+														"type": "string",
+														"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+													},
+													"nonce": {
+														"title": "nonce",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"to": {
+														"title": "to address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"gas": {
+														"title": "gas limit",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"value": {
+														"title": "value",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"input": {
+														"title": "input data",
+														"type": "string",
+														"pattern": "^0x[0-9a-f]*$"
+													},
+													"maxPriorityFeePerGas": {
+														"title": "max priority fee per gas",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+													},
+													"maxFeePerGas": {
+														"title": "max fee per gas",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+													},
+													"accessList": {
+														"title": "accessList",
+														"type": "array",
+														"description": "EIP-2930 access list",
+														"items": {
+															"title": "Access list entry",
+															"type": "object",
+															"properties": {
+																"address": {
+																	"title": "hex encoded address",
+																	"type": "string",
+																	"pattern": "^0x[0-9,a-f,A-F]{40}$"
+																},
+																"storageKeys": {
+																	"type": "array",
+																	"items": {
+																		"title": "32 byte hex value",
+																		"type": "string",
+																		"pattern": "^0x[0-9a-f]{64}$"
+																	}
+																}
+															}
+														}
+													},
+													"chainId": {
+														"title": "chainId",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Chain ID that this transaction is valid on."
+													},
+													"yParity": {
+														"title": "yParity",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+													},
+													"r": {
+														"title": "r",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"s": {
+														"title": "s",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													}
+												}
+											},
+											{
+												"title": "Signed 2930 Transaction",
+												"type": "object",
+												"required": [
+													"accessList",
+													"chainId",
+													"gas",
+													"gasPrice",
+													"input",
+													"nonce",
+													"r",
+													"s",
+													"type",
+													"value",
+													"yParity"
+												],
+												"properties": {
+													"type": {
+														"title": "type",
+														"type": "string",
+														"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+													},
+													"nonce": {
+														"title": "nonce",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"to": {
+														"title": "to address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"gas": {
+														"title": "gas limit",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"value": {
+														"title": "value",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"input": {
+														"title": "input data",
+														"type": "string",
+														"pattern": "^0x[0-9a-f]*$"
+													},
+													"gasPrice": {
+														"title": "gas price",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The gas price willing to be paid by the sender in wei"
+													},
+													"accessList": {
+														"title": "accessList",
+														"type": "array",
+														"description": "EIP-2930 access list",
+														"items": {
+															"title": "Access list entry",
+															"type": "object",
+															"properties": {
+																"address": {
+																	"title": "hex encoded address",
+																	"type": "string",
+																	"pattern": "^0x[0-9,a-f,A-F]{40}$"
+																},
+																"storageKeys": {
+																	"type": "array",
+																	"items": {
+																		"title": "32 byte hex value",
+																		"type": "string",
+																		"pattern": "^0x[0-9a-f]{64}$"
+																	}
+																}
+															}
+														}
+													},
+													"chainId": {
+														"title": "chainId",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Chain ID that this transaction is valid on."
+													},
+													"yParity": {
+														"title": "yParity",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+													},
+													"r": {
+														"title": "r",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"s": {
+														"title": "s",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													}
+												}
+											},
+											{
+												"title": "Signed Legacy Transaction",
+												"type": "object",
+												"required": [
+													"gas",
+													"gasPrice",
+													"input",
+													"nonce",
+													"r",
+													"s",
+													"type",
+													"v",
+													"value"
+												],
+												"properties": {
+													"type": {
+														"title": "type",
+														"type": "string",
+														"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+													},
+													"nonce": {
+														"title": "nonce",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"to": {
+														"title": "to address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"gas": {
+														"title": "gas limit",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"value": {
+														"title": "value",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"input": {
+														"title": "input data",
+														"type": "string",
+														"pattern": "^0x[0-9a-f]*$"
+													},
+													"gasPrice": {
+														"title": "gas price",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The gas price willing to be paid by the sender in wei"
+													},
+													"chainId": {
+														"title": "chainId",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Chain ID that this transaction is valid on."
+													},
+													"v": {
+														"title": "v",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"r": {
+														"title": "r",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"s": {
+														"title": "s",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													}
+												}
+											}
+										]
+									}
+								}
+							]
+						},
+						"withdrawals": {
+							"title": "Withdrawals",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"title": "Validator withdrawal",
+								"required": [
+									"index",
+									"validatorIndex",
+									"address",
+									"amount"
+								],
+								"properties": {
+									"index": {
+										"title": "index of withdrawal",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"validatorIndex": {
+										"title": "index of validator that generated withdrawal",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"address": {
+										"title": "recipient address for withdrawal value",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"amount": {
+										"title": "value contained in withdrawal",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+									}
+								}
+							}
+						},
+						"uncles": {
+							"title": "Uncles",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_getBlockByNumber",
+			"summary": "Returns information about a block by number.",
+			"params": [
+				{
+					"name": "Block",
+					"required": true,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				},
+				{
+					"name": "Hydrated transactions",
+					"required": true,
+					"schema": {
+						"title": "hydrated",
+						"type": "boolean"
+					}
+				}
+			],
+			"result": {
+				"name": "Block information",
+				"schema": {
+					"title": "Block object",
+					"type": "object",
+					"required": [
+						"parentHash",
+						"sha3Uncles",
+						"miner",
+						"stateRoot",
+						"transactionsRoot",
+						"receiptsRoot",
+						"logsBloom",
+						"number",
+						"gasLimit",
+						"gasUsed",
+						"timestamp",
+						"extraData",
+						"mixHash",
+						"nonce",
+						"size",
+						"transactions",
+						"uncles"
+					],
+					"properties": {
+						"parentHash": {
+							"title": "Parent block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"sha3Uncles": {
+							"title": "Ommers hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"miner": {
+							"title": "Coinbase",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"stateRoot": {
+							"title": "State root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactionsRoot": {
+							"title": "Transactions root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"receiptsRoot": {
+							"title": "Receipts root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"logsBloom": {
+							"title": "Bloom filter",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{512}$"
+						},
+						"difficulty": {
+							"title": "Difficulty",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]*$"
+						},
+						"number": {
+							"title": "Number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"gasLimit": {
+							"title": "Gas limit",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"gasUsed": {
+							"title": "Gas used",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"timestamp": {
+							"title": "Timestamp",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"extraData": {
+							"title": "Extra data",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]*$"
+						},
+						"mixHash": {
+							"title": "Mix hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"nonce": {
+							"title": "Nonce",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{16}$"
+						},
+						"totalDifficulty": {
+							"title": "Total difficulty",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"baseFeePerGas": {
+							"title": "Base fee per gas",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"withdrawalsRoot": {
+							"title": "Withdrawals root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"size": {
+							"title": "Block size",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"transactions": {
+							"anyOf": [
+								{
+									"title": "Transaction hashes",
+									"type": "array",
+									"items": {
+										"title": "32 byte hex value",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									}
+								},
+								{
+									"title": "Full transactions",
+									"type": "array",
+									"items": {
+										"oneOf": [
+											{
+												"title": "Signed 1559 Transaction",
+												"type": "object",
+												"required": [
+													"accessList",
+													"chainId",
+													"gas",
+													"input",
+													"maxFeePerGas",
+													"maxPriorityFeePerGas",
+													"nonce",
+													"r",
+													"s",
+													"type",
+													"value",
+													"yParity"
+												],
+												"properties": {
+													"type": {
+														"title": "type",
+														"type": "string",
+														"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+													},
+													"nonce": {
+														"title": "nonce",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"to": {
+														"title": "to address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"gas": {
+														"title": "gas limit",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"value": {
+														"title": "value",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"input": {
+														"title": "input data",
+														"type": "string",
+														"pattern": "^0x[0-9a-f]*$"
+													},
+													"maxPriorityFeePerGas": {
+														"title": "max priority fee per gas",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+													},
+													"maxFeePerGas": {
+														"title": "max fee per gas",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+													},
+													"accessList": {
+														"title": "accessList",
+														"type": "array",
+														"description": "EIP-2930 access list",
+														"items": {
+															"title": "Access list entry",
+															"type": "object",
+															"properties": {
+																"address": {
+																	"title": "hex encoded address",
+																	"type": "string",
+																	"pattern": "^0x[0-9,a-f,A-F]{40}$"
+																},
+																"storageKeys": {
+																	"type": "array",
+																	"items": {
+																		"title": "32 byte hex value",
+																		"type": "string",
+																		"pattern": "^0x[0-9a-f]{64}$"
+																	}
+																}
+															}
+														}
+													},
+													"chainId": {
+														"title": "chainId",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Chain ID that this transaction is valid on."
+													},
+													"yParity": {
+														"title": "yParity",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+													},
+													"r": {
+														"title": "r",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"s": {
+														"title": "s",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													}
+												}
+											},
+											{
+												"title": "Signed 2930 Transaction",
+												"type": "object",
+												"required": [
+													"accessList",
+													"chainId",
+													"gas",
+													"gasPrice",
+													"input",
+													"nonce",
+													"r",
+													"s",
+													"type",
+													"value",
+													"yParity"
+												],
+												"properties": {
+													"type": {
+														"title": "type",
+														"type": "string",
+														"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+													},
+													"nonce": {
+														"title": "nonce",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"to": {
+														"title": "to address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"gas": {
+														"title": "gas limit",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"value": {
+														"title": "value",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"input": {
+														"title": "input data",
+														"type": "string",
+														"pattern": "^0x[0-9a-f]*$"
+													},
+													"gasPrice": {
+														"title": "gas price",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The gas price willing to be paid by the sender in wei"
+													},
+													"accessList": {
+														"title": "accessList",
+														"type": "array",
+														"description": "EIP-2930 access list",
+														"items": {
+															"title": "Access list entry",
+															"type": "object",
+															"properties": {
+																"address": {
+																	"title": "hex encoded address",
+																	"type": "string",
+																	"pattern": "^0x[0-9,a-f,A-F]{40}$"
+																},
+																"storageKeys": {
+																	"type": "array",
+																	"items": {
+																		"title": "32 byte hex value",
+																		"type": "string",
+																		"pattern": "^0x[0-9a-f]{64}$"
+																	}
+																}
+															}
+														}
+													},
+													"chainId": {
+														"title": "chainId",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Chain ID that this transaction is valid on."
+													},
+													"yParity": {
+														"title": "yParity",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+													},
+													"r": {
+														"title": "r",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"s": {
+														"title": "s",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													}
+												}
+											},
+											{
+												"title": "Signed Legacy Transaction",
+												"type": "object",
+												"required": [
+													"gas",
+													"gasPrice",
+													"input",
+													"nonce",
+													"r",
+													"s",
+													"type",
+													"v",
+													"value"
+												],
+												"properties": {
+													"type": {
+														"title": "type",
+														"type": "string",
+														"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+													},
+													"nonce": {
+														"title": "nonce",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"to": {
+														"title": "to address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"gas": {
+														"title": "gas limit",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"value": {
+														"title": "value",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"input": {
+														"title": "input data",
+														"type": "string",
+														"pattern": "^0x[0-9a-f]*$"
+													},
+													"gasPrice": {
+														"title": "gas price",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "The gas price willing to be paid by the sender in wei"
+													},
+													"chainId": {
+														"title": "chainId",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+														"description": "Chain ID that this transaction is valid on."
+													},
+													"v": {
+														"title": "v",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"r": {
+														"title": "r",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													},
+													"s": {
+														"title": "s",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+													}
+												}
+											}
+										]
+									}
+								}
+							]
+						},
+						"withdrawals": {
+							"title": "Withdrawals",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"title": "Validator withdrawal",
+								"required": [
+									"index",
+									"validatorIndex",
+									"address",
+									"amount"
+								],
+								"properties": {
+									"index": {
+										"title": "index of withdrawal",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"validatorIndex": {
+										"title": "index of validator that generated withdrawal",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"address": {
+										"title": "recipient address for withdrawal value",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"amount": {
+										"title": "value contained in withdrawal",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+									}
+								}
+							}
+						},
+						"uncles": {
+							"title": "Uncles",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_getBlockTransactionCountByHash",
+			"summary": "Returns the number of transactions in a block from a block matching the given block hash.",
+			"params": [
+				{
+					"name": "Block hash",
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction count",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_getBlockTransactionCountByNumber",
+			"summary": "Returns the number of transactions in a block matching the given block number.",
+			"params": [
+				{
+					"name": "Block",
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction count",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_getUncleCountByBlockHash",
+			"summary": "Returns the number of uncles in a block from a block matching the given block hash.",
+			"params": [
+				{
+					"name": "Block hash",
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Uncle count",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_getUncleCountByBlockNumber",
+			"summary": "Returns the number of transactions in a block matching the given block number.",
+			"params": [
+				{
+					"name": "Block",
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Uncle count",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_chainId",
+			"summary": "Returns the chain ID of the current network.",
+			"params": [],
+			"result": {
+				"name": "Chain ID",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_syncing",
+			"summary": "Returns an object with data about the sync status or false.",
+			"params": [],
+			"result": {
+				"name": "Syncing status",
+				"schema": {
+					"title": "Syncing status",
+					"oneOf": [
+						{
+							"title": "Syncing progress",
+							"type": "object",
+							"properties": {
+								"startingBlock": {
+									"title": "Starting block",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"currentBlock": {
+									"title": "Current block",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"highestBlock": {
+									"title": "Highest block",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Not syncing",
+							"description": "Should always return false if not syncing.",
+							"type": "boolean"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "eth_coinbase",
+			"summary": "Returns the client coinbase address.",
+			"params": [],
+			"result": {
+				"name": "Coinbase address",
+				"schema": {
+					"title": "hex encoded address",
+					"type": "string",
+					"pattern": "^0x[0-9,a-f,A-F]{40}$"
+				}
+			}
+		},
+		{
+			"name": "eth_accounts",
+			"summary": "Returns a list of addresses owned by client.",
+			"params": [],
+			"result": {
+				"name": "Accounts",
+				"schema": {
+					"title": "Accounts",
+					"type": "array",
+					"items": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_blockNumber",
+			"summary": "Returns the number of most recent block.",
+			"params": [],
+			"result": {
+				"name": "Block number",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_call",
+			"summary": "Executes a new message call immediately without creating a transaction on the block chain.",
+			"params": [
+				{
+					"name": "Transaction",
+					"required": true,
+					"schema": {
+						"type": "object",
+						"title": "Transaction object generic to all types",
+						"properties": {
+							"type": {
+								"title": "type",
+								"type": "string",
+								"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+							},
+							"nonce": {
+								"title": "nonce",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"to": {
+								"title": "to address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"from": {
+								"title": "from address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"gas": {
+								"title": "gas limit",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"value": {
+								"title": "value",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"input": {
+								"title": "input data",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							},
+							"gasPrice": {
+								"title": "gas price",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The gas price willing to be paid by the sender in wei"
+							},
+							"maxPriorityFeePerGas": {
+								"title": "max priority fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+							},
+							"maxFeePerGas": {
+								"title": "max fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+							},
+							"accessList": {
+								"title": "accessList",
+								"type": "array",
+								"description": "EIP-2930 access list",
+								"items": {
+									"title": "Access list entry",
+									"type": "object",
+									"properties": {
+										"address": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"storageKeys": {
+											"type": "array",
+											"items": {
+												"title": "32 byte hex value",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									}
+								}
+							},
+							"chainId": {
+								"title": "chainId",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Chain ID that this transaction is valid on."
+							}
+						}
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number, tag, or block hash",
+						"anyOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							},
+							{
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Return data",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "eth_estimateGas",
+			"summary": "Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.",
+			"params": [
+				{
+					"name": "Transaction",
+					"required": true,
+					"schema": {
+						"type": "object",
+						"title": "Transaction object generic to all types",
+						"properties": {
+							"type": {
+								"title": "type",
+								"type": "string",
+								"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+							},
+							"nonce": {
+								"title": "nonce",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"to": {
+								"title": "to address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"from": {
+								"title": "from address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"gas": {
+								"title": "gas limit",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"value": {
+								"title": "value",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"input": {
+								"title": "input data",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							},
+							"gasPrice": {
+								"title": "gas price",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The gas price willing to be paid by the sender in wei"
+							},
+							"maxPriorityFeePerGas": {
+								"title": "max priority fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+							},
+							"maxFeePerGas": {
+								"title": "max fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+							},
+							"accessList": {
+								"title": "accessList",
+								"type": "array",
+								"description": "EIP-2930 access list",
+								"items": {
+									"title": "Access list entry",
+									"type": "object",
+									"properties": {
+										"address": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"storageKeys": {
+											"type": "array",
+											"items": {
+												"title": "32 byte hex value",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									}
+								}
+							},
+							"chainId": {
+								"title": "chainId",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Chain ID that this transaction is valid on."
+							}
+						}
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Gas used",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_createAccessList",
+			"summary": "Generates an access list for a transaction.",
+			"params": [
+				{
+					"name": "Transaction",
+					"required": true,
+					"schema": {
+						"type": "object",
+						"title": "Transaction object generic to all types",
+						"properties": {
+							"type": {
+								"title": "type",
+								"type": "string",
+								"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+							},
+							"nonce": {
+								"title": "nonce",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"to": {
+								"title": "to address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"from": {
+								"title": "from address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"gas": {
+								"title": "gas limit",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"value": {
+								"title": "value",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"input": {
+								"title": "input data",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							},
+							"gasPrice": {
+								"title": "gas price",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The gas price willing to be paid by the sender in wei"
+							},
+							"maxPriorityFeePerGas": {
+								"title": "max priority fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+							},
+							"maxFeePerGas": {
+								"title": "max fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+							},
+							"accessList": {
+								"title": "accessList",
+								"type": "array",
+								"description": "EIP-2930 access list",
+								"items": {
+									"title": "Access list entry",
+									"type": "object",
+									"properties": {
+										"address": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"storageKeys": {
+											"type": "array",
+											"items": {
+												"title": "32 byte hex value",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									}
+								}
+							},
+							"chainId": {
+								"title": "chainId",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Chain ID that this transaction is valid on."
+							}
+						}
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Gas used",
+				"schema": {
+					"title": "Access list result",
+					"type": "object",
+					"properties": {
+						"accessList": {
+							"title": "accessList",
+							"type": "array",
+							"items": {
+								"title": "Access list entry",
+								"type": "object",
+								"properties": {
+									"address": {
+										"title": "hex encoded address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"storageKeys": {
+										"type": "array",
+										"items": {
+											"title": "32 byte hex value",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										}
+									}
+								}
+							}
+						},
+						"error": {
+							"title": "error",
+							"type": "string"
+						},
+						"gasUsed": {
+							"title": "Gas used",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_gasPrice",
+			"summary": "Returns the current price per gas in wei.",
+			"params": [],
+			"result": {
+				"name": "Gas price",
+				"schema": {
+					"title": "Gas price",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_maxPriorityFeePerGas",
+			"summary": "Returns the current maxPriorityFeePerGas per gas in wei.",
+			"params": [],
+			"result": {
+				"name": "Max priority fee per gas",
+				"schema": {
+					"title": "Max priority fee per gas",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_feeHistory",
+			"summary": "Transaction fee history",
+			"description": "Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.",
+			"params": [
+				{
+					"name": "blockCount",
+					"description": "Requested range of blocks. Clients will return less than the requested range if not all blocks are available.",
+					"required": true,
+					"schema": {
+						"title": "hex encoded unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					}
+				},
+				{
+					"name": "newestBlock",
+					"description": "Highest block of the requested range.",
+					"required": true,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				},
+				{
+					"name": "rewardPercentiles",
+					"description": "A monotonically increasing list of percentile values. For each block in the requested range, the transactions will be sorted in ascending order by effective tip per gas and the coresponding effective tip for the percentile will be determined, accounting for gas consumed.",
+					"required": true,
+					"schema": {
+						"title": "rewardPercentiles",
+						"type": "array",
+						"items": {
+							"title": "rewardPercentile",
+							"description": "Floating point value between 0 and 100.",
+							"type": "number"
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "feeHistoryResult",
+				"description": "Fee history for the returned block range. This can be a subsection of the requested range if not all blocks are available.",
+				"schema": {
+					"title": "feeHistoryResults",
+					"description": "Fee history results.",
+					"type": "object",
+					"required": [
+						"oldestBlock",
+						"baseFeePerGas",
+						"gasUsedRatio"
+					],
+					"properties": {
+						"oldestBlock": {
+							"title": "oldestBlock",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+							"description": "Lowest number block of returned range."
+						},
+						"baseFeePerGas": {
+							"title": "baseFeePerGasArray",
+							"description": "An array of block base fees per gas. This includes the next block after the newest of the returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559 blocks.",
+							"type": "array",
+							"items": {
+								"title": "hex encoded unsigned integer",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							}
+						},
+						"reward": {
+							"title": "rewardArray",
+							"description": "A two-dimensional array of effective priority fees per gas at the requested block percentiles.",
+							"type": "array",
+							"items": {
+								"title": "rewardPercentile",
+								"description": "An array of effective priority fee per gas data points from a single block. All zeroes are returned if the block is empty.",
+								"type": "array",
+								"items": {
+									"title": "rewardPercentile",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "A given percentile sample of effective priority fees per gas from a single block in ascending order, weighted by gas used. Zeroes are returned if the block is empty."
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_newFilter",
+			"summary": "Creates a filter object, based on filter options, to notify when the state changes (logs).",
+			"params": [
+				{
+					"name": "Filter",
+					"schema": {
+						"title": "filter",
+						"type": "object",
+						"properties": {
+							"fromBlock": {
+								"title": "from block",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"toBlock": {
+								"title": "to block",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"address": {
+								"title": "Address(es)",
+								"oneOf": [
+									{
+										"title": "Address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									{
+										"title": "Addresses",
+										"type": "array",
+										"items": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										}
+									}
+								]
+							},
+							"topics": {
+								"title": "Topics",
+								"type": "array",
+								"items": {
+									"title": "Filter Topic List Entry",
+									"oneOf": [
+										{
+											"title": "Any Topic Match",
+											"type": "null"
+										},
+										{
+											"title": "Single Topic Match",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										{
+											"title": "Multiple Topic Match",
+											"type": "array",
+											"items": {
+												"title": "32 hex encoded bytes",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Filter Identifier",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_newBlockFilter",
+			"summary": "Creates a filter in the node, to notify when a new block arrives.",
+			"params": [],
+			"result": {
+				"name": "Filter Identifier",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_newPendingTransactionFilter",
+			"summary": "Creates a filter in the node, to notify when new pending transactions arrive.",
+			"params": [],
+			"result": {
+				"name": "Filter Identifier",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_uninstallFilter",
+			"summary": "Uninstalls a filter with given id.",
+			"params": [
+				{
+					"name": "Filter Identifier",
+					"schema": {
+						"title": "hex encoded unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					}
+				}
+			],
+			"result": {
+				"name": "Success",
+				"schema": {
+					"type": "boolean"
+				}
+			}
+		},
+		{
+			"name": "eth_getFilterChanges",
+			"summary": "Polling method for a filter, which returns an array of logs which occurred since last poll.",
+			"params": [
+				{
+					"name": "Filter Identifier",
+					"schema": {
+						"title": "hex encoded unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					}
+				}
+			],
+			"result": {
+				"name": "Log objects",
+				"schema": {
+					"title": "Filter results",
+					"oneOf": [
+						{
+							"title": "new block hashes",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						},
+						{
+							"title": "new transaction hashes",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						},
+						{
+							"title": "new logs",
+							"type": "array",
+							"items": {
+								"title": "log",
+								"type": "object",
+								"required": [
+									"transactionHash"
+								],
+								"properties": {
+									"removed": {
+										"title": "removed",
+										"type": "boolean"
+									},
+									"logIndex": {
+										"title": "log index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionIndex": {
+										"title": "transaction index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionHash": {
+										"title": "transaction hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockHash": {
+										"title": "block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockNumber": {
+										"title": "block number",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"address": {
+										"title": "address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"data": {
+										"title": "data",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]*$"
+									},
+									"topics": {
+										"title": "topics",
+										"type": "array",
+										"items": {
+											"title": "32 hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										}
+									}
+								}
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "eth_getFilterLogs",
+			"summary": "Returns an array of all logs matching filter with given id.",
+			"params": [
+				{
+					"name": "Filter Identifier",
+					"schema": {
+						"title": "hex encoded unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					}
+				}
+			],
+			"result": {
+				"name": "Log objects",
+				"schema": {
+					"title": "Filter results",
+					"oneOf": [
+						{
+							"title": "new block hashes",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						},
+						{
+							"title": "new transaction hashes",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						},
+						{
+							"title": "new logs",
+							"type": "array",
+							"items": {
+								"title": "log",
+								"type": "object",
+								"required": [
+									"transactionHash"
+								],
+								"properties": {
+									"removed": {
+										"title": "removed",
+										"type": "boolean"
+									},
+									"logIndex": {
+										"title": "log index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionIndex": {
+										"title": "transaction index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionHash": {
+										"title": "transaction hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockHash": {
+										"title": "block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockNumber": {
+										"title": "block number",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"address": {
+										"title": "address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"data": {
+										"title": "data",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]*$"
+									},
+									"topics": {
+										"title": "topics",
+										"type": "array",
+										"items": {
+											"title": "32 hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										}
+									}
+								}
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "eth_getLogs",
+			"summary": "Returns an array of all logs matching filter with given id.",
+			"params": [
+				{
+					"name": "Filter",
+					"schema": {
+						"title": "filter",
+						"type": "object",
+						"properties": {
+							"fromBlock": {
+								"title": "from block",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"toBlock": {
+								"title": "to block",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"address": {
+								"title": "Address(es)",
+								"oneOf": [
+									{
+										"title": "Address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									{
+										"title": "Addresses",
+										"type": "array",
+										"items": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										}
+									}
+								]
+							},
+							"topics": {
+								"title": "Topics",
+								"type": "array",
+								"items": {
+									"title": "Filter Topic List Entry",
+									"oneOf": [
+										{
+											"title": "Any Topic Match",
+											"type": "null"
+										},
+										{
+											"title": "Single Topic Match",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										{
+											"title": "Multiple Topic Match",
+											"type": "array",
+											"items": {
+												"title": "32 hex encoded bytes",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									]
+								}
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Log objects",
+				"schema": {
+					"title": "Filter results",
+					"oneOf": [
+						{
+							"title": "new block hashes",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						},
+						{
+							"title": "new transaction hashes",
+							"type": "array",
+							"items": {
+								"title": "32 byte hex value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						},
+						{
+							"title": "new logs",
+							"type": "array",
+							"items": {
+								"title": "log",
+								"type": "object",
+								"required": [
+									"transactionHash"
+								],
+								"properties": {
+									"removed": {
+										"title": "removed",
+										"type": "boolean"
+									},
+									"logIndex": {
+										"title": "log index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionIndex": {
+										"title": "transaction index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionHash": {
+										"title": "transaction hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockHash": {
+										"title": "block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockNumber": {
+										"title": "block number",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"address": {
+										"title": "address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"data": {
+										"title": "data",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]*$"
+									},
+									"topics": {
+										"title": "topics",
+										"type": "array",
+										"items": {
+											"title": "32 hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										}
+									}
+								}
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "eth_mining",
+			"summary": "Returns whether the client is actively mining new blocks.",
+			"params": [],
+			"result": {
+				"name": "Mining status",
+				"schema": {
+					"title": "miningStatus",
+					"type": "boolean"
+				}
+			}
+		},
+		{
+			"name": "eth_hashrate",
+			"summary": "Returns the number of hashes per second that the node is mining with.",
+			"params": [],
+			"result": {
+				"name": "Mining status",
+				"schema": {
+					"title": "Hashrate",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_getWork",
+			"summary": "Returns the hash of the current block, the seedHash, and the boundary condition to be met (“target”).",
+			"params": [],
+			"result": {
+				"name": "Current work",
+				"schema": {
+					"type": "array",
+					"items": [
+						{
+							"title": "Proof-of-work hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						{
+							"title": "seed hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						{
+							"title": "difficulty",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "eth_submitWork",
+			"summary": "Used for submitting a proof-of-work solution.",
+			"params": [
+				{
+					"name": "nonce",
+					"required": true,
+					"schema": {
+						"title": "8 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{16}$"
+					}
+				},
+				{
+					"name": "hash",
+					"required": true,
+					"schema": {
+						"title": "32 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				},
+				{
+					"name": "digest",
+					"required": true,
+					"schema": {
+						"title": "32 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Success",
+				"schema": {
+					"type": "boolean"
+				}
+			}
+		},
+		{
+			"name": "eth_submitHashrate",
+			"summary": "Used for submitting mining hashrate.",
+			"params": [
+				{
+					"name": "Hashrate",
+					"required": true,
+					"schema": {
+						"title": "32 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				},
+				{
+					"name": "ID",
+					"required": true,
+					"schema": {
+						"title": "32 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Success",
+				"schema": {
+					"type": "boolean"
+				}
+			}
+		},
+		{
+			"name": "eth_sign",
+			"summary": "Returns an EIP-191 signature over the provided data.",
+			"params": [
+				{
+					"name": "Address",
+					"required": true,
+					"schema": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				},
+				{
+					"name": "Message",
+					"required": true,
+					"schema": {
+						"title": "hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]*$"
+					}
+				}
+			],
+			"result": {
+				"name": "Signature",
+				"schema": {
+					"title": "65 hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]{65}$"
+				}
+			}
+		},
+		{
+			"name": "eth_signTransaction",
+			"summary": "Returns an RLP encoded transaction signed by the specified account.",
+			"params": [
+				{
+					"name": "Transaction",
+					"required": true,
+					"schema": {
+						"type": "object",
+						"title": "Transaction object generic to all types",
+						"properties": {
+							"type": {
+								"title": "type",
+								"type": "string",
+								"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+							},
+							"nonce": {
+								"title": "nonce",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"to": {
+								"title": "to address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"from": {
+								"title": "from address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"gas": {
+								"title": "gas limit",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"value": {
+								"title": "value",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"input": {
+								"title": "input data",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							},
+							"gasPrice": {
+								"title": "gas price",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The gas price willing to be paid by the sender in wei"
+							},
+							"maxPriorityFeePerGas": {
+								"title": "max priority fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+							},
+							"maxFeePerGas": {
+								"title": "max fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+							},
+							"accessList": {
+								"title": "accessList",
+								"type": "array",
+								"description": "EIP-2930 access list",
+								"items": {
+									"title": "Access list entry",
+									"type": "object",
+									"properties": {
+										"address": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"storageKeys": {
+											"type": "array",
+											"items": {
+												"title": "32 byte hex value",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									}
+								}
+							},
+							"chainId": {
+								"title": "chainId",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Chain ID that this transaction is valid on."
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Encoded transaction",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "eth_getBalance",
+			"summary": "Returns the balance of the account of given address.",
+			"params": [
+				{
+					"name": "Address",
+					"required": true,
+					"schema": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number, tag, or block hash",
+						"anyOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							},
+							{
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Balance",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_getStorageAt",
+			"summary": "Returns the value from a storage position at a given address.",
+			"params": [
+				{
+					"name": "Address",
+					"required": true,
+					"schema": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				},
+				{
+					"name": "Storage slot",
+					"required": true,
+					"schema": {
+						"title": "hex encoded 256 bit unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number, tag, or block hash",
+						"anyOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							},
+							{
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Value",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "eth_getTransactionCount",
+			"summary": "Returns the number of transactions sent from an address.",
+			"params": [
+				{
+					"name": "Address",
+					"required": true,
+					"schema": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number, tag, or block hash",
+						"anyOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							},
+							{
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction count",
+				"schema": {
+					"title": "hex encoded unsigned integer",
+					"type": "string",
+					"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+				}
+			}
+		},
+		{
+			"name": "eth_getCode",
+			"summary": "Returns code at a given address.",
+			"params": [
+				{
+					"name": "Address",
+					"required": true,
+					"schema": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				},
+				{
+					"name": "Block",
+					"required": false,
+					"schema": {
+						"title": "Block number, tag, or block hash",
+						"anyOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							},
+							{
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Bytecode",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "eth_getProof",
+			"summary": "Returns the merkle proof for a given account and optionally some storage keys.",
+			"params": [
+				{
+					"name": "Address",
+					"required": true,
+					"schema": {
+						"title": "hex encoded address",
+						"type": "string",
+						"pattern": "^0x[0-9,a-f,A-F]{40}$"
+					}
+				},
+				{
+					"name": "StorageKeys",
+					"required": true,
+					"schema": {
+						"title": "Storage keys",
+						"type": "array",
+						"items": {
+							"title": "32 hex encoded bytes",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{0,64}$"
+						}
+					}
+				},
+				{
+					"name": "Block",
+					"required": true,
+					"schema": {
+						"title": "Block number, tag, or block hash",
+						"anyOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							},
+							{
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Account",
+				"schema": {
+					"title": "Account proof",
+					"type": "object",
+					"required": [
+						"address",
+						"accountProof",
+						"balance",
+						"codeHash",
+						"nonce",
+						"storageHash",
+						"storageProof"
+					],
+					"properties": {
+						"address": {
+							"title": "address",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"accountProof": {
+							"title": "accountProof",
+							"type": "array",
+							"items": {
+								"title": "hex encoded bytes",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							}
+						},
+						"balance": {
+							"title": "balance",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+						},
+						"codeHash": {
+							"title": "codeHash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"nonce": {
+							"title": "nonce",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+						},
+						"storageHash": {
+							"title": "storageHash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"storageProof": {
+							"title": "Storage proofs",
+							"type": "array",
+							"items": {
+								"title": "Storage proof",
+								"type": "object",
+								"required": [
+									"key",
+									"value",
+									"proof"
+								],
+								"properties": {
+									"key": {
+										"title": "key",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{0,64}$"
+									},
+									"value": {
+										"title": "value",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+									},
+									"proof": {
+										"title": "proof",
+										"type": "array",
+										"items": {
+											"title": "hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]*$"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_sendTransaction",
+			"summary": "Signs and submits a transaction.",
+			"params": [
+				{
+					"name": "Transaction",
+					"required": true,
+					"schema": {
+						"type": "object",
+						"title": "Transaction object generic to all types",
+						"properties": {
+							"type": {
+								"title": "type",
+								"type": "string",
+								"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+							},
+							"nonce": {
+								"title": "nonce",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"to": {
+								"title": "to address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"from": {
+								"title": "from address",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"gas": {
+								"title": "gas limit",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"value": {
+								"title": "value",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							"input": {
+								"title": "input data",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							},
+							"gasPrice": {
+								"title": "gas price",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The gas price willing to be paid by the sender in wei"
+							},
+							"maxPriorityFeePerGas": {
+								"title": "max priority fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+							},
+							"maxFeePerGas": {
+								"title": "max fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+							},
+							"accessList": {
+								"title": "accessList",
+								"type": "array",
+								"description": "EIP-2930 access list",
+								"items": {
+									"title": "Access list entry",
+									"type": "object",
+									"properties": {
+										"address": {
+											"title": "hex encoded address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"storageKeys": {
+											"type": "array",
+											"items": {
+												"title": "32 byte hex value",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]{64}$"
+											}
+										}
+									}
+								}
+							},
+							"chainId": {
+								"title": "chainId",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+								"description": "Chain ID that this transaction is valid on."
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction hash",
+				"schema": {
+					"title": "32 byte hex value",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]{64}$"
+				}
+			}
+		},
+		{
+			"name": "eth_sendRawTransaction",
+			"summary": "Submits a raw transaction.",
+			"params": [
+				{
+					"name": "Transaction",
+					"required": true,
+					"schema": {
+						"title": "hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]*$"
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction hash",
+				"schema": {
+					"title": "32 byte hex value",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]{64}$"
+				}
+			}
+		},
+		{
+			"name": "eth_getTransactionByHash",
+			"summary": "Returns the information about a transaction requested by transaction hash.",
+			"params": [
+				{
+					"name": "Transaction hash",
+					"required": true,
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction information",
+				"schema": {
+					"type": "object",
+					"title": "Transaction information",
+					"required": [
+						"blockHash",
+						"blockNumber",
+						"from",
+						"hash",
+						"transactionIndex"
+					],
+					"oneOf": [
+						{
+							"title": "Signed 1559 Transaction",
+							"type": "object",
+							"required": [
+								"accessList",
+								"chainId",
+								"gas",
+								"input",
+								"maxFeePerGas",
+								"maxPriorityFeePerGas",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"value",
+								"yParity"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"maxPriorityFeePerGas": {
+									"title": "max priority fee per gas",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+								},
+								"maxFeePerGas": {
+									"title": "max fee per gas",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+								},
+								"accessList": {
+									"title": "accessList",
+									"type": "array",
+									"description": "EIP-2930 access list",
+									"items": {
+										"title": "Access list entry",
+										"type": "object",
+										"properties": {
+											"address": {
+												"title": "hex encoded address",
+												"type": "string",
+												"pattern": "^0x[0-9,a-f,A-F]{40}$"
+											},
+											"storageKeys": {
+												"type": "array",
+												"items": {
+													"title": "32 byte hex value",
+													"type": "string",
+													"pattern": "^0x[0-9a-f]{64}$"
+												}
+											}
+										}
+									}
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"yParity": {
+									"title": "yParity",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Signed 2930 Transaction",
+							"type": "object",
+							"required": [
+								"accessList",
+								"chainId",
+								"gas",
+								"gasPrice",
+								"input",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"value",
+								"yParity"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"gasPrice": {
+									"title": "gas price",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The gas price willing to be paid by the sender in wei"
+								},
+								"accessList": {
+									"title": "accessList",
+									"type": "array",
+									"description": "EIP-2930 access list",
+									"items": {
+										"title": "Access list entry",
+										"type": "object",
+										"properties": {
+											"address": {
+												"title": "hex encoded address",
+												"type": "string",
+												"pattern": "^0x[0-9,a-f,A-F]{40}$"
+											},
+											"storageKeys": {
+												"type": "array",
+												"items": {
+													"title": "32 byte hex value",
+													"type": "string",
+													"pattern": "^0x[0-9a-f]{64}$"
+												}
+											}
+										}
+									}
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"yParity": {
+									"title": "yParity",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Signed Legacy Transaction",
+							"type": "object",
+							"required": [
+								"gas",
+								"gasPrice",
+								"input",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"v",
+								"value"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"gasPrice": {
+									"title": "gas price",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The gas price willing to be paid by the sender in wei"
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"v": {
+									"title": "v",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						}
+					],
+					"properties": {
+						"blockHash": {
+							"title": "block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"blockNumber": {
+							"title": "block number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"from": {
+							"title": "from address",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"hash": {
+							"title": "transaction hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactionIndex": {
+							"title": "transaction index",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_getTransactionByBlockHashAndIndex",
+			"summary": "Returns information about a transaction by block hash and transaction index position.",
+			"params": [
+				{
+					"name": "Block hash",
+					"required": true,
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				},
+				{
+					"name": "Transaction index",
+					"required": true,
+					"schema": {
+						"title": "hex encoded unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction information",
+				"schema": {
+					"type": "object",
+					"title": "Transaction information",
+					"required": [
+						"blockHash",
+						"blockNumber",
+						"from",
+						"hash",
+						"transactionIndex"
+					],
+					"oneOf": [
+						{
+							"title": "Signed 1559 Transaction",
+							"type": "object",
+							"required": [
+								"accessList",
+								"chainId",
+								"gas",
+								"input",
+								"maxFeePerGas",
+								"maxPriorityFeePerGas",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"value",
+								"yParity"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"maxPriorityFeePerGas": {
+									"title": "max priority fee per gas",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+								},
+								"maxFeePerGas": {
+									"title": "max fee per gas",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+								},
+								"accessList": {
+									"title": "accessList",
+									"type": "array",
+									"description": "EIP-2930 access list",
+									"items": {
+										"title": "Access list entry",
+										"type": "object",
+										"properties": {
+											"address": {
+												"title": "hex encoded address",
+												"type": "string",
+												"pattern": "^0x[0-9,a-f,A-F]{40}$"
+											},
+											"storageKeys": {
+												"type": "array",
+												"items": {
+													"title": "32 byte hex value",
+													"type": "string",
+													"pattern": "^0x[0-9a-f]{64}$"
+												}
+											}
+										}
+									}
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"yParity": {
+									"title": "yParity",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Signed 2930 Transaction",
+							"type": "object",
+							"required": [
+								"accessList",
+								"chainId",
+								"gas",
+								"gasPrice",
+								"input",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"value",
+								"yParity"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"gasPrice": {
+									"title": "gas price",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The gas price willing to be paid by the sender in wei"
+								},
+								"accessList": {
+									"title": "accessList",
+									"type": "array",
+									"description": "EIP-2930 access list",
+									"items": {
+										"title": "Access list entry",
+										"type": "object",
+										"properties": {
+											"address": {
+												"title": "hex encoded address",
+												"type": "string",
+												"pattern": "^0x[0-9,a-f,A-F]{40}$"
+											},
+											"storageKeys": {
+												"type": "array",
+												"items": {
+													"title": "32 byte hex value",
+													"type": "string",
+													"pattern": "^0x[0-9a-f]{64}$"
+												}
+											}
+										}
+									}
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"yParity": {
+									"title": "yParity",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Signed Legacy Transaction",
+							"type": "object",
+							"required": [
+								"gas",
+								"gasPrice",
+								"input",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"v",
+								"value"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"gasPrice": {
+									"title": "gas price",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The gas price willing to be paid by the sender in wei"
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"v": {
+									"title": "v",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						}
+					],
+					"properties": {
+						"blockHash": {
+							"title": "block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"blockNumber": {
+							"title": "block number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"from": {
+							"title": "from address",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"hash": {
+							"title": "transaction hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactionIndex": {
+							"title": "transaction index",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_getTransactionByBlockNumberAndIndex",
+			"summary": "Returns information about a transaction by block number and transaction index position.",
+			"params": [
+				{
+					"name": "Block",
+					"required": true,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				},
+				{
+					"name": "Transaction index",
+					"required": true,
+					"schema": {
+						"title": "hex encoded unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+					}
+				}
+			],
+			"result": {
+				"name": "Transaction information",
+				"schema": {
+					"type": "object",
+					"title": "Transaction information",
+					"required": [
+						"blockHash",
+						"blockNumber",
+						"from",
+						"hash",
+						"transactionIndex"
+					],
+					"oneOf": [
+						{
+							"title": "Signed 1559 Transaction",
+							"type": "object",
+							"required": [
+								"accessList",
+								"chainId",
+								"gas",
+								"input",
+								"maxFeePerGas",
+								"maxPriorityFeePerGas",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"value",
+								"yParity"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"maxPriorityFeePerGas": {
+									"title": "max priority fee per gas",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+								},
+								"maxFeePerGas": {
+									"title": "max fee per gas",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+								},
+								"accessList": {
+									"title": "accessList",
+									"type": "array",
+									"description": "EIP-2930 access list",
+									"items": {
+										"title": "Access list entry",
+										"type": "object",
+										"properties": {
+											"address": {
+												"title": "hex encoded address",
+												"type": "string",
+												"pattern": "^0x[0-9,a-f,A-F]{40}$"
+											},
+											"storageKeys": {
+												"type": "array",
+												"items": {
+													"title": "32 byte hex value",
+													"type": "string",
+													"pattern": "^0x[0-9a-f]{64}$"
+												}
+											}
+										}
+									}
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"yParity": {
+									"title": "yParity",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Signed 2930 Transaction",
+							"type": "object",
+							"required": [
+								"accessList",
+								"chainId",
+								"gas",
+								"gasPrice",
+								"input",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"value",
+								"yParity"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"gasPrice": {
+									"title": "gas price",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The gas price willing to be paid by the sender in wei"
+								},
+								"accessList": {
+									"title": "accessList",
+									"type": "array",
+									"description": "EIP-2930 access list",
+									"items": {
+										"title": "Access list entry",
+										"type": "object",
+										"properties": {
+											"address": {
+												"title": "hex encoded address",
+												"type": "string",
+												"pattern": "^0x[0-9,a-f,A-F]{40}$"
+											},
+											"storageKeys": {
+												"type": "array",
+												"items": {
+													"title": "32 byte hex value",
+													"type": "string",
+													"pattern": "^0x[0-9a-f]{64}$"
+												}
+											}
+										}
+									}
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"yParity": {
+									"title": "yParity",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						},
+						{
+							"title": "Signed Legacy Transaction",
+							"type": "object",
+							"required": [
+								"gas",
+								"gasPrice",
+								"input",
+								"nonce",
+								"r",
+								"s",
+								"type",
+								"v",
+								"value"
+							],
+							"properties": {
+								"type": {
+									"title": "type",
+									"type": "string",
+									"pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+								},
+								"nonce": {
+									"title": "nonce",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"to": {
+									"title": "to address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								"gas": {
+									"title": "gas limit",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"value": {
+									"title": "value",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"input": {
+									"title": "input data",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								},
+								"gasPrice": {
+									"title": "gas price",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "The gas price willing to be paid by the sender in wei"
+								},
+								"chainId": {
+									"title": "chainId",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+									"description": "Chain ID that this transaction is valid on."
+								},
+								"v": {
+									"title": "v",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"r": {
+									"title": "r",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								},
+								"s": {
+									"title": "s",
+									"type": "string",
+									"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+								}
+							}
+						}
+					],
+					"properties": {
+						"blockHash": {
+							"title": "block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"blockNumber": {
+							"title": "block number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"from": {
+							"title": "from address",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"hash": {
+							"title": "transaction hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactionIndex": {
+							"title": "transaction index",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "eth_getTransactionReceipt",
+			"summary": "Returns the receipt of a transaction by transaction hash.",
+			"params": [
+				{
+					"name": "Transaction hash",
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Receipt Information",
+				"schema": {
+					"type": "object",
+					"title": "Receipt info",
+					"required": [
+						"blockHash",
+						"blockNumber",
+						"from",
+						"cumulativeGasUsed",
+						"gasUsed",
+						"logs",
+						"logsBloom",
+						"transactionHash",
+						"transactionIndex",
+						"effectiveGasPrice"
+					],
+					"properties": {
+						"transactionHash": {
+							"title": "transaction hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactionIndex": {
+							"title": "transaction index",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"blockHash": {
+							"title": "block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"blockNumber": {
+							"title": "block number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+						},
+						"from": {
+							"title": "from",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"to": {
+							"title": "to",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$",
+							"description": "Address of the receiver or null in a contract creation transaction."
+						},
+						"cumulativeGasUsed": {
+							"title": "cumulative gas used",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+							"description": "The sum of gas used by this transaction and all preceding transactions in the same block."
+						},
+						"gasUsed": {
+							"title": "gas used",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+							"description": "The amount of gas used for this specific transaction alone."
+						},
+						"contractAddress": {
+							"title": "contract address",
+							"description": "The contract address created, if the transaction was a contract creation, otherwise null.",
+							"oneOf": [
+								{
+									"title": "hex encoded address",
+									"type": "string",
+									"pattern": "^0x[0-9,a-f,A-F]{40}$"
+								},
+								{
+									"name": null,
+									"type": "null"
+								}
+							]
+						},
+						"logs": {
+							"title": "logs",
+							"type": "array",
+							"items": {
+								"title": "log",
+								"type": "object",
+								"required": [
+									"transactionHash"
+								],
+								"properties": {
+									"removed": {
+										"title": "removed",
+										"type": "boolean"
+									},
+									"logIndex": {
+										"title": "log index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionIndex": {
+										"title": "transaction index",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"transactionHash": {
+										"title": "transaction hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockHash": {
+										"title": "block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockNumber": {
+										"title": "block number",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+									},
+									"address": {
+										"title": "address",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"data": {
+										"title": "data",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]*$"
+									},
+									"topics": {
+										"title": "topics",
+										"type": "array",
+										"items": {
+											"title": "32 hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										}
+									}
+								}
+							}
+						},
+						"logsBloom": {
+							"title": "logs bloom",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{512}$"
+						},
+						"root": {
+							"title": "state root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$",
+							"description": "The post-transaction state root. Only specified for transactions included before the Byzantium upgrade."
+						},
+						"status": {
+							"title": "status",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+							"description": "Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade."
+						},
+						"effectiveGasPrice": {
+							"title": "effective gas price",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+							"description": "The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas)."
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "debug_getRawHeader",
+			"summary": "Returns an RLP-encoded header.",
+			"params": [
+				{
+					"name": "Block",
+					"required": true,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Header RLP",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "debug_getRawBlock",
+			"summary": "Returns an RLP-encoded block.",
+			"params": [
+				{
+					"name": "Block",
+					"required": true,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Block RLP",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "debug_getRawTransaction",
+			"summary": "Returns an array of EIP-2718 binary-encoded transactions.",
+			"params": [
+				{
+					"name": "Transaction hash",
+					"required": true,
+					"schema": {
+						"title": "32 byte hex value",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{64}$"
+					}
+				}
+			],
+			"result": {
+				"name": "EIP-2718 binary-encoded transaction",
+				"schema": {
+					"title": "hex encoded bytes",
+					"type": "string",
+					"pattern": "^0x[0-9a-f]*$"
+				}
+			}
+		},
+		{
+			"name": "debug_getRawReceipts",
+			"summary": "Returns an array of EIP-2718 binary-encoded receipts.",
+			"params": [
+				{
+					"name": "Block",
+					"required": true,
+					"schema": {
+						"title": "Block number or tag",
+						"oneOf": [
+							{
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+							},
+							{
+								"title": "Block tag",
+								"type": "string",
+								"enum": [
+									"earliest",
+									"finalized",
+									"safe",
+									"latest",
+									"pending"
+								],
+								"description": "`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error"
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Receipts",
+				"schema": {
+					"title": "Receipt array",
+					"type": "array",
+					"items": {
+						"title": "hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]*$"
+					}
+				}
+			}
+		},
+		{
+			"name": "debug_getBadBlocks",
+			"summary": "Returns an array of recent bad blocks that the client has seen on the network.",
+			"params": [],
+			"result": {
+				"name": "Blocks",
+				"schema": {
+					"title": "Bad block array",
+					"type": "array",
+					"items": {
+						"title": "Bad block",
+						"type": "object",
+						"required": [
+							"block",
+							"hash",
+							"rlp"
+						],
+						"properties": {
+							"block": {
+								"title": "Block",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							},
+							"hash": {
+								"title": "Hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"rlp": {
+								"title": "RLP",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "engine_exchangeCapabilities",
+			"summary": "Exchanges list of supported Engine API methods",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#engine_exchangecapabilities"
+			},
+			"params": [
+				{
+					"name": "Consensus client methods",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Execution client methods",
+				"schema": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		{
+			"name": "engine_forkchoiceUpdatedV1",
+			"summary": "Updates the forkchoice state",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_forkchoiceupdatedv1"
+			},
+			"params": [
+				{
+					"name": "Forkchoice state",
+					"required": true,
+					"schema": {
+						"title": "Forkchoice state object V1",
+						"type": "object",
+						"required": [
+							"headBlockHash",
+							"safeBlockHash",
+							"finalizedBlockHash"
+						],
+						"properties": {
+							"headBlockHash": {
+								"title": "Head block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"safeBlockHash": {
+								"title": "Safe block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"finalizedBlockHash": {
+								"title": "Finalized block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						}
+					}
+				},
+				{
+					"name": "Payload attributes",
+					"required": false,
+					"schema": {
+						"title": "Payload attributes object V1",
+						"type": "object",
+						"required": [
+							"timestamp",
+							"prevRandao",
+							"suggestedFeeRecipient"
+						],
+						"properties": {
+							"timestamp": {
+								"title": "Timestamp",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							},
+							"prevRandao": {
+								"title": "Previous randao value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"suggestedFeeRecipient": {
+								"title": "Suggested fee recipient",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Response object",
+				"schema": {
+					"title": "Forkchoice updated response",
+					"type": "object",
+					"required": [
+						"payloadStatus"
+					],
+					"properties": {
+						"payloadStatus": {
+							"title": "Payload status",
+							"type": "object",
+							"required": [
+								"status"
+							],
+							"properties": {
+								"status": {
+									"title": "Payload validation status",
+									"type": "string",
+									"enum": [
+										"VALID",
+										"INVALID",
+										"SYNCING"
+									],
+									"description": "Set of possible values is restricted to VALID, INVALID, SYNCING"
+								},
+								"latestValidHash": {
+									"title": "The hash of the most recent valid block",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]{64}$"
+								},
+								"validationError": {
+									"title": "Validation error message",
+									"type": "string"
+								}
+							}
+						},
+						"payloadId": {
+							"title": "Payload id",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{16}$"
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -38002,
+					"message": "Invalid forkchoice state"
+				},
+				{
+					"code": -38003,
+					"message": "Invalid payload attributes"
+				}
+			]
+		},
+		{
+			"name": "engine_forkchoiceUpdatedV2",
+			"summary": "Updates the forkchoice state",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2"
+			},
+			"params": [
+				{
+					"name": "Forkchoice state",
+					"required": true,
+					"schema": {
+						"title": "Forkchoice state object V1",
+						"type": "object",
+						"required": [
+							"headBlockHash",
+							"safeBlockHash",
+							"finalizedBlockHash"
+						],
+						"properties": {
+							"headBlockHash": {
+								"title": "Head block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"safeBlockHash": {
+								"title": "Safe block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"finalizedBlockHash": {
+								"title": "Finalized block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							}
+						}
+					}
+				},
+				{
+					"name": "Payload attributes",
+					"required": false,
+					"schema": {
+						"title": "Payload attributes object V2",
+						"type": "object",
+						"required": [
+							"timestamp",
+							"prevRandao",
+							"suggestedFeeRecipient",
+							"withdrawals"
+						],
+						"properties": {
+							"timestamp": {
+								"title": "Timestamp",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							},
+							"prevRandao": {
+								"title": "Previous randao value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"suggestedFeeRecipient": {
+								"title": "Suggested fee recipient",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"withdrawals": {
+								"title": "Withdrawals",
+								"type": "array",
+								"items": {
+									"title": "Withdrawal object V1",
+									"type": "object",
+									"required": [
+										"index",
+										"validatorIndex",
+										"address",
+										"amount"
+									],
+									"properties": {
+										"index": {
+											"title": "Withdrawal index",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"validatorIndex": {
+											"title": "Validator index",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"address": {
+											"title": "Withdrawal address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"amount": {
+											"title": "Withdrawal amount",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Response object",
+				"schema": {
+					"title": "Forkchoice updated response",
+					"type": "object",
+					"required": [
+						"payloadStatus"
+					],
+					"properties": {
+						"payloadStatus": {
+							"title": "Payload status",
+							"type": "object",
+							"required": [
+								"status"
+							],
+							"properties": {
+								"status": {
+									"title": "Payload validation status",
+									"type": "string",
+									"enum": [
+										"VALID",
+										"INVALID",
+										"SYNCING"
+									],
+									"description": "Set of possible values is restricted to VALID, INVALID, SYNCING"
+								},
+								"latestValidHash": {
+									"title": "The hash of the most recent valid block",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]{64}$"
+								},
+								"validationError": {
+									"title": "Validation error message",
+									"type": "string"
+								}
+							}
+						},
+						"payloadId": {
+							"title": "Payload id",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{16}$"
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -38002,
+					"message": "Invalid forkchoice state"
+				},
+				{
+					"code": -38003,
+					"message": "Invalid payload attributes"
+				}
+			]
+		},
+		{
+			"name": "engine_newPayloadV1",
+			"summary": "Runs execution payload validation",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_newpayloadv1"
+			},
+			"params": [
+				{
+					"name": "Execution payload",
+					"required": true,
+					"schema": {
+						"title": "Execution payload object V1",
+						"type": "object",
+						"required": [
+							"parentHash",
+							"feeRecipient",
+							"stateRoot",
+							"receiptsRoot",
+							"logsBloom",
+							"prevRandao",
+							"blockNumber",
+							"gasLimit",
+							"gasUsed",
+							"timestamp",
+							"extraData",
+							"baseFeePerGas",
+							"blockHash",
+							"transactions"
+						],
+						"properties": {
+							"parentHash": {
+								"title": "Parent block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"feeRecipient": {
+								"title": "Recipient of transaction priority fees",
+								"type": "string",
+								"pattern": "^0x[0-9,a-f,A-F]{40}$"
+							},
+							"stateRoot": {
+								"title": "State root",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"receiptsRoot": {
+								"title": "Receipts root",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"logsBloom": {
+								"title": "Bloom filter",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{512}$"
+							},
+							"prevRandao": {
+								"title": "Previous randao value",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"blockNumber": {
+								"title": "Block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							},
+							"gasLimit": {
+								"title": "Gas limit",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							},
+							"gasUsed": {
+								"title": "Gas used",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							},
+							"timestamp": {
+								"title": "Timestamp",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							},
+							"extraData": {
+								"title": "Extra data",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{0,64}$"
+							},
+							"baseFeePerGas": {
+								"title": "Base fee per gas",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+							},
+							"blockHash": {
+								"title": "Block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"transactions": {
+								"title": "Transactions",
+								"type": "array",
+								"items": {
+									"title": "hex encoded bytes",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								}
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Payload status",
+				"schema": {
+					"title": "Payload status object V1",
+					"type": "object",
+					"required": [
+						"status"
+					],
+					"properties": {
+						"status": {
+							"title": "Payload validation status",
+							"type": "string",
+							"enum": [
+								"VALID",
+								"INVALID",
+								"SYNCING",
+								"ACCEPTED",
+								"INVALID_BLOCK_HASH"
+							]
+						},
+						"latestValidHash": {
+							"title": "The hash of the most recent valid block",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"validationError": {
+							"title": "Validation error message",
+							"type": "string"
+						}
+					}
+				}
+			}
+		},
+		{
+			"name": "engine_newPayloadV2",
+			"summary": "Runs execution payload validation",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_newpayloadv2"
+			},
+			"params": [
+				{
+					"name": "Execution payload",
+					"required": true,
+					"schema": {
+						"oneOf": [
+							{
+								"title": "Execution payload object V1",
+								"type": "object",
+								"required": [
+									"parentHash",
+									"feeRecipient",
+									"stateRoot",
+									"receiptsRoot",
+									"logsBloom",
+									"prevRandao",
+									"blockNumber",
+									"gasLimit",
+									"gasUsed",
+									"timestamp",
+									"extraData",
+									"baseFeePerGas",
+									"blockHash",
+									"transactions"
+								],
+								"properties": {
+									"parentHash": {
+										"title": "Parent block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"feeRecipient": {
+										"title": "Recipient of transaction priority fees",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"stateRoot": {
+										"title": "State root",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"receiptsRoot": {
+										"title": "Receipts root",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"logsBloom": {
+										"title": "Bloom filter",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{512}$"
+									},
+									"prevRandao": {
+										"title": "Previous randao value",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockNumber": {
+										"title": "Block number",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"gasLimit": {
+										"title": "Gas limit",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"gasUsed": {
+										"title": "Gas used",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"timestamp": {
+										"title": "Timestamp",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"extraData": {
+										"title": "Extra data",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{0,64}$"
+									},
+									"baseFeePerGas": {
+										"title": "Base fee per gas",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+									},
+									"blockHash": {
+										"title": "Block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"transactions": {
+										"title": "Transactions",
+										"type": "array",
+										"items": {
+											"title": "hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]*$"
+										}
+									}
+								}
+							},
+							{
+								"title": "Execution payload object V2",
+								"type": "object",
+								"required": [
+									"parentHash",
+									"feeRecipient",
+									"stateRoot",
+									"receiptsRoot",
+									"logsBloom",
+									"prevRandao",
+									"blockNumber",
+									"gasLimit",
+									"gasUsed",
+									"timestamp",
+									"extraData",
+									"baseFeePerGas",
+									"blockHash",
+									"transactions",
+									"withdrawals"
+								],
+								"properties": {
+									"parentHash": {
+										"title": "Parent block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"feeRecipient": {
+										"title": "Recipient of transaction priority fees",
+										"type": "string",
+										"pattern": "^0x[0-9,a-f,A-F]{40}$"
+									},
+									"stateRoot": {
+										"title": "State root",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"receiptsRoot": {
+										"title": "Receipts root",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"logsBloom": {
+										"title": "Bloom filter",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{512}$"
+									},
+									"prevRandao": {
+										"title": "Previous randao value",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"blockNumber": {
+										"title": "Block number",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"gasLimit": {
+										"title": "Gas limit",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"gasUsed": {
+										"title": "Gas used",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"timestamp": {
+										"title": "Timestamp",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+									},
+									"extraData": {
+										"title": "Extra data",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{0,64}$"
+									},
+									"baseFeePerGas": {
+										"title": "Base fee per gas",
+										"type": "string",
+										"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+									},
+									"blockHash": {
+										"title": "Block hash",
+										"type": "string",
+										"pattern": "^0x[0-9a-f]{64}$"
+									},
+									"transactions": {
+										"title": "Transactions",
+										"type": "array",
+										"items": {
+											"title": "hex encoded bytes",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]*$"
+										}
+									},
+									"withdrawals": {
+										"title": "Withdrawals",
+										"type": "array",
+										"items": {
+											"title": "Withdrawal object V1",
+											"type": "object",
+											"required": [
+												"index",
+												"validatorIndex",
+												"address",
+												"amount"
+											],
+											"properties": {
+												"index": {
+													"title": "Withdrawal index",
+													"type": "string",
+													"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+												},
+												"validatorIndex": {
+													"title": "Validator index",
+													"type": "string",
+													"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+												},
+												"address": {
+													"title": "Withdrawal address",
+													"type": "string",
+													"pattern": "^0x[0-9,a-f,A-F]{40}$"
+												},
+												"amount": {
+													"title": "Withdrawal amount",
+													"type": "string",
+													"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+												}
+											}
+										}
+									}
+								}
+							}
+						]
+					}
+				}
+			],
+			"result": {
+				"name": "Payload status",
+				"schema": {
+					"title": "Payload status object deprecating INVALID_BLOCK_HASH status",
+					"type": "object",
+					"required": [
+						"status"
+					],
+					"properties": {
+						"status": {
+							"title": "Payload validation status",
+							"type": "string",
+							"enum": [
+								"VALID",
+								"INVALID",
+								"SYNCING",
+								"ACCEPTED"
+							]
+						},
+						"latestValidHash": {
+							"title": "The hash of the most recent valid block",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"validationError": {
+							"title": "Validation error message",
+							"type": "string"
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -32602,
+					"message": "Invalid params"
+				}
+			]
+		},
+		{
+			"name": "engine_getPayloadV1",
+			"summary": "Obtains execution payload from payload build process",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_getpayloadv1"
+			},
+			"params": [
+				{
+					"name": "Payload id",
+					"required": true,
+					"schema": {
+						"title": "8 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{16}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Execution payload",
+				"schema": {
+					"title": "Execution payload object V1",
+					"type": "object",
+					"required": [
+						"parentHash",
+						"feeRecipient",
+						"stateRoot",
+						"receiptsRoot",
+						"logsBloom",
+						"prevRandao",
+						"blockNumber",
+						"gasLimit",
+						"gasUsed",
+						"timestamp",
+						"extraData",
+						"baseFeePerGas",
+						"blockHash",
+						"transactions"
+					],
+					"properties": {
+						"parentHash": {
+							"title": "Parent block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"feeRecipient": {
+							"title": "Recipient of transaction priority fees",
+							"type": "string",
+							"pattern": "^0x[0-9,a-f,A-F]{40}$"
+						},
+						"stateRoot": {
+							"title": "State root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"receiptsRoot": {
+							"title": "Receipts root",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"logsBloom": {
+							"title": "Bloom filter",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{512}$"
+						},
+						"prevRandao": {
+							"title": "Previous randao value",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"blockNumber": {
+							"title": "Block number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+						},
+						"gasLimit": {
+							"title": "Gas limit",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+						},
+						"gasUsed": {
+							"title": "Gas used",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+						},
+						"timestamp": {
+							"title": "Timestamp",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+						},
+						"extraData": {
+							"title": "Extra data",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{0,64}$"
+						},
+						"baseFeePerGas": {
+							"title": "Base fee per gas",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+						},
+						"blockHash": {
+							"title": "Block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"transactions": {
+							"title": "Transactions",
+							"type": "array",
+							"items": {
+								"title": "hex encoded bytes",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]*$"
+							}
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -38001,
+					"message": "Unknown payload"
+				}
+			]
+		},
+		{
+			"name": "engine_getPayloadV2",
+			"summary": "Obtains execution payload from payload build process",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadv2"
+			},
+			"params": [
+				{
+					"name": "Payload id",
+					"required": true,
+					"schema": {
+						"title": "8 hex encoded bytes",
+						"type": "string",
+						"pattern": "^0x[0-9a-f]{16}$"
+					}
+				}
+			],
+			"result": {
+				"name": "Response object",
+				"schema": {
+					"type": "object",
+					"required": [
+						"executionPayload",
+						"blockValue"
+					],
+					"properties": {
+						"executionPayload": {
+							"title": "Execution payload",
+							"oneOf": [
+								{
+									"title": "Execution payload object V1",
+									"type": "object",
+									"required": [
+										"parentHash",
+										"feeRecipient",
+										"stateRoot",
+										"receiptsRoot",
+										"logsBloom",
+										"prevRandao",
+										"blockNumber",
+										"gasLimit",
+										"gasUsed",
+										"timestamp",
+										"extraData",
+										"baseFeePerGas",
+										"blockHash",
+										"transactions"
+									],
+									"properties": {
+										"parentHash": {
+											"title": "Parent block hash",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"feeRecipient": {
+											"title": "Recipient of transaction priority fees",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"stateRoot": {
+											"title": "State root",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"receiptsRoot": {
+											"title": "Receipts root",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"logsBloom": {
+											"title": "Bloom filter",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{512}$"
+										},
+										"prevRandao": {
+											"title": "Previous randao value",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"blockNumber": {
+											"title": "Block number",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"gasLimit": {
+											"title": "Gas limit",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"gasUsed": {
+											"title": "Gas used",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"timestamp": {
+											"title": "Timestamp",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"extraData": {
+											"title": "Extra data",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{0,64}$"
+										},
+										"baseFeePerGas": {
+											"title": "Base fee per gas",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+										},
+										"blockHash": {
+											"title": "Block hash",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"transactions": {
+											"title": "Transactions",
+											"type": "array",
+											"items": {
+												"title": "hex encoded bytes",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]*$"
+											}
+										}
+									}
+								},
+								{
+									"title": "Execution payload object V2",
+									"type": "object",
+									"required": [
+										"parentHash",
+										"feeRecipient",
+										"stateRoot",
+										"receiptsRoot",
+										"logsBloom",
+										"prevRandao",
+										"blockNumber",
+										"gasLimit",
+										"gasUsed",
+										"timestamp",
+										"extraData",
+										"baseFeePerGas",
+										"blockHash",
+										"transactions",
+										"withdrawals"
+									],
+									"properties": {
+										"parentHash": {
+											"title": "Parent block hash",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"feeRecipient": {
+											"title": "Recipient of transaction priority fees",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"stateRoot": {
+											"title": "State root",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"receiptsRoot": {
+											"title": "Receipts root",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"logsBloom": {
+											"title": "Bloom filter",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{512}$"
+										},
+										"prevRandao": {
+											"title": "Previous randao value",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"blockNumber": {
+											"title": "Block number",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"gasLimit": {
+											"title": "Gas limit",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"gasUsed": {
+											"title": "Gas used",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"timestamp": {
+											"title": "Timestamp",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"extraData": {
+											"title": "Extra data",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{0,64}$"
+										},
+										"baseFeePerGas": {
+											"title": "Base fee per gas",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+										},
+										"blockHash": {
+											"title": "Block hash",
+											"type": "string",
+											"pattern": "^0x[0-9a-f]{64}$"
+										},
+										"transactions": {
+											"title": "Transactions",
+											"type": "array",
+											"items": {
+												"title": "hex encoded bytes",
+												"type": "string",
+												"pattern": "^0x[0-9a-f]*$"
+											}
+										},
+										"withdrawals": {
+											"title": "Withdrawals",
+											"type": "array",
+											"items": {
+												"title": "Withdrawal object V1",
+												"type": "object",
+												"required": [
+													"index",
+													"validatorIndex",
+													"address",
+													"amount"
+												],
+												"properties": {
+													"index": {
+														"title": "Withdrawal index",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+													},
+													"validatorIndex": {
+														"title": "Validator index",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+													},
+													"address": {
+														"title": "Withdrawal address",
+														"type": "string",
+														"pattern": "^0x[0-9,a-f,A-F]{40}$"
+													},
+													"amount": {
+														"title": "Withdrawal amount",
+														"type": "string",
+														"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+													}
+												}
+											}
+										}
+									}
+								}
+							]
+						},
+						"blockValue": {
+							"title": "Expected fee value",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -38001,
+					"message": "Unknown payload"
+				}
+			]
+		},
+		{
+			"name": "engine_getPayloadBodiesByHashV1",
+			"summary": "Given block hashes returns bodies of the corresponding execution payloads",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1"
+			},
+			"params": [
+				{
+					"name": "Array of block hashes",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"title": "32 byte hex value",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Execution payload bodies",
+				"schema": {
+					"type": "array",
+					"items": {
+						"title": "Execution payload body object V1",
+						"type": "object",
+						"required": [
+							"transactions"
+						],
+						"properties": {
+							"transactions": {
+								"title": "Transactions",
+								"type": "array",
+								"items": {
+									"title": "hex encoded bytes",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								}
+							},
+							"withdrawals": {
+								"title": "Withdrawals",
+								"type": [
+									"array",
+									"null"
+								],
+								"items": {
+									"title": "Withdrawal object V1",
+									"type": "object",
+									"required": [
+										"index",
+										"validatorIndex",
+										"address",
+										"amount"
+									],
+									"properties": {
+										"index": {
+											"title": "Withdrawal index",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"validatorIndex": {
+											"title": "Validator index",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"address": {
+											"title": "Withdrawal address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"amount": {
+											"title": "Withdrawal amount",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -38004,
+					"message": "Too large request"
+				}
+			]
+		},
+		{
+			"name": "engine_getPayloadBodiesByRangeV1",
+			"summary": "Given a range of block numbers returns bodies of the corresponding execution payloads",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadbodiesbyrangev1"
+			},
+			"params": [
+				{
+					"name": "Starting block number",
+					"required": true,
+					"schema": {
+						"title": "hex encoded 64 bit unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+					}
+				},
+				{
+					"name": "Number of blocks to return",
+					"required": true,
+					"schema": {
+						"title": "hex encoded 64 bit unsigned integer",
+						"type": "string",
+						"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+					}
+				}
+			],
+			"result": {
+				"name": "Execution payload bodies",
+				"schema": {
+					"type": "array",
+					"items": {
+						"title": "Execution payload body object V1",
+						"type": "object",
+						"required": [
+							"transactions"
+						],
+						"properties": {
+							"transactions": {
+								"title": "Transactions",
+								"type": "array",
+								"items": {
+									"title": "hex encoded bytes",
+									"type": "string",
+									"pattern": "^0x[0-9a-f]*$"
+								}
+							},
+							"withdrawals": {
+								"title": "Withdrawals",
+								"type": [
+									"array",
+									"null"
+								],
+								"items": {
+									"title": "Withdrawal object V1",
+									"type": "object",
+									"required": [
+										"index",
+										"validatorIndex",
+										"address",
+										"amount"
+									],
+									"properties": {
+										"index": {
+											"title": "Withdrawal index",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"validatorIndex": {
+											"title": "Validator index",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										},
+										"address": {
+											"title": "Withdrawal address",
+											"type": "string",
+											"pattern": "^0x[0-9,a-f,A-F]{40}$"
+										},
+										"amount": {
+											"title": "Withdrawal amount",
+											"type": "string",
+											"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			},
+			"errors": [
+				{
+					"code": -38004,
+					"message": "Too large request"
+				}
+			]
+		},
+		{
+			"name": "engine_exchangeTransitionConfigurationV1",
+			"summary": "Exchanges transition configuration",
+			"externalDocs": {
+				"description": "Method specification",
+				"url": "https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#engine_exchangetransitionconfigurationv1"
+			},
+			"params": [
+				{
+					"name": "Consensus client configuration",
+					"required": true,
+					"schema": {
+						"title": "Transition configuration object",
+						"type": "object",
+						"required": [
+							"terminalTotalDifficulty",
+							"terminalBlockHash",
+							"terminalBlockNumber"
+						],
+						"properties": {
+							"terminalTotalDifficulty": {
+								"title": "Terminal total difficulty",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+							},
+							"terminalBlockHash": {
+								"title": "Terminal block hash",
+								"type": "string",
+								"pattern": "^0x[0-9a-f]{64}$"
+							},
+							"terminalBlockNumber": {
+								"title": "Terminal block number",
+								"type": "string",
+								"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+							}
+						}
+					}
+				}
+			],
+			"result": {
+				"name": "Execution client configuration",
+				"schema": {
+					"title": "Transition configuration object",
+					"type": "object",
+					"required": [
+						"terminalTotalDifficulty",
+						"terminalBlockHash",
+						"terminalBlockNumber"
+					],
+					"properties": {
+						"terminalTotalDifficulty": {
+							"title": "Terminal total difficulty",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+						},
+						"terminalBlockHash": {
+							"title": "Terminal block hash",
+							"type": "string",
+							"pattern": "^0x[0-9a-f]{64}$"
+						},
+						"terminalBlockNumber": {
+							"title": "Terminal block number",
+							"type": "string",
+							"pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+						}
+					}
+				}
+			}
+		}
+	],
+	"components": {}
+}

--- a/rpctypes/schemas/rpcschemaaccountlist.json
+++ b/rpctypes/schemas/rpcschemaaccountlist.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "items": [
+        {
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-Z]{40}$"
+        }
+    ]
+}

--- a/rpctypes/schemas/rpcschemaaccountlist.json
+++ b/rpctypes/schemas/rpcschemaaccountlist.json
@@ -1,10 +1,9 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "array",
-    "items": [
-        {
-            "type": "string",
-            "pattern": "^0x[0-9a-fA-Z]{40}$"
-        }
-    ]
+  "title": "Accounts",
+  "type": "array",
+  "items": {
+    "title": "hex encoded address",
+    "type": "string",
+    "pattern": "^0x[0-9,a-f,A-F]{40}$"
+  }
 }

--- a/rpctypes/schemas/rpcschemaethblock.json
+++ b/rpctypes/schemas/rpcschemaethblock.json
@@ -1,113 +1,469 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "object",
-    "properties": {
-        "baseFeePerGas": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "difficulty": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "extraData": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "gasLimit": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,16}$"
-        },
-        "gasUsed": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,16}$"
-        },
-        "hash": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "logsBloom": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{512}$"
-        },
-        "miner": {
-            "type": "string",
-            "pattern": "^0x[0-9a-fA-Z]{40}$"
-        },
-        "mixHash": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "nonce": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,16}$"
-        },
-        "number": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "parentHash": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "receiptsRoot": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "sha3Uncles": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "size": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "stateRoot": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "timestamp": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "totalDifficulty": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
-        },
-        "transactions": {
-            "type": "array",
-            "items": {}
-        },
-        "transactionsRoot": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{64}$"
-        },
-        "uncles": {
-            "type": "array",
-            "items": {}
-        }
+  "title": "Block object",
+  "type": "object",
+  "required": [
+    "parentHash",
+    "sha3Uncles",
+    "miner",
+    "stateRoot",
+    "transactionsRoot",
+    "receiptsRoot",
+    "logsBloom",
+    "number",
+    "gasLimit",
+    "gasUsed",
+    "timestamp",
+    "extraData",
+    "mixHash",
+    "nonce",
+    "size",
+    "transactions",
+    "uncles"
+  ],
+  "properties": {
+    "parentHash": {
+      "title": "Parent block hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
     },
-    "required": [
-        "baseFeePerGas",
-        "difficulty",
-        "extraData",
-        "gasLimit",
-        "gasUsed",
-        "hash",
-        "logsBloom",
-        "miner",
-        "mixHash",
-        "nonce",
-        "number",
-        "parentHash",
-        "receiptsRoot",
-        "sha3Uncles",
-        "size",
-        "stateRoot",
-        "timestamp",
-        "totalDifficulty",
-        "transactions",
-        "transactionsRoot",
-        "uncles"
-    ]
+    "sha3Uncles": {
+      "title": "Ommers hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "miner": {
+      "title": "Coinbase",
+      "type": "string",
+      "pattern": "^0x[0-9,a-f,A-F]{40}$"
+    },
+    "stateRoot": {
+      "title": "State root",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "transactionsRoot": {
+      "title": "Transactions root",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "receiptsRoot": {
+      "title": "Receipts root",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "logsBloom": {
+      "title": "Bloom filter",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{512}$"
+    },
+    "difficulty": {
+      "title": "Difficulty",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]*$"
+    },
+    "number": {
+      "title": "Number",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "gasLimit": {
+      "title": "Gas limit",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "gasUsed": {
+      "title": "Gas used",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "timestamp": {
+      "title": "Timestamp",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "extraData": {
+      "title": "Extra data",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]*$"
+    },
+    "mixHash": {
+      "title": "Mix hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "nonce": {
+      "title": "Nonce",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{16}$"
+    },
+    "totalDifficulty": {
+      "title": "Total difficulty",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "baseFeePerGas": {
+      "title": "Base fee per gas",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "withdrawalsRoot": {
+      "title": "Withdrawals root",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "size": {
+      "title": "Block size",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "transactions": {
+      "anyOf": [
+        {
+          "title": "Transaction hashes",
+          "type": "array",
+          "items": {
+            "title": "32 byte hex value",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+          }
+        },
+        {
+          "title": "Full transactions",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "title": "Signed 1559 Transaction",
+                "type": "object",
+                "required": [
+                  "accessList",
+                  "chainId",
+                  "gas",
+                  "input",
+                  "maxFeePerGas",
+                  "maxPriorityFeePerGas",
+                  "nonce",
+                  "r",
+                  "s",
+                  "type",
+                  "value",
+                  "yParity"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "type",
+                    "type": "string",
+                    "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+                  },
+                  "nonce": {
+                    "title": "nonce",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "to": {
+                    "title": "to address",
+                    "type": "string",
+                    "pattern": "^0x[0-9,a-f,A-F]{40}$"
+                  },
+                  "gas": {
+                    "title": "gas limit",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "value": {
+                    "title": "value",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "input": {
+                    "title": "input data",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]*$"
+                  },
+                  "maxPriorityFeePerGas": {
+                    "title": "max priority fee per gas",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+                  },
+                  "maxFeePerGas": {
+                    "title": "max fee per gas",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+                  },
+                  "accessList": {
+                    "title": "accessList",
+                    "type": "array",
+                    "description": "EIP-2930 access list",
+                    "items": {
+                      "title": "Access list entry",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "title": "hex encoded address",
+                          "type": "string",
+                          "pattern": "^0x[0-9,a-f,A-F]{40}$"
+                        },
+                        "storageKeys": {
+                          "type": "array",
+                          "items": {
+                            "title": "32 byte hex value",
+                            "type": "string",
+                            "pattern": "^0x[0-9a-f]{64}$"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chainId": {
+                    "title": "chainId",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "Chain ID that this transaction is valid on."
+                  },
+                  "yParity": {
+                    "title": "yParity",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+                  },
+                  "r": {
+                    "title": "r",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "s": {
+                    "title": "s",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  }
+                }
+              },
+              {
+                "title": "Signed 2930 Transaction",
+                "type": "object",
+                "required": [
+                  "accessList",
+                  "chainId",
+                  "gas",
+                  "gasPrice",
+                  "input",
+                  "nonce",
+                  "r",
+                  "s",
+                  "type",
+                  "value",
+                  "yParity"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "type",
+                    "type": "string",
+                    "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+                  },
+                  "nonce": {
+                    "title": "nonce",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "to": {
+                    "title": "to address",
+                    "type": "string",
+                    "pattern": "^0x[0-9,a-f,A-F]{40}$"
+                  },
+                  "gas": {
+                    "title": "gas limit",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "value": {
+                    "title": "value",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "input": {
+                    "title": "input data",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]*$"
+                  },
+                  "gasPrice": {
+                    "title": "gas price",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The gas price willing to be paid by the sender in wei"
+                  },
+                  "accessList": {
+                    "title": "accessList",
+                    "type": "array",
+                    "description": "EIP-2930 access list",
+                    "items": {
+                      "title": "Access list entry",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "title": "hex encoded address",
+                          "type": "string",
+                          "pattern": "^0x[0-9,a-f,A-F]{40}$"
+                        },
+                        "storageKeys": {
+                          "type": "array",
+                          "items": {
+                            "title": "32 byte hex value",
+                            "type": "string",
+                            "pattern": "^0x[0-9a-f]{64}$"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "chainId": {
+                    "title": "chainId",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "Chain ID that this transaction is valid on."
+                  },
+                  "yParity": {
+                    "title": "yParity",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+                  },
+                  "r": {
+                    "title": "r",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "s": {
+                    "title": "s",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  }
+                }
+              },
+              {
+                "title": "Signed Legacy Transaction",
+                "type": "object",
+                "required": [
+                  "gas",
+                  "gasPrice",
+                  "input",
+                  "nonce",
+                  "r",
+                  "s",
+                  "type",
+                  "v",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "title": "type",
+                    "type": "string",
+                    "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+                  },
+                  "nonce": {
+                    "title": "nonce",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "to": {
+                    "title": "to address",
+                    "type": "string",
+                    "pattern": "^0x[0-9,a-f,A-F]{40}$"
+                  },
+                  "gas": {
+                    "title": "gas limit",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "value": {
+                    "title": "value",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "input": {
+                    "title": "input data",
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]*$"
+                  },
+                  "gasPrice": {
+                    "title": "gas price",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The gas price willing to be paid by the sender in wei"
+                  },
+                  "chainId": {
+                    "title": "chainId",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "Chain ID that this transaction is valid on."
+                  },
+                  "v": {
+                    "title": "v",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "r": {
+                    "title": "r",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  },
+                  "s": {
+                    "title": "s",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "withdrawals": {
+      "title": "Withdrawals",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "Validator withdrawal",
+        "required": [
+          "index",
+          "validatorIndex",
+          "address",
+          "amount"
+        ],
+        "properties": {
+          "index": {
+            "title": "index of withdrawal",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+          },
+          "validatorIndex": {
+            "title": "index of validator that generated withdrawal",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]{0,15})|0$"
+          },
+          "address": {
+            "title": "recipient address for withdrawal value",
+            "type": "string",
+            "pattern": "^0x[0-9,a-f,A-F]{40}$"
+          },
+          "amount": {
+            "title": "value contained in withdrawal",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]{0,31})|0$"
+          }
+        }
+      }
+    },
+    "uncles": {
+      "title": "Uncles",
+      "type": "array",
+      "items": {
+        "title": "32 byte hex value",
+        "type": "string",
+        "pattern": "^0x[0-9a-f]{64}$"
+      }
+    }
+  }
 }

--- a/rpctypes/schemas/rpcschemaethblock.json
+++ b/rpctypes/schemas/rpcschemaethblock.json
@@ -1,0 +1,113 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "baseFeePerGas": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "difficulty": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "extraData": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "gasLimit": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,16}$"
+        },
+        "gasUsed": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,16}$"
+        },
+        "hash": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "logsBloom": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{512}$"
+        },
+        "miner": {
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-Z]{40}$"
+        },
+        "mixHash": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "nonce": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,16}$"
+        },
+        "number": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "parentHash": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "receiptsRoot": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "sha3Uncles": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "size": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "stateRoot": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "timestamp": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "totalDifficulty": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "transactions": {
+            "type": "array",
+            "items": {}
+        },
+        "transactionsRoot": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+        },
+        "uncles": {
+            "type": "array",
+            "items": {}
+        }
+    },
+    "required": [
+        "baseFeePerGas",
+        "difficulty",
+        "extraData",
+        "gasLimit",
+        "gasUsed",
+        "hash",
+        "logsBloom",
+        "miner",
+        "mixHash",
+        "nonce",
+        "number",
+        "parentHash",
+        "receiptsRoot",
+        "sha3Uncles",
+        "size",
+        "stateRoot",
+        "timestamp",
+        "totalDifficulty",
+        "transactions",
+        "transactionsRoot",
+        "uncles"
+    ]
+}

--- a/rpctypes/schemas/rpcschemaethreceipt.json
+++ b/rpctypes/schemas/rpcschemaethreceipt.json
@@ -1,0 +1,160 @@
+{
+  "type": "object",
+  "title": "Receipt info",
+  "required": [
+    "blockHash",
+    "blockNumber",
+    "from",
+    "cumulativeGasUsed",
+    "gasUsed",
+    "logs",
+    "logsBloom",
+    "transactionHash",
+    "transactionIndex",
+    "effectiveGasPrice"
+  ],
+  "properties": {
+    "transactionHash": {
+      "title": "transaction hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "transactionIndex": {
+      "title": "transaction index",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "blockHash": {
+      "title": "block hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "blockNumber": {
+      "title": "block number",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "from": {
+      "title": "from",
+      "type": "string",
+      "pattern": "^0x[0-9,a-f,A-F]{40}$"
+    },
+    "to": {
+      "title": "to",
+      "type": "string",
+      "pattern": "^0x[0-9,a-f,A-F]{40}$",
+      "description": "Address of the receiver or null in a contract creation transaction."
+    },
+    "cumulativeGasUsed": {
+      "title": "cumulative gas used",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+      "description": "The sum of gas used by this transaction and all preceding transactions in the same block."
+    },
+    "gasUsed": {
+      "title": "gas used",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+      "description": "The amount of gas used for this specific transaction alone."
+    },
+    "contractAddress": {
+      "title": "contract address",
+      "description": "The contract address created, if the transaction was a contract creation, otherwise null.",
+      "oneOf": [
+        {
+          "title": "hex encoded address",
+          "type": "string",
+          "pattern": "^0x[0-9,a-f,A-F]{40}$"
+        },
+        {
+          "name": null,
+          "type": "null"
+        }
+      ]
+    },
+    "logs": {
+      "title": "logs",
+      "type": "array",
+      "items": {
+        "title": "log",
+        "type": "object",
+        "required": [
+          "transactionHash"
+        ],
+        "properties": {
+          "removed": {
+            "title": "removed",
+            "type": "boolean"
+          },
+          "logIndex": {
+            "title": "log index",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+          },
+          "transactionIndex": {
+            "title": "transaction index",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+          },
+          "transactionHash": {
+            "title": "transaction hash",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+          },
+          "blockHash": {
+            "title": "block hash",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+          },
+          "blockNumber": {
+            "title": "block number",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+          },
+          "address": {
+            "title": "address",
+            "type": "string",
+            "pattern": "^0x[0-9,a-f,A-F]{40}$"
+          },
+          "data": {
+            "title": "data",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]*$"
+          },
+          "topics": {
+            "title": "topics",
+            "type": "array",
+            "items": {
+              "title": "32 hex encoded bytes",
+              "type": "string",
+              "pattern": "^0x[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    },
+    "logsBloom": {
+      "title": "logs bloom",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{512}$"
+    },
+    "root": {
+      "title": "state root",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$",
+      "description": "The post-transaction state root. Only specified for transactions included before the Byzantium upgrade."
+    },
+    "status": {
+      "title": "status",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+      "description": "Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade."
+    },
+    "effectiveGasPrice": {
+      "title": "effective gas price",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+      "description": "The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas)."
+    }
+  }
+}

--- a/rpctypes/schemas/rpcschemaethsyncing.json
+++ b/rpctypes/schemas/rpcschemaethsyncing.json
@@ -4,13 +4,15 @@
     "properties": {
         "startingBlock": {
             "type": "string",
-            ""
+            "pattern": "^0x[0-9a-f]{1,}$"
         },
         "currentBlock": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
         },
         "highestBlock": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
         }
     },
     "required": [

--- a/rpctypes/schemas/rpcschemaethsyncing.json
+++ b/rpctypes/schemas/rpcschemaethsyncing.json
@@ -1,23 +1,31 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "object",
-    "properties": {
+  "title": "Syncing status",
+  "oneOf": [
+    {
+      "title": "Syncing progress",
+      "type": "object",
+      "properties": {
         "startingBlock": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
+          "title": "Starting block",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
         },
         "currentBlock": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
+          "title": "Current block",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
         },
         "highestBlock": {
-            "type": "string",
-            "pattern": "^0x[0-9a-f]{1,}$"
+          "title": "Highest block",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
         }
+      }
     },
-    "required": [
-        "startingBlock",
-        "currentBlock",
-        "highestBlock"
-    ]
+    {
+      "title": "Not syncing",
+      "description": "Should always return false if not syncing.",
+      "type": "boolean"
+    }
+  ]
 }

--- a/rpctypes/schemas/rpcschemaethsyncing.json
+++ b/rpctypes/schemas/rpcschemaethsyncing.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "startingBlock": {
+            "type": "string",
+            ""
+        },
+        "currentBlock": {
+            "type": "string"
+        },
+        "highestBlock": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "startingBlock",
+        "currentBlock",
+        "highestBlock"
+    ]
+}

--- a/rpctypes/schemas/rpcschemaethtransaction.json
+++ b/rpctypes/schemas/rpcschemaethtransaction.json
@@ -1,0 +1,323 @@
+{
+  "type": "object",
+  "title": "Transaction information",
+  "required": [
+    "blockHash",
+    "blockNumber",
+    "from",
+    "hash",
+    "transactionIndex"
+  ],
+  "oneOf": [
+    {
+      "title": "Signed 1559 Transaction",
+      "type": "object",
+      "required": [
+        "accessList",
+        "chainId",
+        "gas",
+        "input",
+        "maxFeePerGas",
+        "maxPriorityFeePerGas",
+        "nonce",
+        "r",
+        "s",
+        "type",
+        "value",
+        "yParity"
+      ],
+      "properties": {
+        "type": {
+          "title": "type",
+          "type": "string",
+          "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+        },
+        "nonce": {
+          "title": "nonce",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "to": {
+          "title": "to address",
+          "type": "string",
+          "pattern": "^0x[0-9,a-f,A-F]{40}$"
+        },
+        "gas": {
+          "title": "gas limit",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "value": {
+          "title": "value",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "input": {
+          "title": "input data",
+          "type": "string",
+          "pattern": "^0x[0-9a-f]*$"
+        },
+        "maxPriorityFeePerGas": {
+          "title": "max priority fee per gas",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+        },
+        "maxFeePerGas": {
+          "title": "max fee per gas",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+        },
+        "accessList": {
+          "title": "accessList",
+          "type": "array",
+          "description": "EIP-2930 access list",
+          "items": {
+            "title": "Access list entry",
+            "type": "object",
+            "properties": {
+              "address": {
+                "title": "hex encoded address",
+                "type": "string",
+                "pattern": "^0x[0-9,a-f,A-F]{40}$"
+              },
+              "storageKeys": {
+                "type": "array",
+                "items": {
+                  "title": "32 byte hex value",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]{64}$"
+                }
+              }
+            }
+          }
+        },
+        "chainId": {
+          "title": "chainId",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "Chain ID that this transaction is valid on."
+        },
+        "yParity": {
+          "title": "yParity",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+        },
+        "r": {
+          "title": "r",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "s": {
+          "title": "s",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        }
+      }
+    },
+    {
+      "title": "Signed 2930 Transaction",
+      "type": "object",
+      "required": [
+        "accessList",
+        "chainId",
+        "gas",
+        "gasPrice",
+        "input",
+        "nonce",
+        "r",
+        "s",
+        "type",
+        "value",
+        "yParity"
+      ],
+      "properties": {
+        "type": {
+          "title": "type",
+          "type": "string",
+          "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+        },
+        "nonce": {
+          "title": "nonce",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "to": {
+          "title": "to address",
+          "type": "string",
+          "pattern": "^0x[0-9,a-f,A-F]{40}$"
+        },
+        "gas": {
+          "title": "gas limit",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "value": {
+          "title": "value",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "input": {
+          "title": "input data",
+          "type": "string",
+          "pattern": "^0x[0-9a-f]*$"
+        },
+        "gasPrice": {
+          "title": "gas price",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "The gas price willing to be paid by the sender in wei"
+        },
+        "accessList": {
+          "title": "accessList",
+          "type": "array",
+          "description": "EIP-2930 access list",
+          "items": {
+            "title": "Access list entry",
+            "type": "object",
+            "properties": {
+              "address": {
+                "title": "hex encoded address",
+                "type": "string",
+                "pattern": "^0x[0-9,a-f,A-F]{40}$"
+              },
+              "storageKeys": {
+                "type": "array",
+                "items": {
+                  "title": "32 byte hex value",
+                  "type": "string",
+                  "pattern": "^0x[0-9a-f]{64}$"
+                }
+              }
+            }
+          }
+        },
+        "chainId": {
+          "title": "chainId",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "Chain ID that this transaction is valid on."
+        },
+        "yParity": {
+          "title": "yParity",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
+        },
+        "r": {
+          "title": "r",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "s": {
+          "title": "s",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        }
+      }
+    },
+    {
+      "title": "Signed Legacy Transaction",
+      "type": "object",
+      "required": [
+        "gas",
+        "gasPrice",
+        "input",
+        "nonce",
+        "r",
+        "s",
+        "type",
+        "v",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "title": "type",
+          "type": "string",
+          "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
+        },
+        "nonce": {
+          "title": "nonce",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "to": {
+          "title": "to address",
+          "type": "string",
+          "pattern": "^0x[0-9,a-f,A-F]{40}$"
+        },
+        "gas": {
+          "title": "gas limit",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "value": {
+          "title": "value",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "input": {
+          "title": "input data",
+          "type": "string",
+          "pattern": "^0x[0-9a-f]*$"
+        },
+        "gasPrice": {
+          "title": "gas price",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "The gas price willing to be paid by the sender in wei"
+        },
+        "chainId": {
+          "title": "chainId",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+          "description": "Chain ID that this transaction is valid on."
+        },
+        "v": {
+          "title": "v",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "r": {
+          "title": "r",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        },
+        "s": {
+          "title": "s",
+          "type": "string",
+          "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+        }
+      }
+    }
+  ],
+  "properties": {
+    "blockHash": {
+      "title": "block hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "blockNumber": {
+      "title": "block number",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    },
+    "from": {
+      "title": "from address",
+      "type": "string",
+      "pattern": "^0x[0-9,a-f,A-F]{40}$"
+    },
+    "hash": {
+      "title": "transaction hash",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$"
+    },
+    "transactionIndex": {
+      "title": "transaction index",
+      "type": "string",
+      "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+    }
+  }
+}

--- a/rpctypes/schemas/rpcschemafilterchanges.json
+++ b/rpctypes/schemas/rpcschemafilterchanges.json
@@ -1,0 +1,84 @@
+{
+  "title": "Filter results",
+  "anyOf": [
+    {
+      "title": "new block hashes",
+      "type": "array",
+      "items": {
+        "title": "32 byte hex value",
+        "type": "string",
+        "pattern": "^0x[0-9a-f]{64}$"
+      }
+    },
+    {
+      "title": "new transaction hashes",
+      "type": "array",
+      "items": {
+        "title": "32 byte hex value",
+        "type": "string",
+        "pattern": "^0x[0-9a-f]{64}$"
+      }
+    },
+    {
+      "title": "new logs",
+      "type": "array",
+      "items": {
+        "title": "log",
+        "type": "object",
+        "required": [
+          "transactionHash"
+        ],
+        "properties": {
+          "removed": {
+            "title": "removed",
+            "type": "boolean"
+          },
+          "logIndex": {
+            "title": "log index",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+          },
+          "transactionIndex": {
+            "title": "transaction index",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+          },
+          "transactionHash": {
+            "title": "transaction hash",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+          },
+          "blockHash": {
+            "title": "block hash",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{64}$"
+          },
+          "blockNumber": {
+            "title": "block number",
+            "type": "string",
+            "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
+          },
+          "address": {
+            "title": "address",
+            "type": "string",
+            "pattern": "^0x[0-9,a-f,A-F]{40}$"
+          },
+          "data": {
+            "title": "data",
+            "type": "string",
+            "pattern": "^0x[0-9a-f]*$"
+          },
+          "topics": {
+            "title": "topics",
+            "type": "array",
+            "items": {
+              "title": "32 hex encoded bytes",
+              "type": "string",
+              "pattern": "^0x[0-9a-f]{64}$"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/rpctypes/schemas/rpcschemafilterchanges.json
+++ b/rpctypes/schemas/rpcschemafilterchanges.json
@@ -1,6 +1,6 @@
 {
   "title": "Filter results",
-  "anyOf": [
+  "oneOf": [
     {
       "title": "new block hashes",
       "type": "array",

--- a/rpctypes/schemas/rpcschemasigntxresponse.json
+++ b/rpctypes/schemas/rpcschemasigntxresponse.json
@@ -7,75 +7,111 @@
             "pattern": "^0x[0-9a-f]{1,}$"
         },
         "tx": {
+            "title": "Signed 1559 Transaction",
             "type": "object",
+            "required": [
+                "accessList",
+                "chainId",
+                "gas",
+                "input",
+                "maxFeePerGas",
+                "maxPriorityFeePerGas",
+                "nonce",
+                "r",
+                "s",
+                "type",
+                "value"
+            ],
             "properties": {
                 "type": {
+                    "title": "type",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([0-9,a-f,A-F]?){1,2}$"
                 },
                 "nonce": {
+                    "title": "nonce",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
                 },
                 "to": {
+                    "title": "to address",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x[0-9,a-f,A-F]{40}$"
                 },
                 "gas": {
+                    "title": "gas limit",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
-                },
-                "gasPrice": {
-                    "type": ["string", "null"]
-                },
-                "maxPriorityFeePerGas": {
-                    "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
-                },
-                "maxFeePerGas": {
-                    "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
                 },
                 "value": {
+                    "title": "value",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
                 },
                 "input": {
+                    "title": "input data",
                     "type": "string",
                     "pattern": "^0x[0-9a-f]*$"
                 },
-                "v": {
+                "maxPriorityFeePerGas": {
+                    "title": "max priority fee per gas",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "Maximum fee per gas the sender is willing to pay to miners in wei"
+                },
+                "maxFeePerGas": {
+                    "title": "max fee per gas",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei"
+                },
+                "accessList": {
+                    "title": "accessList",
+                    "type": "array",
+                    "description": "EIP-2930 access list",
+                    "items": {
+                        "title": "Access list entry",
+                        "type": "object",
+                        "properties": {
+                            "address": {
+                                "title": "hex encoded address",
+                                "type": "string",
+                                "pattern": "^0x[0-9,a-f,A-F]{40}$"
+                            },
+                            "storageKeys": {
+                                "type": "array",
+                                "items": {
+                                    "title": "32 byte hex value",
+                                    "type": "string",
+                                    "pattern": "^0x[0-9a-f]{64}$"
+                                }
+                            }
+                        }
+                    }
+                },
+                "chainId": {
+                    "title": "chainId",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "Chain ID that this transaction is valid on."
+                },
+                "yParity": {
+                    "title": "yParity",
+                    "type": "string",
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$",
+                    "description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature."
                 },
                 "r": {
+                    "title": "r",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
                 },
                 "s": {
+                    "title": "s",
                     "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
-                },
-                "hash": {
-                    "type": "string",
-                    "pattern": "^0x[0-9a-f]{1,}$"
+                    "pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
                 }
-            },
-            "required": [
-                "type",
-                "nonce",
-                "to",
-                "gas",
-                "gasPrice",
-                "maxPriorityFeePerGas",
-                "maxFeePerGas",
-                "value",
-                "input",
-                "v",
-                "r",
-                "s",
-                "hash"
-            ]
+            }
         }
     },
     "required": [

--- a/rpctypes/schemas/rpcschemasigntxresponse.json
+++ b/rpctypes/schemas/rpcschemasigntxresponse.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "raw": {
+            "type": "string",
+            "pattern": "^0x[0-9a-f]{1,}$"
+        },
+        "tx": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "nonce": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "string"
+                },
+                "gas": {
+                    "type": "string"
+                },
+                "gasPrice": {
+                    "type": ["string", "null"]
+                },
+                "maxPriorityFeePerGas": {
+                    "type": "string"
+                },
+                "maxFeePerGas": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "input": {
+                    "type": "string"
+                },
+                "v": {
+                    "type": "string"
+                },
+                "r": {
+                    "type": "string"
+                },
+                "s": {
+                    "type": "string"
+                },
+                "hash": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "nonce",
+                "to",
+                "gas",
+                "gasPrice",
+                "maxPriorityFeePerGas",
+                "maxFeePerGas",
+                "value",
+                "input",
+                "v",
+                "r",
+                "s",
+                "hash"
+            ]
+        }
+    },
+    "required": [
+        "raw",
+        "tx"
+    ]
+}

--- a/rpctypes/schemas/rpcschemasigntxresponse.json
+++ b/rpctypes/schemas/rpcschemasigntxresponse.json
@@ -10,43 +10,55 @@
             "type": "object",
             "properties": {
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "nonce": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "to": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "gas": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "gasPrice": {
                     "type": ["string", "null"]
                 },
                 "maxPriorityFeePerGas": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "maxFeePerGas": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "value": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "input": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]*$"
                 },
                 "v": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "r": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "s": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 },
                 "hash": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{1,}$"
                 }
             },
             "required": [


### PR DESCRIPTION
# Description

We build and work with a wide variety of EVM implementations. We need quick ways to verify adherence to common RPC standards across clients. E.g if some clients respond with a hex string for block numbers and others respond with a number, that's going to make integration and adoption more challenging. The goal here is to be able assess EVM clients quickly and understand if they are implement in a way that conforms to a reference implementation (geth)

The approach taken here is to have a Test object that can executed in isolation. Each test should be an independent atomic unit that can executed in any order or in parallel. Since the tests themselves are objects, they are programmable. They can be sorted, fuzzed run at high speed, etc. Over time we'll add more edge cases, fuzzing capabilities, and additional name spaces like `debug` or `bor` and `zkevm`.

