### PR TITLE
[DVT-812] Conformance Fuzzing Library

### DIFF
--- a/cmd/rpcfuzz/argfuzz/argfuzz.go
+++ b/cmd/rpcfuzz/argfuzz/argfuzz.go
@@ -1,0 +1,52 @@
+package argfuzz
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"github.com/google/gofuzz"
+)
+
+type Hex64String string
+
+func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
+	// TODO: think of better mutators here
+	// some examples would be a valid hex, invalid hex, passing integers where
+	// expecting string, etc.
+	for i, d := range *args {
+		switch d.(type) {
+		case string:
+			// random string vals
+			(*args)[i] = c.RandString()
+		case int:
+			// todo: need to think what to randmoize
+			(*args)[i] = c.Intn(100)
+		case bool:
+			// random bool val
+			(*args)[i] = c.RandBool()
+		case Hex64String:
+			// generate a valid mutation or for invalid fuzz
+			val := (*args)[i].(Hex64String)
+			(*args)[i] = val.Mutate()
+		default:
+			// no mutation for unknown types
+			fmt.Println("no match")
+		}
+	}
+}
+
+func RandomHex(n int) (string, error) {
+	bytes := make([]byte, n)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func (val Hex64String) Mutate() string {
+	randHex, err := RandomHex(32)
+	if err != nil {
+		fmt.Println("err")
+	}
+	return "0x" + randHex
+}

--- a/cmd/rpcfuzz/argfuzz/argfuzz.go
+++ b/cmd/rpcfuzz/argfuzz/argfuzz.go
@@ -39,9 +39,9 @@ func MutateExecutor(arg []byte, c fuzz.Continue) []byte {
 }
 
 func ByteMutator(arg []byte, c fuzz.Continue) []byte {
-    if arg == nil {
-        return arg
-    }
+	if arg == nil {
+		return arg
+	}
 
 	arg = MutateExecutor(arg, c)
 	// fitty-fitty chance of more mutations
@@ -54,9 +54,9 @@ func ByteMutator(arg []byte, c fuzz.Continue) []byte {
 
 func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
 	for i, d := range *args {
-        if d == nil {
-            continue
-        }
+		if d == nil {
+			continue
+		}
 
 		switch d.(type) {
 		case string:

--- a/cmd/rpcfuzz/argfuzz/argfuzz.go
+++ b/cmd/rpcfuzz/argfuzz/argfuzz.go
@@ -1,52 +1,197 @@
 package argfuzz
 
 import (
-	"crypto/rand"
+	cryptoRand "crypto/rand"
 	"encoding/hex"
-	"fmt"
+	"github.com/rs/zerolog/log"
+	"math/rand"
+	"strings"
+
 	"github.com/google/gofuzz"
 )
 
-type Hex64String string
+type (
+	// probably don't need this for fuzzing
+	BaseType interface {
+		Mutate() string
+	}
+	Hex64String string
+	Hex42String string
+	Hex32String string
+)
+
+func RandomStringMutator(arg string, c fuzz.Continue) string {
+	switch rand.Intn(10) {
+	case 0:
+		return EmptyString()
+	case 1:
+		return c.RandString()
+	case 2:
+		return AddRandomCharacter(arg)
+	case 3:
+		return AddCharacters(arg, c.RandString())
+	case 4:
+		return RemoveRandomCharacter(arg)
+	case 5:
+		return GenerateRandomHexStringFixedSize(len(arg))
+	case 6:
+		return GenerateRandomHexStringRandomSize()
+	case 7:
+		return GenerateInvalidHexString(len(arg))
+	case 8:
+		return TestWhitespaceControlChars(arg)
+	case 9:
+		return TestCaseSensitivity(arg)
+	default:
+		return c.RandString()
+	}
+}
+
+func MutateStringArgs(args *string, c fuzz.Continue) {
+	*args = RandomStringMutator(*args, c)
+}
 
 func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
-	// TODO: think of better mutators here
-	// some examples would be a valid hex, invalid hex, passing integers where
-	// expecting string, etc.
 	for i, d := range *args {
 		switch d.(type) {
 		case string:
-			// random string vals
-			(*args)[i] = c.RandString()
+			(*args)[i] = RandomStringMutator((*args)[i].(string), c)
 		case int:
-			// todo: need to think what to randmoize
+			// use large number
+			// use float?
 			(*args)[i] = c.Intn(100)
 		case bool:
 			// random bool val
+			// use string bool value
+			// use 0/1
 			(*args)[i] = c.RandBool()
-		case Hex64String:
-			// generate a valid mutation or for invalid fuzz
-			val := (*args)[i].(Hex64String)
+		case BaseType:
+			// Mutate to valid type
+			val := (*args)[i].(BaseType)
 			(*args)[i] = val.Mutate()
 		default:
-			// no mutation for unknown types
-			fmt.Println("no match")
+			// No mutation for unknown types
+			log.Error().Msg("Unable to retreive type for fuzzing")
 		}
 	}
 }
 
 func RandomHex(n int) (string, error) {
 	bytes := make([]byte, n)
-	if _, err := rand.Read(bytes); err != nil {
+	if _, err := cryptoRand.Read(bytes); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(bytes), nil
+	return "0x" + hex.EncodeToString(bytes), nil
 }
 
 func (val Hex64String) Mutate() string {
-	randHex, err := RandomHex(32)
-	if err != nil {
-		fmt.Println("err")
+	return GenerateRandomHexStringFixedSize(32)
+}
+
+func (val Hex42String) Mutate() string {
+	return GenerateRandomHexStringFixedSize(21)
+}
+
+func (val Hex32String) Mutate() string {
+	return GenerateRandomHexStringFixedSize(16)
+}
+
+func EmptyString() string {
+	return ""
+}
+
+func GenerateRandomString(input string) string {
+	f := fuzz.New()
+	var fuzzedString string
+	f.Fuzz(&fuzzedString)
+	return fuzzedString
+}
+
+func AddRandomCharacter(input string) string {
+	index := rand.Intn(len(input) + 1)
+	char := string(rune(rand.Intn(128))) // a random ASCII val added
+	return input[:index] + char + input[index:]
+}
+
+func AddCharacters(input string, characters string) string {
+	index := rand.Intn(len(input) + 1)
+	return input[:index] + characters + input[index:]
+}
+
+func RemoveRandomCharacter(input string) string {
+	if len(input) == 0 {
+		return input
 	}
-	return "0x" + randHex
+	index := rand.Intn(len(input))
+	return input[:index] + input[index+1:]
+}
+
+func IsHexString(input string) bool {
+	_, err := ParseHexString(input)
+	return err == nil
+}
+func ParseHexString(input string) ([]byte, error) {
+	return hex.DecodeString(input)
+}
+
+func GenerateRandomHexStringFixedSize(length int) string {
+	buf := make([]byte, length)
+	rand.Read(buf)
+	return "0x" + hex.EncodeToString(buf)
+}
+
+func GenerateRandomHexStringRandomSize() string {
+	buf := make([]byte, rand.Intn(100)+1) // length 1 - 100
+	rand.Read(buf)
+	return "0x" + hex.EncodeToString(buf)
+}
+
+func GenerateInvalidHexString(length int) string {
+	invalidChars := []rune{'G', 'Z', '#', '$', '%', '@'}
+	result := make([]rune, length)
+	for i := 0; i < length; i++ {
+		if rand.Intn(5) == 0 {
+			result[i] = invalidChars[rand.Intn(len(invalidChars))]
+		} else {
+			result[i] = rune(rand.Intn(16)) + '0'
+		}
+	}
+	return string(result)
+}
+
+func TestWhitespaceControlChars(input string) string {
+	whitespaceChars := []rune{' ', '\t', '\n'}
+	controlChars := []rune{'\x00', '\x01', '\x02'}
+
+	// Add leading whitespace
+	if len(input) > 0 && rand.Intn(2) == 0 {
+		input = string(whitespaceChars[rand.Intn(len(whitespaceChars))]) + input
+	}
+
+	// Add trailing whitespace
+	if len(input) > 0 && rand.Intn(2) == 0 {
+		input += string(whitespaceChars[rand.Intn(len(whitespaceChars))])
+	}
+
+	// Add internal whitespace
+	if len(input) > 1 && rand.Intn(2) == 0 {
+		index := rand.Intn(len(input)-1) + 1
+		input = input[:index] + string(whitespaceChars[rand.Intn(len(whitespaceChars))]) + input[index:]
+	}
+
+	// Add control characters
+	numControlChars := rand.Intn(3) // Random number of control characters (0-2)
+	for i := 0; i < numControlChars; i++ {
+		index := rand.Intn(len(input) + 1)
+		input = input[:index] + string(controlChars[rand.Intn(len(controlChars))]) + input[index:]
+	}
+
+	return input
+}
+
+func TestCaseSensitivity(input string) string {
+	if rand.Intn(2) == 0 {
+		return strings.ToUpper(input)
+	}
+	return strings.ToLower(input)
 }

--- a/cmd/rpcfuzz/argfuzz/argfuzz.go
+++ b/cmd/rpcfuzz/argfuzz/argfuzz.go
@@ -58,10 +58,10 @@ func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
 			continue
 		}
 
-		switch d.(type) {
-		case string:
+		switch dataType := reflect.TypeOf(d).Kind(); dataType {
+		case reflect.String:
 			(*args)[i] = string(ByteMutator([]byte(d.(string)), c))
-		case int:
+		case reflect.Int:
 			numString := strconv.Itoa(d.(int))
 
 			byteArrString := string(ByteMutator([]byte(numString), c))
@@ -71,7 +71,7 @@ func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
 			} else {
 				(*args)[i] = num
 			}
-		case bool:
+		case reflect.Bool:
 			(*args)[i] = c.RandBool()
 		default:
 			if reflect.TypeOf(d).Kind() == reflect.Ptr {

--- a/cmd/rpcfuzz/argfuzz/argfuzz.go
+++ b/cmd/rpcfuzz/argfuzz/argfuzz.go
@@ -39,6 +39,10 @@ func MutateExecutor(arg []byte, c fuzz.Continue) []byte {
 }
 
 func ByteMutator(arg []byte, c fuzz.Continue) []byte {
+    if arg == nil {
+        return arg
+    }
+
 	arg = MutateExecutor(arg, c)
 	// fitty-fitty chance of more mutations
 	if rand.Intn(2) == 0 && arg != nil {
@@ -50,6 +54,10 @@ func ByteMutator(arg []byte, c fuzz.Continue) []byte {
 
 func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
 	for i, d := range *args {
+        if d == nil {
+            continue
+        }
+
 		switch d.(type) {
 		case string:
 			(*args)[i] = string(ByteMutator([]byte(d.(string)), c))

--- a/cmd/rpcfuzz/argfuzz/argfuzz.go
+++ b/cmd/rpcfuzz/argfuzz/argfuzz.go
@@ -3,6 +3,7 @@ package argfuzz
 import (
 	"encoding/hex"
 	"math/rand"
+	"reflect"
 	"strconv"
 
 	"github.com/google/gofuzz"
@@ -65,8 +66,12 @@ func MutateRPCArgs(args *[]interface{}, c fuzz.Continue) {
 		case bool:
 			(*args)[i] = c.RandBool()
 		default:
-			c.Fuzz(d)
-			(*args)[i] = d
+			if reflect.TypeOf(d).Kind() == reflect.Ptr {
+				c.Fuzz(d)
+				(*args)[i] = d
+			} else {
+				(*args)[i] = c.RandString()
+			}
 		}
 	}
 }

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -1688,14 +1688,13 @@ func CallRPCAndValidate(ctx context.Context, rpcClient *rpc.Client, currTest RPC
 		NumberOfTestsRan: n,
 	}
 	args := currTest.GetArgs()
-  
-  var result interface{}
-			err = rpcClient.CallContext(ctx, &result, t.GetMethod(), t.GetArgs()...)
-			if err != nil && !t.ExpectError() {
-				log.Error().Err(err).Str("method", t.GetMethod()).Msg("Method test failed")
-				continue
-			}
-			
+
+	var result interface{}
+	err = rpcClient.CallContext(ctx, &result, t.GetMethod(), t.GetArgs()...)
+	if err != nil && !t.ExpectError() {
+		log.Error().Err(err).Str("method", t.GetMethod()).Msg("Method test failed")
+		continue
+	}
 
 	idx := 0 // only one run happening
 	var result interface{}
@@ -1708,11 +1707,11 @@ func CallRPCAndValidate(ctx context.Context, rpcClient *rpc.Client, currTest RPC
 		currTestResult.Errors[idx] = errors.New("Method test failed: " + err.Error())
 		return currTestResult
 	}
-  if err == nil && t.ExpectError() {
-    currTestResult.NumberOfTestsFailed++
+	if err == nil && t.ExpectError() {
+		currTestResult.NumberOfTestsFailed++
 		currTestResult.Errors[idx] = errors.New("Expected an error but didn't get one: " + err.Error())
 		return currTestResult
-  }
+	}
 
 	if currTest.ExpectError() {
 		err = currTest.Validate(err)

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/xeipuuv/gojsonschema"
 	"math/big"
+	"math/rand"
 	"os"
 	"regexp"
 	"strings"
@@ -1593,6 +1594,7 @@ func shouldRunTest(t RPCTest) bool {
 }
 
 func init() {
+	rand.Seed(time.Now().UnixNano())
 	zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -33,7 +33,6 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 	"math/big"
 	"math/rand"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -1689,13 +1688,6 @@ func CallRPCAndValidate(ctx context.Context, rpcClient *rpc.Client, currTest RPC
 	}
 	args := currTest.GetArgs()
 
-	var result interface{}
-	err = rpcClient.CallContext(ctx, &result, t.GetMethod(), t.GetArgs()...)
-	if err != nil && !t.ExpectError() {
-		log.Error().Err(err).Str("method", t.GetMethod()).Msg("Method test failed")
-		continue
-	}
-
 	idx := 0 // only one run happening
 	var result interface{}
 	err := rpcClient.CallContext(ctx, &result, currTest.GetMethod(), args...)
@@ -1707,7 +1699,7 @@ func CallRPCAndValidate(ctx context.Context, rpcClient *rpc.Client, currTest RPC
 		currTestResult.Errors[idx] = errors.New("Method test failed: " + err.Error())
 		return currTestResult
 	}
-	if err == nil && t.ExpectError() {
+	if err == nil && currTest.ExpectError() {
 		currTestResult.NumberOfTestsFailed++
 		currTestResult.Errors[idx] = errors.New("Expected an error but didn't get one: " + err.Error())
 		return currTestResult

--- a/cmd/rpcfuzz/testreporter/testreporter.go
+++ b/cmd/rpcfuzz/testreporter/testreporter.go
@@ -1,0 +1,31 @@
+package testreporter
+
+import (
+	"github.com/rs/zerolog/log"
+)
+
+type (
+	TestResult struct {
+		Name                string
+		Method              string
+		Args                [][]interface{}
+		Result              []interface{}
+		Errors              []error
+		NumberOfTestsRan    int
+		NumberOfTestsPassed int
+		NumberOfTestsFailed int
+	}
+	TestResults []TestResult
+)
+
+// TODO:
+// export to json
+// export to csv
+func (trs *TestResults) PrintTabularResult() {
+}
+
+func (trs *TestResults) PrintSummary() {
+	for _, tr := range *trs {
+		log.Info().Str("Method", tr.Method).Msgf("%d/%d Test(s) Passed", tr.NumberOfTestsPassed, tr.NumberOfTestsRan)
+	}
+}

--- a/cmd/rpcfuzz/testreporter/testreporter.go
+++ b/cmd/rpcfuzz/testreporter/testreporter.go
@@ -1,3 +1,4 @@
+// Package testreporter provides the utilities to capture, report, and log test results.
 package testreporter
 
 import (
@@ -17,6 +18,28 @@ type (
 	}
 	TestResults []TestResult
 )
+
+func New(testName string, testMethod string, numOfTestRuns int) TestResult {
+	return TestResult{
+		Name:             testName,
+		Method:           testMethod,
+		NumberOfTestsRan: numOfTestRuns,
+	}
+}
+
+func (tr *TestResult) Pass(args []interface{}, result interface{}, err error) {
+	tr.NumberOfTestsPassed++
+	tr.Args = append(tr.Args, args)
+	tr.Result = append(tr.Result, result)
+	tr.Errors = append(tr.Errors, err)
+}
+
+func (tr *TestResult) Fail(args []interface{}, result interface{}, err error) {
+	tr.NumberOfTestsFailed++
+	tr.Args = append(tr.Args, args)
+	tr.Result = append(tr.Result, result)
+	tr.Errors = append(tr.Errors, err)
+}
 
 // TODO:
 // export to json


### PR DESCRIPTION
# Description

Fuzzing functionality integrated into the arguments of the JSON RPC calls, by running with the `--fuzz` flag. The fuzzer's effectiveness becomes evident through multiple iterations of running fuzzed tests (default to 100 times), with the expected outcome being an error returned by the RPC.

## Jira / Linear Tickets

- [DVT-812](https://polygon.atlassian.net/browse/DVT-812?atlOrigin=eyJpIjoiZmVmNDk4MTgxYmNjNGJjNWEyYWEyMDlkODZkODQzMzgiLCJwIjoiaiJ9)

# Testing

Test run:
```
$ time go run main.go rpcfuzz http://localhost:8545 --fuzz --fuzzn 5
5:32PM INF Loaded private key ethAddress=0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
5:32PM INF enabling namespaces namespaces=["eth_","web3_","net_"]
5:32PM TRC Doing test setup
5:32PM TRC current nonce value curNonce=1
5:32PM TRC fetch chainid chainId=1337
...
5:40PM INF 1/1 Test(s) Passed Method=net_version
5:40PM INF 1/1 Test(s) Passed Method=web3_clientVersion
5:40PM INF 1/1 Test(s) Passed Method=web3_sha3
5:40PM INF 1/1 Test(s) Passed Method=web3_sha3
5:40PM INF 1/1 Test(s) Passed Method=net_listening
5:40PM INF 1/1 Test(s) Passed Method=net_peerCount
5:40PM INF 1/1 Test(s) Passed Method=eth_protocolVersion
5:40PM INF 1/1 Test(s) Passed Method=eth_syncing
5:40PM INF 1/1 Test(s) Passed Method=eth_coinbase
5:40PM INF 1/1 Test(s) Passed Method=eth_chainId
5:40PM INF 1/1 Test(s) Passed Method=eth_mining
5:40PM INF 1/1 Test(s) Passed Method=eth_hashrate
5:40PM INF 1/1 Test(s) Passed Method=eth_hashrate
5:40PM INF 1/1 Test(s) Passed Method=eth_gasPrice
5:40PM INF 1/1 Test(s) Passed Method=eth_accounts
5:40PM INF 1/1 Test(s) Passed Method=eth_blockNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getBalance
5:40PM INF 1/1 Test(s) Passed Method=eth_getBalance
5:40PM INF 1/1 Test(s) Passed Method=eth_getBalance
5:40PM INF 1/1 Test(s) Passed Method=eth_getBalance
5:40PM INF 1/1 Test(s) Passed Method=eth_getStorageAt
5:40PM INF 1/1 Test(s) Passed Method=eth_getStorageAt
5:40PM INF 1/1 Test(s) Passed Method=eth_getStorageAt
5:40PM INF 1/1 Test(s) Passed Method=eth_getStorageAt
5:40PM INF 1/1 Test(s) Passed Method=eth_getTransactionCount
5:40PM INF 1/1 Test(s) Passed Method=eth_getTransactionCount
5:40PM INF 1/1 Test(s) Passed Method=eth_getTransactionCount
5:40PM INF 1/1 Test(s) Passed Method=eth_getTransactionCount
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockTransactionCountByHash
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockTransactionCountByHash
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockTransactionCountByNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockTransactionCountByNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockTransactionCountByNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockTransactionCountByNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleCountByBlockHash
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleCountByBlockHash
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleCountByBlockNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleCountByBlockNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleCountByBlockNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleCountByBlockNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getCode
5:40PM INF 1/1 Test(s) Passed Method=eth_getCode
5:40PM INF 1/1 Test(s) Passed Method=eth_getCode
5:40PM INF 1/1 Test(s) Passed Method=eth_sign
5:40PM INF 1/1 Test(s) Passed Method=eth_sign
5:40PM INF 1/1 Test(s) Passed Method=eth_signTransaction
5:40PM INF 1/1 Test(s) Passed Method=eth_sendTransaction
5:40PM INF 1/1 Test(s) Passed Method=eth_sendRawTransaction
5:40PM INF 1/1 Test(s) Passed Method=eth_call
5:40PM INF 1/1 Test(s) Passed Method=eth_call
5:40PM INF 1/1 Test(s) Passed Method=eth_call
5:40PM INF 1/1 Test(s) Passed Method=eth_call
5:40PM INF 1/1 Test(s) Passed Method=eth_estimateGas
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockByHash
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockByHash
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockByNumber
5:40PM INF 1/1 Test(s) Passed Method=eth_getBlockByNumber
5:40PM INF 0/1 Test(s) Passed Method=eth_getTransactionByHash
5:40PM INF 0/1 Test(s) Passed Method=eth_getTransactionByBlockHashAndIndex
5:40PM INF 0/1 Test(s) Passed Method=eth_getTransactionByBlockNumberAndIndex
5:40PM INF 0/1 Test(s) Passed Method=eth_getTransactionReceipt
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleByBlockHashAndIndex
5:40PM INF 1/1 Test(s) Passed Method=eth_getUncleByBlockNumberAndIndex
5:40PM INF 1/1 Test(s) Passed Method=eth_getCompilers
5:40PM INF 1/1 Test(s) Passed Method=eth_compileSolidity
5:40PM INF 1/1 Test(s) Passed Method=eth_compileLLL
5:40PM INF 1/1 Test(s) Passed Method=eth_compileSerpent
5:40PM INF 1/1 Test(s) Passed Method=eth_newFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newBlockFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_newPendingTransactionFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_uninstallFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_uninstallFilter
5:40PM INF 1/1 Test(s) Passed Method=eth_getFilterChanges
5:40PM INF 0/1 Test(s) Passed Method=eth_getFilterLogs
5:40PM INF 0/1 Test(s) Passed Method=eth_getLogs
5:40PM INF 1/1 Test(s) Passed Method=eth_getWork
5:40PM INF 1/1 Test(s) Passed Method=eth_submitWork
5:40PM INF 1/1 Test(s) Passed Method=eth_submitHashrate
5:40PM INF 1/1 Test(s) Passed Method=eth_feeHistory
5:40PM INF 1/1 Test(s) Passed Method=eth_maxPriorityFeePerGas
5:40PM INF 1/1 Test(s) Passed Method=eth_createAccessList
5:40PM INF 1/1 Test(s) Passed Method=eth_getProof
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-net_version
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-web3_clientVersion
5:40PM INF 4/5 Test(s) Passed Method=fuzzed-web3_sha3
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-net_peerCount
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-net_listening
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-web3_sha3
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_syncing
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_protocolVersion
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_coinbase
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_mining
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_chainId
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_hashrate
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_hashrate
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_gasPrice
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_accounts
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_blockNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBalance
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBalance
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBalance
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBalance
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getStorageAt
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getStorageAt
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getStorageAt
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionCount
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getStorageAt
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionCount
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionCount
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionCount
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockTransactionCountByHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockTransactionCountByHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockTransactionCountByNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockTransactionCountByNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockTransactionCountByNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockTransactionCountByNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleCountByBlockHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleCountByBlockNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleCountByBlockNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleCountByBlockNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleCountByBlockHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleCountByBlockNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getCode
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getCode
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getCode
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_sign
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_sign
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_signTransaction
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_sendTransaction
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_sendRawTransaction
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_call
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_call
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_call
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_call
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_estimateGas
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockByHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockByHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockByNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getBlockByNumber
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionByHash
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionByBlockHashAndIndex
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleByBlockHashAndIndex
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_compileSolidity
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getUncleByBlockNumberAndIndex
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getCompilers
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_compileSerpent
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_compileLLL
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_newFilter
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_newFilter
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_newFilter
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_newFilter
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_newFilter
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_newFilter
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_newBlockFilter
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_newPendingTransactionFilter
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_uninstallFilter
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_uninstallFilter
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getFilterChanges
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getFilterLogs
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getWork
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getLogs
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_submitWork
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_submitHashrate
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_feeHistory
5:40PM INF 5/5 Test(s) Passed Method=fuzzed-eth_maxPriorityFeePerGas
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_createAccessList
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getProof
5:40PM INF 0/5 Test(s) Passed Method=fuzzed-eth_getTransactionByBlockNumberAndIndex
go run main.go rpcfuzz http://localhost:8545 --fuzz --fuzzn 5  3.37s user 1.76s system 1% cpu 8:06.41 total
```

### What's next?
- [ ] Summarizing test results

[DVT-812]: https://polygon.atlassian.net/browse/DVT-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ