### PR TITLE
fix(loadtest): panic when loadtesting on a new chain with no blocks 

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -178,6 +178,11 @@ var LoadtestCmd = &cobra.Command{
 		if *inputLoadTestParams.AdaptiveBackoffFactor <= 0.0 {
 			return fmt.Errorf("the backoff factor needs to be non-zero positive")
 		}
+
+		if *inputLoadTestParams.ContractCallBlockInterval == 0 {
+			return fmt.Errorf("the contract call block interval must be strictly positive")
+		}
+
 		return nil
 	},
 }

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -743,6 +743,7 @@ func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, f func() err
 			if currentBlockNumber != lastBlockNumber {
 				lock = false
 			}
+			// Note: blockInterval > 0 (enforced at the flag level).
 			if blockDiff%blockInterval == 0 {
 				if !lock {
 					lock = true

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -721,7 +721,12 @@ func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, f func() err
 			return ctx.Err()
 		default:
 			elapsed := time.Since(start)
-			blockDiff := currentBlockNumber % startBlockNumber
+			var blockDiff uint64
+			if startBlockNumber == 0 {
+				blockDiff = startBlockNumber
+			} else {
+				blockDiff = currentBlockNumber % startBlockNumber
+			}
 			if blockDiff > numberOfBlocksToWaitFor {
 				log.Error().Err(err).Dur("elapsedTimeSeconds", elapsed).Msg("Exhausted waiting period")
 				return err
@@ -738,7 +743,7 @@ func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, f func() err
 			if currentBlockNumber != lastBlockNumber {
 				lock = false
 			}
-			if (currentBlockNumber%startBlockNumber)%blockInterval == 0 {
+			if blockDiff%blockInterval == 0 {
 				if !lock {
 					lock = true
 					err := f()


### PR DESCRIPTION
# Description

When sending load test on a new chain with no blocks, the software panics. This PR avoids the division by zero and also makes sure the block interval is strictly positive (to avoid another potential division by zero).

```sh
$ polycli loadtest \
  --private-key 26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48 \
  --verbosity 700 \
  --chain-id 1337 \
  --concurrency 1 \
  --requests 1000 \
  --rate-limit 100 \
  --mode r \
  --legacy \
  http://127.0.0.1:8545
9:43AM DBG Starting logger in console mode
9:43AM INF Starting Load Test
9:43AM INF Connecting with RPC endpoint to initialize load test parameters
9:43AM TRC Retrieved current gas price gasprice=1000000000
9:43AM TRC Current Block Number blocknumber=0
9:43AM TRC Current account balance balance=10000000000000000000000
9:43AM TRC Hex of odd length original=38D7EA4C68000
9:43AM DBG eip-1559 support detected
9:43AM TRC Detected Chain ID chainID=1337
9:43AM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"BatchSize":999,"ByteCount":1024,"CallOnly":false,"CallOnlyLatestBlock":false,"ChainID":1337,"ChainSupportBaseFee":true,"Concurrency":1,"ContractCallBlockInterval":1,"ContractCallNumberOfBlocksToWaitFor":30,"CurrentBaseFee":1000000000,"CurrentGasPrice":1000000000,"CurrentGasTipCap":null,"CurrentNonce":0,"DelAddress":null,"ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":17598557843537777818459448895819073762294649963548201139657808040799297436488,"X":93892095914855307777350407775934806739907407448656208519945352397394334536370,"Y":101172758353457024624117786934341612040181903195096392396278830431499338346753},"ERC20Address":"","ERC721Address":"","ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"ForcePriorityGasPrice":0,"FromETHAddress":"0x67b1d87101671b127f5f8714789c7192f7ad340e","Function":1,"HexSendAmount":"0x38D7EA4C68000","Iterations":1,"LegacyTransactionMode":true,"LtAddress":"","Mode":11,"Modes":["r"],"MultiMode":false,"ParsedModes":[11],"PrivateKey":"26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48","RateLimit":100,"RecallLength":50,"Requests":1000,"Seed":123456,"SendAmount":1000000000000000,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false,"URL":{"ForceQuery":false,"Fragment":"","Host":"127.0.0.1:8545","OmitHost":false,"Opaque":"","Path":"","RawFragment":"","RawPath":"","RawQuery":"","Scheme":"http","User":null}}
9:43AM TRC Load test contract address contractaddress=0x3126d03e98bb95a7d4046ba8a64369e6656fe448
9:43AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=0
panic: runtime error: integer divide by zero

goroutine 24 [running]:
github.com/maticnetwork/polygon-cli/cmd/loadtest.blockUntilSuccessful({0x1015dfc68, 0x102021720}, 0xc00001e968, 0xc0003eb1e8)
	/Users/leovct/Documents/work/polycli/cmd/loadtest/loadtest.go:791 +0x5ab
github.com/maticnetwork/polygon-cli/cmd/loadtest.getLoadTestContract({0x1015dfc68, 0x102021720}, 0x100f07020?, 0xc0001feb70?, 0xc0003ebbc8)
	/Users/leovct/Documents/work/polycli/cmd/loadtest/loadtest.go:673 +0x252
github.com/maticnetwork/polygon-cli/cmd/loadtest.mainLoop({0x1015dfc68?, 0x102021720}, 0xc00001e968, 0xc000248cf0)
	/Users/leovct/Documents/work/polycli/cmd/loadtest/loadtest.go:417 +0x5f7
github.com/maticnetwork/polygon-cli/cmd/loadtest.runLoadTest.func1()
	/Users/leovct/Documents/work/polycli/cmd/loadtest/loadtest.go:320 +0x91
github.com/maticnetwork/polygon-cli/cmd/loadtest.runLoadTest.func2()
	/Users/leovct/Documents/work/polycli/cmd/loadtest/loadtest.go:329 +0x22
created by github.com/maticnetwork/polygon-cli/cmd/loadtest.runLoadTest in goroutine 1
	/Users/leovct/Documents/work/polycli/cmd/loadtest/loadtest.go:328 +0x365
```

## Jira / Linear Tickets

- [DVT-992](https://polygon.atlassian.net/browse/DVT-992)

# Testing

```sh
$ polycli loadtest --private-key 26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48 --verbosity 700 --chain-id 1337 --concurrency 1 --requests 1000 --rate-limit 100 --mode r --legacy http://127.0.0.1:8545
9:51AM DBG Starting logger in console mode
9:51AM INF Starting Load Test
9:51AM INF Connecting with RPC endpoint to initialize load test parameters
9:51AM TRC Retrieved current gas price gasprice=1000000000
9:51AM TRC Current Block Number blocknumber=0
9:51AM TRC Current account balance balance=10000000000000000000000
9:51AM TRC Hex of odd length original=38D7EA4C68000
9:51AM DBG eip-1559 support detected
9:51AM TRC Detected Chain ID chainID=1337
9:51AM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"BatchSize":999,"ByteCount":1024,"CallOnly":false,"CallOnlyLatestBlock":false,"ChainID":1337,"ChainSupportBaseFee":true,"Concurrency":1,"ContractCallBlockInterval":1,"ContractCallNumberOfBlocksToWaitFor":30,"CurrentBaseFee":1000000000,"CurrentGasPrice":1000000000,"CurrentGasTipCap":null,"CurrentNonce":0,"DelAddress":null,"ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":17598557843537777818459448895819073762294649963548201139657808040799297436488,"X":93892095914855307777350407775934806739907407448656208519945352397394334536370,"Y":101172758353457024624117786934341612040181903195096392396278830431499338346753},"ERC20Address":"","ERC721Address":"","ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"ForcePriorityGasPrice":0,"FromETHAddress":"0x67b1d87101671b127f5f8714789c7192f7ad340e","Function":1,"HexSendAmount":"0x38D7EA4C68000","Iterations":1,"LegacyTransactionMode":true,"LtAddress":"","Mode":11,"Modes":["r"],"MultiMode":false,"ParsedModes":[11],"PrivateKey":"26e86e45f6fc45ec6e2ecd128cec80fa1d1505e5507dcd2ae58c3130a7a97b48","RateLimit":100,"RecallLength":50,"Requests":1000,"Seed":123456,"SendAmount":1000000000000000,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false,"URL":{"ForceQuery":false,"Fragment":"","Host":"127.0.0.1:8545","OmitHost":false,"Opaque":"","Path":"","RawFragment":"","RawPath":"","RawQuery":"","Scheme":"http","User":null}}
9:51AM TRC Load test contract address contractaddress=0x3126d03e98bb95a7d4046ba8a64369e6656fe448
9:51AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=0
9:51AM TRC New block newBlock=0
9:51AM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
9:51AM TRC New block newBlock=1
9:51AM TRC Function executed successfully elapsedTimeSeconds=1
9:51AM DBG Obtained load test contract address ltAddr=0x3126D03e98bb95a7d4046bA8A64369E6656Fe448
9:51AM TRC ERC20 contract address contractaddress=0x0d4c6c6605a729a379216c93e919711a081beba2
9:51AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=1
9:51AM TRC New block newBlock=1
9:51AM TRC Unable to execute function error="no contract code at given address" elapsedTimeSeconds=0
9:51AM TRC New block newBlock=2
9:51AM TRC Function executed successfully elapsedTimeSeconds=1
9:51AM TRC Starting blocking loop blockInterval=1 numberOfBlocksToWaitFor=30 startBlockNumber=2
9:51AM TRC New block newBlock=2
9:51AM TRC Unable to execute function error="ERC20 Balance is Zero" elapsedTimeSeconds=0
9:51AM TRC New block newBlock=3
9:51AM TRC Function executed successfully elapsedTimeSeconds=1
9:51AM DBG Obtained erc 20 contract address erc20Addr=0x0D4C6C6605A729A379216C93e919711a081BEbA2
...
```


[DVT-992]: https://polygon.atlassian.net/browse/DVT-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ