### PR TITLE
Fix/makefile2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ install: build ## Install the go binary.
 cross: $(BUILD_DIR) ## Cross-compile go binaries using CGO.
 	env CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build -ldflags "$(STATIC_LD_FLAGS)" -tags netgo -o $(BUILD_DIR)/linux-arm64-$(BIN_NAME) main.go
 	env                          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags "$(STATIC_LD_FLAGS)" -tags netgo -o $(BUILD_DIR)/linux-amd64-$(BIN_NAME) main.go
-  # MAC builds - this will be functional but will still have secp issues.
+# MAC builds - this will be functional but will still have secp issues.
 	env GOOS=darwin GOARCH=arm64 go build -ldflags "$(LD_FLAGS)" -tags netgo -o $(BUILD_DIR)/darwin-arm64-$(BIN_NAME) main.go
 	env GOOS=darwin GOARCH=amd64 go build -ldflags "$(LD_FLAGS)" -tags netgo -o $(BUILD_DIR)/darwin-amd64-$(BIN_NAME) main.go
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ generate: ## Generate protobuf stubs.
 
 .PHONY: build
 build: $(BUILD_DIR) ## Build go binary.
-	go build -ldflags "-w -X \"github.com/maticnetwork/polygon-cli/cmd/version.Version=dev ($(GIT_SHA))\"" -o $(BUILD_DIR)/$(BIN_NAME) main.go
+	go build -ldflags "-X \"github.com/maticnetwork/polygon-cli/cmd/version.Version=dev ($(GIT_SHA))\"" -o $(BUILD_DIR)/$(BIN_NAME) main.go
 
 .PHONY: install
 install: build ## Install the go binary.

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,17 @@ simplecross: $(BUILD_DIR) ## Cross-compile go binaries without using CGO.
 
 .PHONY: clean
 clean: ## Clean the binary folder.
+## To avoid misconfiguration mistakes that could delete important files, it will run 2 checks before deleting.
+## Check if $(BUILD_DIR) is empty. If it is, prints an error message and exits
+	@if [ -z "$(BUILD_DIR)" ]; then \
+		echo "BUILD_DIR is not set. Aborting clean."; \
+		exit 1; \
+	fi
+## Check if $(BUILD_DIR) is a critical path. If it is prints an error  message and exists.
+	@if [ "$(BUILD_DIR)" = "/" ] || [ "$(BUILD_DIR)" = "/usr" ] || [ "$(BUILD_DIR)" = "/usr/local" ]; then \
+		echo "Refusing to clean critical directory $(BUILD_DIR). Aborting."; \
+		exit 1; \
+	fi
 	$(RM) -r $(BUILD_DIR)
 
 ##@ Test


### PR DESCRIPTION
# Description

1. Removed leading spaces before comment that can cause some issues  in some versions of `make`.

2. In the `build` target flag `-w` is being used by its already defined in `LD_FLAGS`. Removed duplication.

3. Make clean is now more robust. Before deleting will check if its not empty or if its  misconfigured to an important folder like  `/`, `/usr` or `/usr/local`


