### PR TITLE
Fix rpcfuzz panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 coverage.out
 
 .vscode
+.idea

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha1"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,8 +25,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	_ "embed"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -1693,7 +1692,7 @@ func CallRPCAndValidate(ctx context.Context, rpcClient *rpc.Client, currTest RPC
 		return currTestResult
 	}
 	if err == nil && currTest.ExpectError() {
-		currTestResult.Fail(args, result, errors.New("Expected an error but didn't get one: "+err.Error()))
+		currTestResult.Fail(args, result, errors.New("Expected an error but didn't get one"))
 		return currTestResult
 	}
 


### PR DESCRIPTION
# Description

This PR fixes a panic in rpcfuzz command. It dereferences nil when it expects and error but got none. 


# Testing

I manually observed while running rpcfuzz against the ERC20 contract deployed to supernets2-node. I verified the fix manually.