### PR TITLE
feat(rpcfuzz): add empty `eth_estimageGas`, `eth_sendTransaction` and `eth_sendRawTransaction` calls to `rpcfuzz`

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1171,7 +1171,6 @@ func loadTestRecall(ctx context.Context, c *ethclient.Client, nonce uint64, orig
 }
 
 func loadTestRPC(ctx context.Context, c *ethclient.Client, nonce uint64, ia *IndexedActivity) (t1 time.Time, t2 time.Time, err error) {
-
 	funcNum := randSrc.Intn(300)
 	t1 = time.Now()
 	defer func() { t2 = time.Now() }()

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -173,7 +173,6 @@ var (
 
 // setupTests will add all of the `RPCTests` to the `allTests` slice.
 func setupTests(ctx context.Context, rpcClient *rpc.Client) {
-
 	// cast rpc --rpc-url localhost:8545 net_version
 	allTests = append(allTests, &RPCTestGeneric{
 		Name:      "RPCTestNetVersion",
@@ -527,6 +526,23 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Args:      ArgsCoinbaseTransaction(ctx, rpcClient, &RPCTestTransactionArgs{To: testEthAddress.String(), Value: "0x123", Gas: "0x5208", Data: "0x", MaxFeePerGas: defaultMaxFeePerGas, MaxPriorityFeePerGas: defaultMaxPriorityFeePerGas}),
 		Validator: ValidateRegexString(`^0x[[:xdigit:]]{64}$`),
 		Flags:     FlagRequiresUnlock,
+	})
+
+	// $ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[],"id":1}' http://localhost:8545
+	// {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"missing value for required argument 0"}}
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthSendTransactionEmpty",
+		Method:    "eth_sendTransaction",
+		Args:      []interface{}{},
+		Validator: ValidateError(-32602, "missing value for required argument 0"),
+	})
+	// $ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[],"id":1}' http://localhost:8545
+	// {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"missing value for required argument 0"}}
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthSendRawTransactionEmpty",
+		Method:    "eth_sendRawTransaction",
+		Args:      []interface{}{},
+		Validator: ValidateError(-32602, "missing value for required argument 0"),
 	})
 
 	// cast rpc --rpc-url localhost:8545 eth_sendRawTransaction '{"from": "0xb9b1cf51a65b50f74ed8bcb258413c02cba2ec57", "to": "0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6", "data": "0x", "gas": "0x5208", "gasPrice": "0x1", "nonce": "0x1"}'

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -542,6 +542,7 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthSendTransactionEmpty",
 		Method:    "eth_sendTransaction",
 		Args:      []interface{}{},
+		Flags:     FlagErrorValidation,
 		Validator: ValidateError(invalidParamsErr, "missing value for required argument 0"),
 	})
 	// $ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[],"id":1}' http://localhost:8545
@@ -550,6 +551,7 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthSendRawTransactionEmpty",
 		Method:    "eth_sendRawTransaction",
 		Args:      []interface{}{},
+		Flags:     FlagErrorValidation,
 		Validator: ValidateError(invalidParamsErr, "missing value for required argument 0"),
 	})
 
@@ -640,6 +642,7 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Name:      "RPCTestEthEstimateGasEmpty",
 		Method:    "eth_estimateGas",
 		Args:      []interface{}{},
+		Flags:     FlagErrorValidation,
 		Validator: ValidateError(invalidParamsErr, `missing value for required argument 0`),
 	})
 

--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -610,6 +610,15 @@ func setupTests(ctx context.Context, rpcClient *rpc.Client) {
 		Flags: FlagStrictValidation,
 	})
 
+	// $ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc": "2.0", "method": "eth_estimateGas", "params": [], "id":1}' localhost:8545
+	// {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"missing value for required argument 0"}}
+	allTests = append(allTests, &RPCTestGeneric{
+		Name:      "RPCTestEthEstimateGasEmpty",
+		Method:    "eth_estimateGas",
+		Args:      []interface{}{},
+		Validator: ValidateError(-32602, `missing value for required argument 0`),
+	})
+
 	// cast block --rpc-url localhost:8545 latest
 	allTests = append(allTests, &RPCTestDynamicArgs{
 		Name:   "RPCTestEthGetBlockByHash",

--- a/cmd/rpcfuzz/usage.md
+++ b/cmd/rpcfuzz/usage.md
@@ -5,41 +5,65 @@ Some setup might be needed depending on how you're testing. We'll demonstrate wi
 In order to quickly test this, you can run geth in dev mode.
 
 ```bash
-$ geth --dev --dev.period 5 --http --http.addr localhost \
+$ geth \
+    --dev \
+    --dev.period 5 \
+    --http \
+    --http.addr localhost \
     --http.port 8545 \
-    --http.api 'admin,debug,web3,eth,txpool,personal,clique,miner,net' \
-    --verbosity 5 --rpc.gascap 50000000  --rpc.txfeecap 0 \
-    --miner.gaslimit  10 --miner.gasprice 1 --gpo.blocks 1 \
-    --gpo.percentile 1 --gpo.maxprice 10 --gpo.ignoreprice 2 \
+    --http.api 'admin,debug,web3,eth,txpool,personal,miner,net' \
+    --verbosity 5 \
+    --rpc.gascap 50000000 \
+    --rpc.txfeecap 0 \
+    --miner.gaslimit 10 \
+    --miner.gasprice 1 \
+    --gpo.blocks 1 \
+    --gpo.percentile 1 \
+    --gpo.maxprice 10 \
+    --gpo.ignoreprice 2 \
     --dev.gaslimit 50000000
 ```
 
 If we wanted to use erigon for testing, we could do something like this as well.
 
 ```bash
-$ erigon --chain dev --dev.period 5 --http --http.addr localhost \
+$ erigon \
+    --chain dev \
+    --dev.period 5 \
+    --http \
+    --http.addr localhost \
     --http.port 8545 \
-    --http.api 'admin,debug,web3,eth,txpool,personal,clique,miner,net' \
-    --verbosity 5 --rpc.gascap 50000000 \
-    --miner.gaslimit  10 --gpo.blocks 1 \
-    --gpo.percentile 1 --mine
+    --http.api 'admin,debug,web3,eth,txpool,clique,net' \
+    --verbosity 5 \
+    --rpc.gascap 50000000 \
+    --miner.gaslimit 10 \
+    --gpo.blocks 1 \
+    --gpo.percentile 1 \
+    --mine
 ```
 
 Once your Eth client is running and the RPC is functional, you'll need to transfer some amount of ether to a known account that ca be used for testing.
 
 ```
-$ cast send --from "$(cast rpc --rpc-url localhost:8545 eth_coinbase | jq -r '.')" \
-    --rpc-url localhost:8545 --unlocked --value 100ether \
-    0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
+$ cast send \
+    --from "$(cast rpc --rpc-url localhost:8545 eth_coinbase | jq -r '.')" \
+    --rpc-url localhost:8545 \
+    --unlocked \
+    --value 100ether \
+    --json \
+    0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 | jq
 ```
 
 Then we might want to deploy some test smart contracts. For the purposes of testing we'll our ERC20 contract.
 
 ```bash
-$ cast send --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
+$ cast send \
+    --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
     --private-key 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa \
-    --rpc-url localhost:8545 --create \
-    "$(cat ./contracts/ERC20.bin)"
+    --rpc-url localhost:8545 \
+    --json \
+    --create \
+    "$(cat ./contracts/tokens/ERC20/ERC20.bin)" | jq
 ```
 
 Once this has been completed this will be the address of the contract: `0x6fda56c57b0acadb96ed5624ac500c0429d59429`.

--- a/cmd/rpcfuzz/usage.md
+++ b/cmd/rpcfuzz/usage.md
@@ -69,7 +69,7 @@ $ cast send \
 Once this has been completed this will be the address of the contract: `0x6fda56c57b0acadb96ed5624ac500c0429d59429`.
 
 ```bash
-$  docker run -v $PWD/contracts:/contracts ethereum/solc:stable --storage-layout /contracts/ERC20.sol
+$  docker run -v $PWD/contracts:/contracts ethereum/solc:stable --storage-layout /contracts/tokens/ERC20/ERC20.sol
 ```
 
 ### Links

--- a/doc/polycli_rpcfuzz.md
+++ b/doc/polycli_rpcfuzz.md
@@ -90,7 +90,7 @@ $ cast send \
 Once this has been completed this will be the address of the contract: `0x6fda56c57b0acadb96ed5624ac500c0429d59429`.
 
 ```bash
-$  docker run -v $PWD/contracts:/contracts ethereum/solc:stable --storage-layout /contracts/ERC20.sol
+$  docker run -v $PWD/contracts:/contracts ethereum/solc:stable --storage-layout /contracts/tokens/ERC20/ERC20.sol
 ```
 
 ### Links

--- a/doc/polycli_rpcfuzz.md
+++ b/doc/polycli_rpcfuzz.md
@@ -26,41 +26,65 @@ Some setup might be needed depending on how you're testing. We'll demonstrate wi
 In order to quickly test this, you can run geth in dev mode.
 
 ```bash
-$ geth --dev --dev.period 5 --http --http.addr localhost \
+$ geth \
+    --dev \
+    --dev.period 5 \
+    --http \
+    --http.addr localhost \
     --http.port 8545 \
-    --http.api 'admin,debug,web3,eth,txpool,personal,clique,miner,net' \
-    --verbosity 5 --rpc.gascap 50000000  --rpc.txfeecap 0 \
-    --miner.gaslimit  10 --miner.gasprice 1 --gpo.blocks 1 \
-    --gpo.percentile 1 --gpo.maxprice 10 --gpo.ignoreprice 2 \
+    --http.api 'admin,debug,web3,eth,txpool,personal,miner,net' \
+    --verbosity 5 \
+    --rpc.gascap 50000000 \
+    --rpc.txfeecap 0 \
+    --miner.gaslimit 10 \
+    --miner.gasprice 1 \
+    --gpo.blocks 1 \
+    --gpo.percentile 1 \
+    --gpo.maxprice 10 \
+    --gpo.ignoreprice 2 \
     --dev.gaslimit 50000000
 ```
 
 If we wanted to use erigon for testing, we could do something like this as well.
 
 ```bash
-$ erigon --chain dev --dev.period 5 --http --http.addr localhost \
+$ erigon \
+    --chain dev \
+    --dev.period 5 \
+    --http \
+    --http.addr localhost \
     --http.port 8545 \
-    --http.api 'admin,debug,web3,eth,txpool,personal,clique,miner,net' \
-    --verbosity 5 --rpc.gascap 50000000 \
-    --miner.gaslimit  10 --gpo.blocks 1 \
-    --gpo.percentile 1 --mine
+    --http.api 'admin,debug,web3,eth,txpool,clique,net' \
+    --verbosity 5 \
+    --rpc.gascap 50000000 \
+    --miner.gaslimit 10 \
+    --gpo.blocks 1 \
+    --gpo.percentile 1 \
+    --mine
 ```
 
 Once your Eth client is running and the RPC is functional, you'll need to transfer some amount of ether to a known account that ca be used for testing.
 
 ```
-$ cast send --from "$(cast rpc --rpc-url localhost:8545 eth_coinbase | jq -r '.')" \
-    --rpc-url localhost:8545 --unlocked --value 100ether \
-    0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6
+$ cast send \
+    --from "$(cast rpc --rpc-url localhost:8545 eth_coinbase | jq -r '.')" \
+    --rpc-url localhost:8545 \
+    --unlocked \
+    --value 100ether \
+    --json \
+    0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 | jq
 ```
 
 Then we might want to deploy some test smart contracts. For the purposes of testing we'll our ERC20 contract.
 
 ```bash
-$ cast send --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
+$ cast send \
+    --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
     --private-key 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa \
-    --rpc-url localhost:8545 --create \
-    "$(cat ./contracts/ERC20.bin)"
+    --rpc-url localhost:8545 \
+    --json \
+    --create \
+    "$(cat ./contracts/tokens/ERC20/ERC20.bin)" | jq
 ```
 
 Once this has been completed this will be the address of the contract: `0x6fda56c57b0acadb96ed5624ac500c0429d59429`.


### PR DESCRIPTION
# Description

- Add empty `eth_estimageGas`, `eth_sendTransaction` and `eth_sendRawTransaction` calls to `rpcfuzz`.
- Add json-rpc error code constants.
- Update `rpcfuzz` usage doc.

## Jira / Linear Tickets

- [DVT-859](https://polygon.atlassian.net/browse/DVT-859)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] Run `rpcfuzz` against local geth.

We only keep the relevant methods to make the description shorter.

| NAME                                        | METHOD                  | TEST(S) PASSED | TEST(S) RAN |
|---------------------------------------------|-------------------------|----------------|------------|
| RPCTestEthEstimateGasEmpty                   | eth_estimateGas         | 1              | 1          |
| RPCTestEthSendRawTransactionEmpty            | eth_sendRawTransaction  | 1              | 1          |
| RPCTestEthSendTransactionEmpty               | eth_sendTransaction     | 1              | 1          |



[DVT-859]: https://polygon.atlassian.net/browse/DVT-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DVT-979]: https://polygon.atlassian.net/browse/DVT-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ