### PR TITLE
Log Level Change

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -547,7 +547,7 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			if setBlock {
 				selectedBlock = renderedBlocks[len(renderedBlocks)-blockTable.SelectedRow]
 				setBlock = false
-				log.Info().Uint64("blockNumber", selectedBlock.Number().Uint64()).Msg("Selected block changed")
+				log.Debug().Uint64("blockNumber", selectedBlock.Number().Uint64()).Msg("Selected block changed")
 			}
 		}
 


### PR DESCRIPTION
# Description

If you're not doing `2> out.err` when running `polycli monitor` this log message is very disruptive. Dropping the default level for now to deal with it.
