### PR TITLE
Block Until Successful Fix

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -36,43 +36,41 @@ type (
 	}
 	loadTestParams struct {
 		// inputs
-		RPCUrl                              *string
-		Requests                            *int64
-		Concurrency                         *int64
-		BatchSize                           *uint64
-		TimeLimit                           *int64
-		ToRandom                            *bool
-		CallOnly                            *bool
-		CallOnlyLatestBlock                 *bool
-		ChainID                             *uint64
-		PrivateKey                          *string
-		ToAddress                           *string
-		HexSendAmount                       *string
-		RateLimit                           *float64
-		AdaptiveRateLimit                   *bool
-		SteadyStateTxPoolSize               *uint64
-		AdaptiveRateLimitIncrement          *uint64
-		AdaptiveCycleDuration               *uint64
-		AdaptiveBackoffFactor               *float64
-		Modes                               *[]string
-		Function                            *uint64
-		Iterations                          *uint64
-		ByteCount                           *uint64
-		Seed                                *int64
-		LtAddress                           *string
-		ERC20Address                        *string
-		ERC721Address                       *string
-		DelAddress                          *string
-		ContractCallNumberOfBlocksToWaitFor *uint64
-		ContractCallBlockInterval           *uint64
-		ForceContractDeploy                 *bool
-		ForceGasLimit                       *uint64
-		ForceGasPrice                       *uint64
-		ForcePriorityGasPrice               *uint64
-		ShouldProduceSummary                *bool
-		SummaryOutputMode                   *string
-		LegacyTransactionMode               *bool
-		RecallLength                        *uint64
+		RPCUrl                     *string
+		Requests                   *int64
+		Concurrency                *int64
+		BatchSize                  *uint64
+		TimeLimit                  *int64
+		ToRandom                   *bool
+		CallOnly                   *bool
+		CallOnlyLatestBlock        *bool
+		ChainID                    *uint64
+		PrivateKey                 *string
+		ToAddress                  *string
+		HexSendAmount              *string
+		RateLimit                  *float64
+		AdaptiveRateLimit          *bool
+		SteadyStateTxPoolSize      *uint64
+		AdaptiveRateLimitIncrement *uint64
+		AdaptiveCycleDuration      *uint64
+		AdaptiveBackoffFactor      *float64
+		Modes                      *[]string
+		Function                   *uint64
+		Iterations                 *uint64
+		ByteCount                  *uint64
+		Seed                       *int64
+		LtAddress                  *string
+		ERC20Address               *string
+		ERC721Address              *string
+		DelAddress                 *string
+		ForceContractDeploy        *bool
+		ForceGasLimit              *uint64
+		ForceGasPrice              *uint64
+		ForcePriorityGasPrice      *uint64
+		ShouldProduceSummary       *bool
+		SummaryOutputMode          *string
+		LegacyTransactionMode      *bool
+		RecallLength               *uint64
 
 		// Computed
 		CurrentGasPrice     *big.Int
@@ -184,10 +182,6 @@ func checkLoadtestFlags() error {
 		return fmt.Errorf("the backoff factor needs to be non-zero positive")
 	}
 
-	if ltp.ContractCallBlockInterval != nil && *ltp.ContractCallBlockInterval == 0 {
-		return fmt.Errorf("the contract call block interval must be strictly positive")
-	}
-
 	return nil
 }
 
@@ -219,8 +213,6 @@ func initFlags() {
 	ltp.AdaptiveBackoffFactor = LoadtestCmd.PersistentFlags().Float64("adaptive-backoff-factor", 2, "When using adaptive rate limiting, this flag controls our multiplicative decrease value.")
 	ltp.Iterations = LoadtestCmd.PersistentFlags().Uint64P("iterations", "i", 1, "If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size")
 	ltp.Seed = LoadtestCmd.PersistentFlags().Int64("seed", 123456, "A seed for generating random values and addresses")
-	ltp.ContractCallNumberOfBlocksToWaitFor = LoadtestCmd.PersistentFlags().Uint64("contract-call-nb-blocks-to-wait-for", 30, "The number of blocks to wait for before giving up on a contract deployment")
-	ltp.ContractCallBlockInterval = LoadtestCmd.PersistentFlags().Uint64("contract-call-block-interval", 1, "During deployment, this flag controls if we should check every block, every other block, or every nth block to determine that the contract has been deployed")
 	ltp.ForceGasLimit = LoadtestCmd.PersistentFlags().Uint64("gas-limit", 0, "In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas")
 	ltp.ForceGasPrice = LoadtestCmd.PersistentFlags().Uint64("gas-price", 0, "In environments where the gas price can't be determined automatically, we can specify it manually")
 	ltp.ForcePriorityGasPrice = LoadtestCmd.PersistentFlags().Uint64("priority-gas-price", 0, "Specify Gas Tip Price in the case of EIP-1559")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -760,7 +760,7 @@ func getERC721Contract(ctx context.Context, c *ethclient.Client, tops *bind.Tran
 
 func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, retryable func() error) error {
 	// this function use to be very complicated (and not work). I'm dumbing this down to a basic time based retryable which should work 99% of the time
-	b := backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 24)
+	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 24), ctx)
 	return backoff.Retry(retryable, b)
 }
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -65,8 +65,6 @@ const (
 	codeQualityPrivateKey = "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa"
 )
 
-var errWaitingPeriodExhausted = errors.New("waiting period exhausted")
-
 func characterToLoadTestMode(mode string) (loadTestMode, error) {
 	switch mode {
 	case "t", "transaction":

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -23,6 +23,7 @@ import (
 	"github.com/maticnetwork/polygon-cli/rpctypes"
 	"github.com/maticnetwork/polygon-cli/util"
 
+	"github.com/cenkalti/backoff/v4"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -759,66 +760,10 @@ func getERC721Contract(ctx context.Context, c *ethclient.Client, tops *bind.Tran
 	return
 }
 
-func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, f func() error) error {
-	numberOfBlocksToWaitFor := *inputLoadTestParams.ContractCallNumberOfBlocksToWaitFor
-	blockInterval := *inputLoadTestParams.ContractCallBlockInterval
-	start := time.Now()
-	currStartBlockNumber, err := c.BlockNumber(ctx)
-	if err != nil {
-		log.Error().Err(err).Msg("Error getting block number")
-		return err
-	}
-	log.Trace().
-		Uint64("currStartBlockNumber", currStartBlockNumber).
-		Uint64("numberOfBlocksToWaitFor", numberOfBlocksToWaitFor).
-		Uint64("blockInterval", blockInterval).
-		Msg("Starting blocking loop")
-	var lastBlockNumber, currentBlockNumber uint64
-	var lock bool
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			elapsed := time.Since(start)
-			var blockDiff uint64
-			if currStartBlockNumber == 0 {
-				blockDiff = currStartBlockNumber
-			} else {
-				blockDiff = currentBlockNumber % currStartBlockNumber
-			}
-			if blockDiff > numberOfBlocksToWaitFor {
-				log.Error().Err(err).Dur("elapsedTimeSeconds", elapsed).Msg("Waiting period exhausted")
-				return errWaitingPeriodExhausted
-			}
-
-			currentBlockNumber, err = c.BlockNumber(ctx)
-			if err != nil {
-				log.Error().Err(err).Msg("Error getting block number")
-				return err
-			} else {
-				log.Trace().Uint64("newBlock", currentBlockNumber).Msg("New block")
-			}
-
-			if currentBlockNumber != lastBlockNumber {
-				lock = false
-			}
-			// Note: blockInterval > 0 (enforced at the flag level).
-			if blockDiff%blockInterval == 0 {
-				if !lock {
-					lock = true
-					err := f()
-					if err == nil {
-						log.Trace().Err(err).Dur("elapsedTimeSeconds", elapsed).Msg("Function executed successfully")
-						return nil
-					}
-					log.Trace().Err(err).Dur("elapsedTimeSeconds", elapsed).Msg("Unable to execute function")
-				}
-			}
-			lastBlockNumber = currentBlockNumber
-			time.Sleep(time.Second)
-		}
-	}
+func blockUntilSuccessful(ctx context.Context, c *ethclient.Client, retryable func() error) error {
+	// this function use to be very complicated (and not work). I'm dumbing this down to a basic time based retryable which should work 99% of the time
+	b := backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 24)
+	return backoff.Retry(retryable, b)
 }
 
 func loadTestTransaction(ctx context.Context, c *ethclient.Client, nonce uint64) (t1 time.Time, t2 time.Time, err error) {

--- a/cmd/loadtest/uniswapv3/pool.go
+++ b/cmd/loadtest/uniswapv3/pool.go
@@ -19,7 +19,7 @@ var (
 	poolReserveForOneToken = big.NewInt(1_000_000_000_000)
 
 	// The timeout of the mint operation (liquidity providing).
-	mintOperationTimeout = 10 * time.Second
+	mintOperationTimeout = 1 * time.Hour
 )
 
 // The maximum tick that may be passed to `getSqrtRatioAtTick` computed from log base 1.0001 of 2**128.

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	ui "github.com/gizak/termui/v3"
 	"github.com/gizak/termui/v3/widgets"
 	"github.com/maticnetwork/polygon-cli/metrics"

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -102,56 +102,54 @@ The codebase has a contract that used for load testing. It's written in Yul and 
 ## Flags
 
 ```bash
-      --adaptive-backoff-factor float              When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
-      --adaptive-cycle-duration-seconds uint       When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
-      --adaptive-rate-limit                        Enable AIMD-style congestion control to automatically adjust request rate
-      --adaptive-rate-limit-increment uint         When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
-      --batch-size uint                            Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
-  -b, --byte-count uint                            If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
-      --call-only                                  When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
-      --call-only-latest                           When using call only mode with recall, should we execute on the latest block or on the original block
-      --chain-id uint                              The chain id for the transactions.
-  -c, --concurrency int                            Number of requests to perform concurrently. Default is one request at a time. (default 1)
-      --contract-call-block-interval uint          During deployment, this flag controls if we should check every block, every other block, or every nth block to determine that the contract has been deployed (default 1)
-      --contract-call-nb-blocks-to-wait-for uint   The number of blocks to wait for before giving up on a contract deployment (default 30)
-      --erc20-address string                       The address of a pre-deployed ERC20 contract
-      --erc721-address string                      The address of a pre-deployed ERC721 contract
-      --force-contract-deploy                      Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
-  -f, --function --mode f                          A specific function to be called if running with --mode f or a specific precompiled contract when running with `--mode a` (default 1)
-      --gas-limit uint                             In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
-      --gas-price uint                             In environments where the gas price can't be determined automatically, we can specify it manually
-  -h, --help                                       help for loadtest
-  -i, --iterations uint                            If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
-      --legacy                                     Send a legacy transaction instead of an EIP1559 transaction.
-      --lt-address string                          The address of a pre-deployed load test contract
-  -m, --mode strings                               The testing mode to use. It can be multiple like: "t,c,d,f"
-                                                   t - sending transactions
-                                                   d - deploy contract
-                                                   c - call random contract functions
-                                                   f - call specific contract function
-                                                   p - call random precompiled contracts
-                                                   a - call a specific precompiled contract address
-                                                   s - store mode
-                                                   r - random modes
-                                                   2 - ERC20 transfers
-                                                   7 - ERC721 mints
-                                                   v3 - UniswapV3 swaps
-                                                   R - total recall
-                                                   rpc - call random rpc methods (default [t])
-      --output-mode string                         Format mode for summary output (json | text) (default "text")
-      --priority-gas-price uint                    Specify Gas Tip Price in the case of EIP-1559
-      --private-key string                         The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
-      --rate-limit float                           An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
-      --recall-blocks uint                         The number of blocks that we'll attempt to fetch for recall (default 50)
-  -n, --requests int                               Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
-  -r, --rpc-url string                             The RPC endpoint url (default "http://localhost:8545")
-      --seed int                                   A seed for generating random values and addresses (default 123456)
-      --send-amount string                         The amount of wei that we'll send every transaction (default "0x38D7EA4C68000")
-      --steady-state-tx-pool-size uint             When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
-      --summarize                                  Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
-  -t, --time-limit int                             Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
-      --to-address string                          The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
-      --to-random                                  When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
+      --adaptive-backoff-factor float          When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
+      --adaptive-cycle-duration-seconds uint   When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
+      --adaptive-rate-limit                    Enable AIMD-style congestion control to automatically adjust request rate
+      --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
+  -b, --byte-count uint                        If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
+      --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
+      --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
+      --chain-id uint                          The chain id for the transactions.
+  -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
+      --erc20-address string                   The address of a pre-deployed ERC20 contract
+      --erc721-address string                  The address of a pre-deployed ERC721 contract
+      --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
+  -f, --function --mode f                      A specific function to be called if running with --mode f or a specific precompiled contract when running with `--mode a` (default 1)
+      --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
+      --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually
+  -h, --help                                   help for loadtest
+  -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
+      --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
+      --lt-address string                      The address of a pre-deployed load test contract
+  -m, --mode strings                           The testing mode to use. It can be multiple like: "t,c,d,f"
+                                               t - sending transactions
+                                               d - deploy contract
+                                               c - call random contract functions
+                                               f - call specific contract function
+                                               p - call random precompiled contracts
+                                               a - call a specific precompiled contract address
+                                               s - store mode
+                                               r - random modes
+                                               2 - ERC20 transfers
+                                               7 - ERC721 mints
+                                               v3 - UniswapV3 swaps
+                                               R - total recall
+                                               rpc - call random rpc methods (default [t])
+      --output-mode string                     Format mode for summary output (json | text) (default "text")
+      --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
+      --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
+      --rate-limit float                       An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
+      --recall-blocks uint                     The number of blocks that we'll attempt to fetch for recall (default 50)
+  -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
+  -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
+      --seed int                               A seed for generating random values and addresses (default 123456)
+      --send-amount string                     The amount of wei that we'll send every transaction (default "0x38D7EA4C68000")
+      --steady-state-tx-pool-size uint         When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
+      --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
+  -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
+      --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
+      --to-random                              When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
 ```
 
 The command also inherits flags from parent commands.

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -76,43 +76,41 @@ Contracts are cloned from the different Uniswap repositories, compiled with a sp
 The command also inherits flags from parent commands.
 
 ```bash
-      --adaptive-backoff-factor float              When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
-      --adaptive-cycle-duration-seconds uint       When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
-      --adaptive-rate-limit                        Enable AIMD-style congestion control to automatically adjust request rate
-      --adaptive-rate-limit-increment uint         When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
-      --batch-size uint                            Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
-      --call-only                                  When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
-      --call-only-latest                           When using call only mode with recall, should we execute on the latest block or on the original block
-      --chain-id uint                              The chain id for the transactions.
-  -c, --concurrency int                            Number of requests to perform concurrently. Default is one request at a time. (default 1)
-      --config string                              config file (default is $HOME/.polygon-cli.yaml)
-      --contract-call-block-interval uint          During deployment, this flag controls if we should check every block, every other block, or every nth block to determine that the contract has been deployed (default 1)
-      --contract-call-nb-blocks-to-wait-for uint   The number of blocks to wait for before giving up on a contract deployment (default 30)
-      --gas-limit uint                             In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
-      --gas-price uint                             In environments where the gas price can't be determined automatically, we can specify it manually
-  -i, --iterations uint                            If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
-      --legacy                                     Send a legacy transaction instead of an EIP1559 transaction.
-      --output-mode string                         Format mode for summary output (json | text) (default "text")
-      --pretty-logs                                Should logs be in pretty format or JSON (default true)
-      --priority-gas-price uint                    Specify Gas Tip Price in the case of EIP-1559
-      --private-key string                         The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
-      --rate-limit float                           An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
-  -n, --requests int                               Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
-  -r, --rpc-url string                             The RPC endpoint url (default "http://localhost:8545")
-      --seed int                                   A seed for generating random values and addresses (default 123456)
-      --send-amount string                         The amount of wei that we'll send every transaction (default "0x38D7EA4C68000")
-      --steady-state-tx-pool-size uint             When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
-      --summarize                                  Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
-  -t, --time-limit int                             Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
-      --to-address string                          The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
-      --to-random                                  When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
-  -v, --verbosity int                              0 - Silent
-                                                   100 Fatal
-                                                   200 Error
-                                                   300 Warning
-                                                   400 Info
-                                                   500 Debug
-                                                   600 Trace (default 400)
+      --adaptive-backoff-factor float          When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
+      --adaptive-cycle-duration-seconds uint   When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
+      --adaptive-rate-limit                    Enable AIMD-style congestion control to automatically adjust request rate
+      --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
+      --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
+      --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
+      --chain-id uint                          The chain id for the transactions.
+  -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
+      --config string                          config file (default is $HOME/.polygon-cli.yaml)
+      --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
+      --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually
+  -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
+      --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
+      --output-mode string                     Format mode for summary output (json | text) (default "text")
+      --pretty-logs                            Should logs be in pretty format or JSON (default true)
+      --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
+      --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
+      --rate-limit float                       An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
+  -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
+  -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
+      --seed int                               A seed for generating random values and addresses (default 123456)
+      --send-amount string                     The amount of wei that we'll send every transaction (default "0x38D7EA4C68000")
+      --steady-state-tx-pool-size uint         When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
+      --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
+  -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
+      --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
+      --to-random                              When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
+  -v, --verbosity int                          0 - Silent
+                                               100 Fatal
+                                               200 Error
+                                               300 Warning
+                                               400 Info
+                                               500 Debug
+                                               600 Trace (default 400)
 ```
 
 ## See also

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	cloud.google.com/go/datastore v1.14.0
 	github.com/btcsuite/btcutil v1.0.2
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ethereum/go-ethereum v1.13.2
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/google/gofuzz v1.2.0
@@ -46,6 +45,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.7.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cockroachdb/errors v1.8.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=


### PR DESCRIPTION
The `blockUntilSuccessful` had gotten weirdly complicated (and yet still didn't work). I was planning to add logic to estimate block intervals, but then I figured it would be better just to have a simpler time based implementation and drop some of this complicated logic. If this doesn't work, then it means there is a use case where waiting for 2 minutes doesn't work which seems surprising.