### PR TITLE
[DVT-801] Add flags for each datastore entity

### DIFF
--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -19,21 +19,23 @@ import (
 
 type (
 	sensorParams struct {
-		Bootnodes                   string
-		Threads                     int
-		NetworkID                   uint64
-		NodesFile                   string
-		Database                    string
-		ProjectID                   string
-		SensorID                    string
-		MaxPeers                    int
-		MaxConcurrentDatabaseWrites int
-		ShouldWriteBlocks           bool
-		ShouldWriteTransactions     bool
-		RevalidationInterval        string
-		revalidationInterval        time.Duration
-		ShouldRunPprof              bool
-		PprofPort                   uint
+		Bootnodes                    string
+		Threads                      int
+		NetworkID                    uint64
+		NodesFile                    string
+		Database                     string
+		ProjectID                    string
+		SensorID                     string
+		MaxPeers                     int
+		MaxConcurrentDatabaseWrites  int
+		ShouldWriteBlocks            bool
+		ShouldWriteBlockEvents       bool
+		ShouldWriteTransactions      bool
+		ShouldWriteTransactionEvents bool
+		RevalidationInterval         string
+		revalidationInterval         time.Duration
+		ShouldRunPprof               bool
+		PprofPort                    uint
 	}
 )
 
@@ -135,8 +137,12 @@ required, so other nodes in the network can discover each other.`)
 this will result in less chance of missing data (i.e. broken pipes) but
 can significantly increase memory usage.`)
 	SensorCmd.PersistentFlags().BoolVarP(&inputSensorParams.ShouldWriteBlocks, "write-blocks", "B", true, "Whether to write blocks to the database.")
+	SensorCmd.PersistentFlags().BoolVar(&inputSensorParams.ShouldWriteBlockEvents, "write-block-events", true, "Whether to write block events to the database.")
 	SensorCmd.PersistentFlags().BoolVarP(&inputSensorParams.ShouldWriteTransactions, "write-txs", "t", true,
 		`Whether to write transactions to the database. This option could significantly
+increase CPU and memory usage.`)
+	SensorCmd.PersistentFlags().BoolVar(&inputSensorParams.ShouldWriteTransactionEvents, "write-tx-events", true,
+		`Whether to write transaction events to the database. This option could significantly
 increase CPU and memory usage.`)
 	SensorCmd.PersistentFlags().StringVarP(&inputSensorParams.RevalidationInterval, "revalidation-interval", "r", "10m", "The amount of time it takes to retry connecting to a failed peer.")
 	SensorCmd.PersistentFlags().BoolVar(&inputSensorParams.ShouldRunPprof, "pprof", false, "Whether to run pprof.")

--- a/cmd/p2p/sensor/sensor_util.go
+++ b/cmd/p2p/sensor/sensor_util.go
@@ -52,14 +52,15 @@ func newSensor(input p2p.NodeSet, disc resolver, iters ...enode.Iterator) *senso
 		iters:     iters,
 		inputIter: enode.IterNodes(input.Nodes()),
 		nodeCh:    make(chan *enode.Node),
-		db: database.NewDatastore(
-			context.Background(),
-			inputSensorParams.ProjectID,
-			inputSensorParams.SensorID,
-			inputSensorParams.MaxConcurrentDatabaseWrites,
-			inputSensorParams.ShouldWriteBlocks,
-			inputSensorParams.ShouldWriteTransactions,
-		),
+		db: database.NewDatastore(context.Background(), database.DatastoreOptions{
+			ProjectID:                    inputSensorParams.ProjectID,
+			SensorID:                     inputSensorParams.SensorID,
+			MaxConcurrentWrites:          inputSensorParams.MaxConcurrentDatabaseWrites,
+			ShouldWriteBlocks:            inputSensorParams.ShouldWriteBlocks,
+			ShouldWriteBlockEvents:       inputSensorParams.ShouldWriteBlockEvents,
+			ShouldWriteTransactions:      inputSensorParams.ShouldWriteTransactions,
+			ShouldWriteTransactionEvents: inputSensorParams.ShouldWriteTransactionEvents,
+		}),
 		peers: make(map[string]struct{}),
 		count: &p2p.MessageCount{},
 	}

--- a/p2p/database/database.go
+++ b/p2p/database/database.go
@@ -23,5 +23,7 @@ type Database interface {
 
 	MaxConcurrentWrites() int
 	ShouldWriteBlocks() bool
+	ShouldWriteBlockEvents() bool
 	ShouldWriteTransactions() bool
+	ShouldWriteTransactionEvents() bool
 }

--- a/p2p/database/database.go
+++ b/p2p/database/database.go
@@ -14,11 +14,27 @@ import (
 // to. To use another database solution, just implement these methods and
 // update the sensor to use the new connection.
 type Database interface {
+	// WriteBlock will write the both the block and block event to the database
+	// if ShouldWriteBlocks and ShouldWriteBlockEvents return true, respectively.
 	WriteBlock(context.Context, *enode.Node, *types.Block, *big.Int)
+
+	// WriteBlockHeaders will write the block headers if ShouldWriteBlocks
+	// returns true.
 	WriteBlockHeaders(context.Context, []*types.Header)
+
+	// WriteBlockHashes will write the block hashes if ShouldWriteBlockEvents
+	// returns true.
 	WriteBlockHashes(context.Context, *enode.Node, []common.Hash)
+
+	// WriteBlockBodies will write the block bodies if ShouldWriteBlocks returns
+	// true.
 	WriteBlockBody(context.Context, *eth.BlockBody, common.Hash)
+
+	// WriteTransactions will write the both the transaction and transaction
+	// event to the database if ShouldWriteTransactions and
+	// ShouldWriteTransactionEvents return true, respectively.
 	WriteTransactions(context.Context, *enode.Node, []*types.Transaction)
+
 	HasParentBlock(context.Context, common.Hash) bool
 
 	MaxConcurrentWrites() int

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -182,7 +182,7 @@ func (c *Conn) ReadAndServe(db database.Database, count *MessageCount) error {
 				atomic.AddInt32(&count.BlockHeaders, int32(len(msg.BlockHeadersPacket)))
 				c.logger.Trace().Msgf("Received %v BlockHeaders", len(msg.BlockHeadersPacket))
 
-				if db != nil {
+				if db != nil && db.ShouldWriteBlocks() {
 					for _, header := range msg.BlockHeadersPacket {
 						if err := c.getParentBlock(ctx, db, header); err != nil {
 							return err
@@ -259,7 +259,7 @@ func (c *Conn) ReadAndServe(db database.Database, count *MessageCount) error {
 					}
 				}
 
-				if db != nil && db.ShouldWriteBlocks() && len(hashes) > 0 {
+				if db != nil && db.ShouldWriteBlockEvents() && len(hashes) > 0 {
 					dbCh <- struct{}{}
 					go func() {
 						db.WriteBlockHashes(ctx, c.node, hashes)
@@ -270,7 +270,7 @@ func (c *Conn) ReadAndServe(db database.Database, count *MessageCount) error {
 				atomic.AddInt32(&count.Blocks, 1)
 				c.logger.Trace().Str("hash", msg.Block.Hash().Hex()).Msg("Received NewBlock")
 
-				if db != nil && db.ShouldWriteBlocks() {
+				if db != nil && (db.ShouldWriteBlocks() || db.ShouldWriteBlockEvents()) {
 					if err := c.getParentBlock(ctx, db, msg.Block.Header()); err != nil {
 						return err
 					}
@@ -285,7 +285,7 @@ func (c *Conn) ReadAndServe(db database.Database, count *MessageCount) error {
 				atomic.AddInt32(&count.Transactions, int32(len(*msg)))
 				c.logger.Trace().Msgf("Received %v Transactions", len(*msg))
 
-				if db != nil && db.ShouldWriteTransactions() {
+				if db != nil && (db.ShouldWriteTransactions() || db.ShouldWriteTransactionEvents()) {
 					dbCh <- struct{}{}
 					go func() {
 						db.WriteTransactions(ctx, c.node, *msg)
@@ -296,7 +296,7 @@ func (c *Conn) ReadAndServe(db database.Database, count *MessageCount) error {
 				atomic.AddInt32(&count.Transactions, int32(len(msg.PooledTransactionsPacket)))
 				c.logger.Trace().Msgf("Received %v PooledTransactions", len(msg.PooledTransactionsPacket))
 
-				if db != nil && db.ShouldWriteTransactions() {
+				if db != nil && (db.ShouldWriteTransactions() || db.ShouldWriteTransactionEvents()) {
 					dbCh <- struct{}{}
 					go func() {
 						db.WriteTransactions(ctx, c.node, msg.PooledTransactionsPacket)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->
- adds `--write-block-events` and `--write-tx-events` flags to toggle whether to write events to datastore

## Jira / Linear Tickets

- [DVT-801](https://polygon.atlassian.net/browse/DVT-801)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

```bash
go run main.go p2p sensor nodes.json --bootnodes enode://0cb82b395094ee4a2915e9714894627de9ed8498fb881cec6db7c65e8b9a5bd7f2f25cc84e71e89d0947e51c76e85d0847de848c7782b13c0255247a6758178c@44.232.55.71:30303,enode://88116f4295f5a31538ae409e4d44ad40d22e44ee9342869e7d68bdec55b0f83c1530355ce8b41fbec0928a7d75a5745d528450d30aec92066ab6ba1ee351d710@159.203.9.164:30303,enode://4be7248c3a12c5f95d4ef5fff37f7c44ad1072fdb59701b2e5987c5f3846ef448ce7eabc941c5575b13db0fb016552c1fa5cca0dda1a8008cf6d63874c0f3eb7@3.93.224.197:30303,enode://32dd20eaf75513cf84ffc9940972ab17a62e88ea753b0780ea5eca9f40f9254064dacb99508337043d944c2a41b561a17deaad45c53ea0be02663e55e6a302b2@3.212.183.151:30303 -n 137 -s "mvu" --project-id "devtools-sandbox"
```
- [x] Run with `--write-blocks=true --write-block-events=false --write-txs=false --write-tx-events=false`
- [x] Run with `--write-blocks=false --write-block-events=true --write-txs=false --write-tx-events=false`
- [x] Run with `--write-blocks=false --write-block-events=false --write-txs=true --write-tx-events=false`
- [x] Run with `--write-blocks=false --write-block-events=false --write-txs=false --write-tx-events=true`


[DVT-801]: https://polygon.atlassian.net/browse/DVT-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ