### PR TITLE
[DVT-1060] Add eth/67 and eth/68 protocols

### DIFF
--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -169,7 +169,7 @@ var SensorCmd = &cobra.Command{
 			Number:          block.Number.ToUint64(),
 		}
 
-		opts := p2p.Eth66ProtocolOptions{
+		opts := p2p.EthProtocolOptions{
 			Context:     cmd.Context(),
 			Database:    db,
 			Genesis:     &inputSensorParams.genesis,
@@ -190,11 +190,15 @@ var SensorCmd = &cobra.Command{
 			MaxPeers:       inputSensorParams.MaxPeers,
 			ListenAddr:     fmt.Sprintf(":%d", inputSensorParams.Port),
 			DiscAddr:       fmt.Sprintf(":%d", inputSensorParams.DiscoveryPort),
-			Protocols:      []ethp2p.Protocol{p2p.NewEth66Protocol(opts)},
 			DialRatio:      inputSensorParams.DialRatio,
 			NAT:            inputSensorParams.nat,
 			DiscoveryV4:    true,
 			DiscoveryV5:    true,
+			Protocols: []ethp2p.Protocol{
+				p2p.NewEthProtocol(66, opts),
+				p2p.NewEthProtocol(67, opts),
+				p2p.NewEthProtocol(68, opts),
+			},
 		}
 
 		if inputSensorParams.QuickStart {

--- a/p2p/types.go
+++ b/p2p/types.go
@@ -156,7 +156,7 @@ type rlpxConn struct {
 	logger zerolog.Logger
 }
 
-// Read reads an eth66 packet from the connection.
+// Read reads an eth protocol packet from the connection.
 func (c *rlpxConn) Read() Message {
 	code, rawData, _, err := c.Conn.Read()
 	if err != nil {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

- Adds `eth/66` and `eth/67`

## Jira / Linear Tickets

- [DVT-1060](https://polygon.atlassian.net/browse/DVT-1060)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] Seeing `New peer`s with versions `67` and `68`.
```
9:49PM INF New peer peer=enode://109be30a5dfcc16b3bdb3916c039464e49bd1ac81b5d04df19cb52dd1bf4c84635216fde36f411ade92373c41797941f91ac34fa3c9b99c2587ac22c6b18ed07@138.2.237.133:30303 status={"ForkID":{"Hash":[79,47,113,204],"Next":0},"Genesis":"0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b","Head":"0x57a190bf916c41f8f22ece291cc86a61dd3cd585d977cc75dfd25e455cd975ef","NetworkID":137,"ProtocolVersion":68,"TD":873119258}
9:49PM INF New peer peer=enode://1844fe238ad8da5390cd9491edc2403871479ef0844774d809ef36fcfe60f4db2b3e03fda0d5b9f35a6121e706e173d97e77ed8cf509b47cdd22073f09af2a6f@44.206.26.226:30327 status={"ForkID":{"Hash":[79,47,113,204],"Next":0},"Genesis":"0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b","Head":"0x1dce64c82ca465197a75c5f7fcd4f2924499ce28036b000d70571f9aad5ea3d7","NetworkID":137,"ProtocolVersion":67,"TD":873119235}
```
