### PR TITLE
protoc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Requirements:
 - make
 - jq
 - bc
+- protoc (Only required for `make generate`)
 
 To install, clone this repo and run:
 
@@ -260,7 +261,13 @@ zcat < foo.gz | jq '. | select(.transactions | length > 0) | select(.transaction
 Dumpblocks can also output to protobuf format. If you wish to make changes to the protobuf:
 
 1. Install the protobuf compiler
-
+   
+   On GNU/Linux:
+   ```bash
+   sudo apt install protoc-gen-go
+   ```
+   
+   On a MAC:
    ```bash
    brew install protobuf
    ```


### PR DESCRIPTION
Only for the command `make generate` you will also need protoc installed on your system or you will get an error.

* Added protoc as requirements for `make generate`
* Added instructions to install protoc on a Linux based system. (it was only written for mac)