### PR TITLE
fix: `polycli loadtest` does not stop immediately when one try to interrupt it with `Ctrl+C`

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -365,17 +365,17 @@ func runLoadTest(ctx context.Context) error {
 	// Make sure to define any logic associated to the load test (initialization, main load test loop
 	// or completion steps) in this function in order to handle cancellation signals properly.
 	loopFunc := func() error {
-		if initializeLoadTestParams(ctx, ec) != nil {
+		if err = initializeLoadTestParams(ctx, ec); err != nil {
 			log.Error().Err(err).Msg("Error initializing load test parameters")
 			return err
 		}
 
-		if mainLoop(ctx, ec, rpc) != nil {
+		if err = mainLoop(ctx, ec, rpc); err != nil {
 			log.Error().Err(err).Msg("Error during the main load test loop")
 			return err
 		}
 
-		if completeLoadTest(ctx, ec, rpc) != nil {
+		if err = completeLoadTest(ctx, ec, rpc); err != nil {
 			log.Error().Err(err).Msg("Encountered error while wrapping up loadtest")
 		}
 		return nil

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -351,7 +351,7 @@ func runLoadTest(ctx context.Context) error {
 		overallTimer = new(time.Timer)
 	}
 
-	// // Dial the Ethereum RPC server.
+	// Dial the Ethereum RPC server.
 	rpc, err := ethrpc.DialContext(ctx, *inputLoadTestParams.RPCUrl)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to dial rpc")
@@ -385,14 +385,14 @@ func runLoadTest(ctx context.Context) error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 
-	// // Initialize channels for handling errors and running the main loop.
+	// Initialize channels for handling errors and running the main loop.
 	loadTestResults = make([]loadTestSample, 0)
 	errCh := make(chan error)
 	go func() {
 		errCh <- loopFunc()
 	}()
 
-	// // Wait for the load test to complete, either due to time limit, interrupt signal, or completion.
+	// Wait for the load test to complete, either due to time limit, interrupt signal, or completion.
 	select {
 	case <-overallTimer.C:
 		log.Info().Msg("Time's up")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -356,12 +356,18 @@ func runLoadTest(ctx context.Context) error {
 	ec := ethclient.NewClient(rpc)
 
 	loopFunc := func() error {
-		err = initializeLoadTestParams(ctx, ec)
-		if err != nil {
+		if err := initializeLoadTestParams(ctx, ec); err != nil {
 			return err
 		}
 
-		return mainLoop(ctx, ec, rpc)
+		if err := mainLoop(ctx, ec, rpc); err != nil {
+			return err
+		}
+
+		if err := completeLoadTest(ctx, ec, rpc); err != nil {
+			log.Error().Err(err).Msg("Encountered error while wrapping up loadtest")
+		}
+		return nil
 	}
 
 	sigCh := make(chan os.Signal, 1)
@@ -383,11 +389,6 @@ func runLoadTest(ctx context.Context) error {
 		if err != nil {
 			log.Fatal().Err(err).Msg("Received critical error while running load test")
 		}
-	}
-
-	err = completeLoadTest(ctx, ec, rpc)
-	if err != nil {
-		log.Error().Err(err).Msg("Encountered error while wrapping up loadtest")
 	}
 
 	log.Info().Msg("Finished")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -365,17 +365,17 @@ func runLoadTest(ctx context.Context) error {
 	// Make sure to define any logic associated to the load test (initialization, main load test loop
 	// or ven completion steps) in this function in order to handle cancellation signals properly.
 	loopFunc := func() error {
-		if err := initializeLoadTestParams(ctx, ec); err != nil {
+		if initializeLoadTestParams(ctx, ec) != nil {
 			log.Error().Err(err).Msg("Error initializing load test parameters")
 			return err
 		}
 
-		if err := mainLoop(ctx, ec, rpc); err != nil {
+		if mainLoop(ctx, ec, rpc) != nil {
 			log.Error().Err(err).Msg("Error during the main load test loop")
 			return err
 		}
 
-		if err := completeLoadTest(ctx, ec, rpc); err != nil {
+		if completeLoadTest(ctx, ec, rpc) != nil {
 			log.Error().Err(err).Msg("Encountered error while wrapping up loadtest")
 		}
 		return nil

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -363,7 +363,7 @@ func runLoadTest(ctx context.Context) error {
 
 	// Define the main loop function.
 	// Make sure to define any logic associated to the load test (initialization, main load test loop
-	// or ven completion steps) in this function in order to handle cancellation signals properly.
+	// or completion steps) in this function in order to handle cancellation signals properly.
 	loopFunc := func() error {
 		if initializeLoadTestParams(ctx, ec) != nil {
 			log.Error().Err(err).Msg("Error initializing load test parameters")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -378,6 +378,7 @@ func runLoadTest(ctx context.Context) error {
 		log.Info().Msg("Time's up")
 	case <-sigCh:
 		log.Info().Msg("Interrupted.. Stopping load test")
+		return nil
 	case err = <-errCh:
 		if err != nil {
 			log.Fatal().Err(err).Msg("Received critical error while running load test")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	cloud.google.com/go/datastore v1.14.0
 	github.com/btcsuite/btcutil v1.0.2
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/ethereum/go-ethereum v1.13.2
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/google/gofuzz v1.2.0
@@ -45,7 +46,6 @@ require (
 	github.com/bits-and-blooms/bitset v1.7.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cockroachdb/errors v1.8.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
# Description

- Move `completeLoadTest` inside `loopFunc` to handle cancellation signals properly.
- Document `runLoadTest` function.

## Jira / Linear Tickets

- [DVT-1069](https://polygon.atlassian.net/browse/DVT-1069)

# Testing

- [x] Make sure `polycli loadtest` stops when performing load test
- [x] Make sure `polycli loadtest` stops when completing load test (summarising)


[DVT-1069]: https://polygon.atlassian.net/browse/DVT-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ