### PR TITLE
Feat: loadtest improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage.out
 
 .vscode
 .idea
+*.swp
+*.swo

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -73,6 +73,7 @@ type (
 		SummaryOutputMode                   *string
 		LegacyTransactionMode               *bool
 		RecallLength                        *uint64
+		BarChartNumBucket                   *int
 
 		// Computed
 		CurrentGasPrice     *big.Int
@@ -88,13 +89,23 @@ type (
 		ParsedModes         []loadTestMode
 		MultiMode           bool
 	}
+	Bucket struct {
+		Name  string
+		Start int64
+		End   int64
+		Count int
+	}
+
+	loadTestSamples []loadTestSample
+	Buckets         []*Bucket
 )
 
 var (
 	//go:embed usage.md
 	usage               string
 	inputLoadTestParams loadTestParams
-	loadTestResults     []loadTestSample
+	maxLoadTestTime     int64
+	loadTestResults     loadTestSamples
 	loadTestResutsMutex sync.RWMutex
 
 	hexwords = []byte{
@@ -232,6 +243,7 @@ rpc - call random rpc methods`)
 	ltp.SummaryOutputMode = LoadtestCmd.PersistentFlags().String("output-mode", "text", "Format mode for summary output (json | text)")
 	ltp.LegacyTransactionMode = LoadtestCmd.PersistentFlags().Bool("legacy", false, "Send a legacy transaction instead of an EIP1559 transaction.")
 	ltp.RecallLength = LoadtestCmd.PersistentFlags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
+	ltp.BarChartNumBucket = LoadtestCmd.PersistentFlags().Int("bar-chart-num-bucket", 10, "The number of buckets to visualize latency time distribution")
 	inputLoadTestParams = *ltp
 
 	// TODO Compression

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -306,7 +306,8 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 	log.Debug().Uint64("currentNonce", currentNonce).Msg("Finished main load test loop")
 	log.Debug().Msg("Waiting for remaining transactions to be completed and mined")
 
-	finalBlockNumber, err := waitForFinalBlock(ctx, c, rpc, startBlockNumber, startNonce, currentNonce)
+	var err error
+	finalBlockNumber, err = waitForFinalBlock(ctx, c, rpc, startBlockNumber, startNonce, currentNonce)
 	log.Debug().Uint64("currentNone", currentNonce).Uint64("final block number", finalBlockNumber).Msg("got final block number")
 	if err != nil {
 		log.Error().Err(err).Msg("there was an issue waiting for all transactions to be mined")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1368,7 +1368,7 @@ func waitForFinalBlock(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Cli
 			return 0, err
 		}
 		if currentNonceForFinalBlock < endNonce && maxWaitCount > 0 {
-			log.Trace().Uint64("endNonce", endNonce).Uint64("currentNonceForFinalBlock", currentNonceForFinalBlock).Uint64("prevNonceForFinalBlock", currentNonceForFinalBlock).Msg("Not all transactions have been mined. Waiting")
+			log.Trace().Uint64("endNonce", endNonce).Uint64("currentNonceForFinalBlock", currentNonceForFinalBlock).Uint64("prevNonceForFinalBlock", prevNonceForFinalBlock).Msg("Not all transactions have been mined. Waiting")
 			time.Sleep(5 * time.Second)
 			if currentNonceForFinalBlock == prevNonceForFinalBlock {
 				maxWaitCount = maxWaitCount - 1 // only decrement if currentNonceForFinalBlock doesn't progress

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	ui "github.com/gizak/termui/v3"
 	"github.com/maticnetwork/polygon-cli/contracts"
 	"github.com/maticnetwork/polygon-cli/contracts/tokens"
 	"github.com/maticnetwork/polygon-cli/metrics"
@@ -580,8 +579,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	lightSummary(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce, rl)
 
 	bucketedLoadTestResults := loadTestResults.Bucketize(*ltp.BarChartNumBucket)
-	termWidth, _ := ui.TerminalDimensions()
-	bucketedLoadTestResults.PrintBucketAsBarChart(termWidth / 2)
+	bucketedLoadTestResults.PrintBucketAsBarChart(50)
 
 	if *ltp.ShouldProduceSummary {
 		err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -303,7 +303,7 @@ func initializeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Cl
 }
 
 func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) error {
-	log.Debug().Uint64("currentNonce", currentNonce).Msg("Finished main load test loop")
+	log.Debug().Uint64("startNonce", startNonce).Uint64("lastNonce", currentNonce).Msg("Finished main load test loop")
 	log.Debug().Msg("Waiting for remaining transactions to be completed and mined")
 
 	var err error

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -308,12 +308,12 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 
 	var err error
 	finalBlockNumber, err = waitForFinalBlock(ctx, c, rpc, startBlockNumber, startNonce, currentNonce)
-	log.Debug().Uint64("currentNone", currentNonce).Uint64("final block number", finalBlockNumber).Msg("got final block number")
 	if err != nil {
 		log.Error().Err(err).Msg("there was an issue waiting for all transactions to be mined")
 	}
-
-	lightSummary(ctx, c, rpc, startBlockNumber, finalBlockNumber, rl)
+	endTime := time.Now()
+	startTime := loadTestResults[0].RequestTime
+	log.Debug().Uint64("currentNonce", currentNonce).Uint64("final block number", finalBlockNumber).Msg("got final block number")
 
 	if *inputLoadTestParams.ShouldProduceSummary {
 		err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)
@@ -321,7 +321,7 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 			log.Error().Err(err).Msg("There was an issue creating the load test summary")
 		}
 	}
-	printResults(loadTestResults)
+	lightSummary(loadTestResults, startTime, endTime, rl)
 
 	return nil
 }

--- a/cmd/loadtest/output.go
+++ b/cmd/loadtest/output.go
@@ -3,6 +3,7 @@ package loadtest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"golang.org/x/time/rate"
 	"math"
 	"math/big"
@@ -459,4 +460,60 @@ func lightSummary(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client, 
 		Float64("tps", tps).
 		Float64("final rate limit", float64(rl.Limit())).
 		Msg("rough test summary (ignores errors)")
+}
+
+const FullBlock string = "\u2588"
+
+func (b Buckets) PrintBucketAsBarChart(maxBarLength int) {
+	if len(b) == 0 {
+		return
+	}
+
+	maxCount := b[0].Count
+	for _, bucket := range b {
+		// fmt.Println(bucket)
+		if bucket.Count > maxCount {
+			maxCount = bucket.Count
+		}
+	}
+
+	for _, bucket := range b {
+		barLength := (bucket.Count * maxBarLength) / maxCount
+		// fmt.Println(bucket.Count, maxCount, maxBarLength, barLength)
+		bar := ""
+		for i := 0; i < barLength; i++ {
+			bar += FullBlock
+		}
+		fmt.Printf("|%15s ms| %s (%d)\n", bucket.Name, bar, bucket.Count)
+	}
+}
+
+func (lts loadTestSamples) Bucketize(numBuckets int) Buckets {
+	buckets := []*Bucket{}
+	bucketWidth := maxLoadTestTime / int64(numBuckets)
+
+	for i := 0; i < numBuckets; i++ {
+		startRange := int64(i) * bucketWidth
+		endRange := startRange + bucketWidth
+		stringRange := fmt.Sprintf("%d - %d", startRange, endRange)
+		bucket := Bucket{
+			Name:  stringRange,
+			Start: startRange,
+			End:   endRange,
+		}
+		buckets = append(buckets, &bucket)
+	}
+
+	for _, sample := range lts {
+		for _, b := range buckets {
+			sampleWaitTime := int64(sample.WaitTime.Milliseconds())
+			// fmt.Printf("%d, %d, %d\n", sampleWaitTime, b.Start, b.End)
+			if sampleWaitTime >= b.Start && sampleWaitTime < b.End {
+				b.Count += 1
+				break
+			}
+		}
+	}
+
+	return buckets
 }

--- a/cmd/loadtest/output.go
+++ b/cmd/loadtest/output.go
@@ -406,31 +406,6 @@ func isEmptyJSONResponse(r *json.RawMessage) bool {
 	return len(rawJson) == 0
 }
 
-func printResults(lts []loadTestSample) {
-	if len(lts) == 0 {
-		log.Error().Msg("No results recorded")
-		return
-	}
-
-	log.Info().Msg("* Results")
-	log.Info().Int("samples", len(lts)).Msg("Samples")
-
-	var meanWait float64
-	var totalWait float64 = 0
-	var numErrors uint64 = 0
-
-	for _, s := range lts {
-		if s.IsError {
-			numErrors += 1
-		}
-		totalWait = float64(s.WaitTime.Seconds()) + totalWait
-	}
-	meanWait = totalWait / float64(len(lts))
-
-	log.Info().Float64("meanWait between sending transactions", meanWait).Msg("Mean Wait")
-	log.Info().Uint64("numErrors", numErrors).Msg("Num errors")
-}
-
 func lightSummary(lts []loadTestSample, startTime, endTime time.Time, rl *rate.Limiter) {
 	if len(lts) == 0 {
 		log.Error().Msg("No results recorded")

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -106,6 +106,7 @@ The codebase has a contract that used for load testing. It's written in Yul and 
       --adaptive-cycle-duration-seconds uint       When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
       --adaptive-rate-limit                        Enable AIMD-style congestion control to automatically adjust request rate
       --adaptive-rate-limit-increment uint         When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --bar-chart-num-bucket int                   The number of buckets to visualize latency time distribution (default 10)
       --batch-size uint                            Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
   -b, --byte-count uint                            If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --call-only                                  When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -106,7 +106,6 @@ The codebase has a contract that used for load testing. It's written in Yul and 
       --adaptive-cycle-duration-seconds uint       When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
       --adaptive-rate-limit                        Enable AIMD-style congestion control to automatically adjust request rate
       --adaptive-rate-limit-increment uint         When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
-      --bar-chart-num-bucket int                   The number of buckets to visualize latency time distribution (default 10)
       --batch-size uint                            Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
   -b, --byte-count uint                            If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --call-only                                  When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.


### PR DESCRIPTION
# Description

Some loadtest improvements:
- `time-limit` reporting loadtest summary
- legacy transaction bugfix
- fix incorrect tps calculation in light summary
- bugfix with nil rate limiter

# Testing

Eg Functional ERC-721 loadtest:

```
$ go run main.go loadtest --chain-id 12321 \
    --legacy \
    --verbosity 700 \
    --iterations 1 \
    --mode 7 \
    --rate-limit 40 \
    --concurrency 20 \
    --requests 500 http://localhost:8123/
...
4:45AM DBG got final block number currentNonce=1582198 final block number=1609581
4:45AM INF * Results
4:45AM INF Samples samples=10000
4:45AM INF Start time of loadtest (first transaction sent) startTime=2023-10-20T04:33:47Z
4:45AM INF End time of loadtest (final transaction mined) endTime=2023-10-20T04:45:46Z
4:45AM INF Estimated tps tps=13.908103300385962
4:45AM INF Mean Wait meanWait between sending transactions=1.2280712369711047
4:45AM INF rough test summary final rate limit=40 testDuration (seconds)=719.005301012
4:45AM INF Num errors numErrors=0
4:45AM INF Finished
```
