### PR TITLE
chore: remove `recall` mode from `polycli loadtest --mode random`

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -475,7 +475,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	}
 
 	var recallTransactions []rpctypes.PolyTransaction
-	if mode == loadTestModeRecall || mode == loadTestModeRandom {
+	if mode == loadTestModeRecall {
 		recallTransactions, err = getRecallTransactions(ctx, c, rpc)
 		if err != nil {
 			return err

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/maticnetwork/polygon-cli/rpctypes"
 	"io"
 	"math/big"
 	"math/rand"
@@ -16,7 +15,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/maticnetwork/polygon-cli/rpctypes"
+
 	_ "embed"
+
 	"github.com/maticnetwork/polygon-cli/metrics"
 
 	ethereum "github.com/ethereum/go-ethereum"
@@ -48,10 +50,10 @@ const (
 	loadTestModeERC721
 	loadTestModePrecompiledContracts
 	loadTestModePrecompiledContract
-	loadTestModeRecall
 
 	// All the modes AFTER random mode will not be used when mode random is selected
 	loadTestModeRandom
+	loadTestModeRecall
 	loadTestModeRPC
 
 	codeQualitySeed       = "code code code code code code code code code code code quality"

--- a/cmd/loadtest/loadtestmode_string.go
+++ b/cmd/loadtest/loadtestmode_string.go
@@ -18,12 +18,12 @@ func _() {
 	_ = x[loadTestModeERC721-7]
 	_ = x[loadTestModePrecompiledContracts-8]
 	_ = x[loadTestModePrecompiledContract-9]
-	_ = x[loadTestModeRecall-10]
-	_ = x[loadTestModeRandom-11]
+	_ = x[loadTestModeRandom-10]
+	_ = x[loadTestModeRecall-11]
 	_ = x[loadTestModeRPC-12]
 }
 
-const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRecallloadTestModeRandomloadTestModeRPC"
+const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPC"
 
 var _loadTestMode_index = [...]uint16{0, 23, 41, 57, 77, 92, 109, 126, 144, 176, 207, 225, 243, 258}
 


### PR DESCRIPTION
# Description

When using `polycli loadtest --mode random`, there is an edge with `recall` mode being called as the first random mode which will cause the program to stop. I suggest to simply remove this mode from the random modes. Or we could also just prevent this mode to being called first.

Here are the complete logs.

```sh
$ go run main.go loadtest http://localhost:8545 --mode random --requests 100 --concurrency 10 --rate-limit 100 --verbosity 700      INT at 10:40:44
10:40AM DBG Starting logger in console mode
10:40AM INF Starting Load Test
10:40AM INF Connecting with RPC endpoint to initialize load test parameters
10:40AM TRC Retrieved current gas price gasprice=201441672
10:40AM TRC Retrieved current gas tip cap gastipcap=1
10:40AM TRC Current Block Number blocknumber=12
10:40AM TRC Current account balance balance=5000000000000000000000
10:40AM TRC Hex of odd length original=38D7EA4C68000
10:40AM DBG eip-1559 support detected
10:40AM TRC Detected Chain ID chainID=1337
10:40AM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"AvailRuntime":null,"BatchSize":999,"ByteCount":1024,"CallOnly":false,"CallOnlyLatestBlock":false,"ChainID":1337,"ChainSupportBaseFee":true,"Concurrency":10,"ContractCallBlockInterval":1,"ContractCallNumberOfBlocksToWaitFor":30,"CurrentBaseFee":201441671,"CurrentGasPrice":201441672,"CurrentGasTipCap":1,"CurrentNonce":0,"DelAddress":null,"ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":30175782965061331201157137042014122781558886384910785332752666033589853463034,"X":36405839969746785076083915005678656647806951607600131854360360806126023484467,"Y":33607126158016649181688023362411565996635601901352589004706892696521135399893},"ERC20Address":"","ERC721Address":"","ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"ForcePriorityGasPrice":0,"FromAvailAddress":null,"FromETHAddress":"0x85da99c8a7c2c95964c8efd687e95e632fc533d6","Function":1,"HexSendAmount":"0x38D7EA4C68000","IsAvail":null,"Iterations":1,"LegacyTransactionMode":false,"LtAddress":"","Mode":11,"Modes":["r"],"MultiMode":false,"ParsedModes":[11],"PrivateKey":"42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa","RateLimit":100,"RecallLength":50,"Requests":100,"Seed":123456,"SendAmount":1000000000000000,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToAvailAddress":null,"ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false,"URL":{"ForceQuery":false,"Fragment":"","Host":"localhost:8545","OmitHost":false,"Opaque":"","Path":"","RawFragment":"","RawPath":"","RawQuery":"","Scheme":"http","User":null}}
10:40AM TRC Load test contract address contractaddress=0x6fda56c57b0acadb96ed5624ac500c0429d59429
10:40AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=12
10:40AM TRC New block newBlock=12
10:40AM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
10:40AM TRC New block newBlock=13
10:40AM TRC Function executed successfully elapsedTimeSeconds=1
10:40AM DBG Obtained load test contract address ltAddr=0x6FdA56C57B0Acadb96Ed5624aC500C0429d59429
10:40AM TRC ERC20 contract address contractaddress=0x58145f797db29e89b1f132f80c10f09ada7c3742
10:40AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=13
10:40AM TRC New block newBlock=13
10:40AM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
10:40AM TRC New block newBlock=13
10:40AM TRC New block newBlock=14
10:40AM TRC Function executed successfully elapsedTimeSeconds=2
10:40AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=14
10:40AM TRC New block newBlock=14
10:40AM TRC Unable to execute function error="ERC20 Balance is Zero" elapsedTimeSeconds=0
10:40AM TRC New block newBlock=14
10:40AM TRC New block newBlock=15
10:40AM TRC Function executed successfully elapsedTimeSeconds=2
10:40AM DBG Obtained erc 20 contract address erc20Addr=0x58145F797Db29e89b1F132F80c10F09Ada7c3742
10:40AM TRC ERC721 contract address contractaddress=0xec59ea1acb9fc9f630b2dce73790ed8be0ac036e
10:40AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=15
10:40AM TRC New block newBlock=15
10:40AM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
10:40AM TRC New block newBlock=15
10:40AM TRC New block newBlock=16
10:40AM TRC Function executed successfully elapsedTimeSeconds=2
10:40AM DBG Obtained erc 721 contract address erc721Addr=0xEc59Ea1ACB9fc9F630B2DCe73790eD8Be0ac036e
10:40AM FTL Received critical error while running load test error="we weren't able to fetch any recall transactions"
exit status 1
```

## Jira / Linear Tickets

x

# Testing

x
