### PR TITLE
Added requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ commonly needed tools and provide interfaces and formats.
 Requirements:
 
 - [Go](https://go.dev/)
+- make
+- jq
+- bc
 
 To install, clone this repo and run:
 


### PR DESCRIPTION
# Description

Added requirements. 
Without "make" you cannot run the next command and without `jq`and `bc` the installation will run with errors and silently fail.


```bash
:~/polygon-cli$ make install
/bin/sh: 1: jq: not found
/bin/sh: 1: bc: not found
mkdir -p ./out
go build -ldflags "-s -w -X \"github.com/maticnetwork/polygon-cli/cmd/version.Version=dev (f96f208b)\"" -o ./out/polycli main.go
go: downloading github.com/rs/zerolog v1.27.0
go: downloading github.com/spf13/viper v1.12.0
...
```

