### PR TITLE
doc: update genesis generation part

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ support migrating clients other chains to supernets.
       --bootnode /ip4/127.0.0.1/tcp/10001/p2p/$NODE_ID
   ```
 
+```shell
+# In this case local host is running a POA Core Archive node.
+polycli dumpblocks http://127.0.0.1:8545 0 100000 --filename poa-core.0.to.100k --dump-receipts=false
+
+# Even with disabling receipts, edge's eth_getBlockByNumber returns transactions.
+# This needs to be done only if using json mode. Filter them out before forging:
+cat poa-core.0.to.100k | grep '"difficulty"' > poa-core.0.to.100k.blocks
+
+polycli forge --genesis genesis.json --mode json --blocks poa-core.0.to.100k.blocks --count 99999
+```
+
+```bash
+# To do the same with using proto instead of json:
+polycli dumpblocks http://127.0.0.1:8545 0 1000000 -f poa-core.0.to.100k.proto -r=false -m proto
+polycli forge --genesis genesis.json --mode proto --blocks poa-core.0.to.100k.proto --count 99999
+```
+
 ### Forging Filtered Blocks
 
 Sometimes, it can be helpful to only import the blocks and transactions that are


### PR DESCRIPTION
# Description

As mentioned in this issue (#88), the link referring to the genesis generation in edge has changed.


This PR:
- Updates the link to point to the [new documentation](https://wiki.polygon.technology/docs/category/deploy-a-supernet) (generate genesis in the case of PolyBFT consensus).
- Install `v1.0.0` instead of `develop` version.
- Add instructions to generate a genesis file for PolyBFT consensus.
- Updates instructions to generate a genesis file for IBFT consensus.

## Jira / Linear Tickets

x

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] Genesis file can be generate with IBFT or PolyBFT
- [ ] The server can start with the genesis file generated
