### PR TITLE
fix: loadtest panic when cut off brutally with `ctrl+c`

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -316,12 +316,12 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 	var err error
 	finalBlockNumber, err = waitForFinalBlock(ctx, c, rpc, startBlockNumber, startNonce, currentNonce)
 	if err != nil {
-		log.Error().Err(err).Msg("there was an issue waiting for all transactions to be mined")
+		log.Error().Err(err).Msg("There was an issue waiting for all transactions to be mined")
 	}
 	if len(loadTestResults) > 0 {
 		startTime := loadTestResults[0].RequestTime
 		endTime := time.Now()
-		log.Debug().Uint64("currentNonce", currentNonce).Uint64("final block number", finalBlockNumber).Msg("got final block number")
+		log.Debug().Uint64("currentNonce", currentNonce).Uint64("final block number", finalBlockNumber).Msg("Got final block number")
 
 		if *inputLoadTestParams.ShouldProduceSummary {
 			err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -318,17 +318,21 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 	if err != nil {
 		log.Error().Err(err).Msg("there was an issue waiting for all transactions to be mined")
 	}
-	endTime := time.Now()
-	startTime := loadTestResults[0].RequestTime
-	log.Debug().Uint64("currentNonce", currentNonce).Uint64("final block number", finalBlockNumber).Msg("got final block number")
+	if len(loadTestResults) > 0 {
+		startTime := loadTestResults[0].RequestTime
+		endTime := time.Now()
+		log.Debug().Uint64("currentNonce", currentNonce).Uint64("final block number", finalBlockNumber).Msg("got final block number")
 
-	if *inputLoadTestParams.ShouldProduceSummary {
-		err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)
-		if err != nil {
-			log.Error().Err(err).Msg("There was an issue creating the load test summary")
+		if *inputLoadTestParams.ShouldProduceSummary {
+			err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)
+			if err != nil {
+				log.Error().Err(err).Msg("There was an issue creating the load test summary")
+			}
 		}
+		lightSummary(loadTestResults, startTime, endTime, rl)
+	} else {
+		log.Info().Msg("Loadtest stopped before completion")
 	}
-	lightSummary(loadTestResults, startTime, endTime, rl)
 
 	return nil
 }


### PR DESCRIPTION
# Description

![Screenshot 2023-10-20 at 19 14 30](https://github.com/maticnetwork/polygon-cli/assets/28714795/10766081-17ad-43c3-bba5-58e65e532930)

## Jira / Linear Tickets

x

# Testing

<img width="748" alt="Screenshot 2023-10-21 at 12 47 58" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/58522950-822c-4c62-bcb5-45813500c3e7">

