### PR TITLE
fix: release names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 
 on:
   push:
@@ -52,6 +52,7 @@ jobs:
           else
             echo "✅ The documentation is up to date."
           fi
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: polycli-releaser
+name: release
 
 on:
   push:
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: write
-  # packages: write
-  # issues: write
 
 env:
   GO_VERSION: "1.21"
@@ -18,36 +16,36 @@ jobs:
   manual-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install go
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --yes gcc-aarch64-linux-gnu
 
-      - name: Perform cross build and compress binaries
-        shell: bash
+      - name: Perform cross builds
+        run: make cross
+
+      - name: Compress binaries
         run: |
-          make cross
-          pushd out
-          echo -n "${{github.ref_name}}" | sed 's/^v//' | tee ref_name.txt
-          readonly tag_name="$(cat ref_name.txt)"
-          echo "$tag_name"
+          cd out
+          tar czf polycli_${GITHUB_REF#refs/tags/}_linux_arm64.tar.gz polycli_${GITHUB_REF#refs/tags/}_linux_arm64/
+          tar czf polycli_${GITHUB_REF#refs/tags/}_linux_amd64.tar.gz polycli_${GITHUB_REF#refs/tags/}_linux_amd64/
 
-          mkdir polycli_${tag_name}_linux_arm64/
-          mv linux-arm64-polycli polycli_${tag_name}_linux_arm64/polycli
-          tar czf polycli_${tag_name}_linux_arm64.tar.gz polycli_${tag_name}_linux_arm64/
-
-          mkdir polycli_${tag_name}_linux_amd64/
-          mv linux-amd64-polycli polycli_${tag_name}_linux_amd64/polycli
-          tar czf polycli_${tag_name}_linux_amd64.tar.gz polycli_${tag_name}_linux_amd64/
+      - name: Get git tag
+        id: get_tag
+        run: echo "::set-output name=tag::$(git describe --tags --exact-match HEAD)"
 
       - name: Publish binaries
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: out/*.tar.gz
-          tag: ${{ github.ref }}
-          overwrite: true
+          tag: ${{ steps.get_tag.outputs.tag }}
+          release_name: ${{ steps.get_tag.outputs.tag }}
           file_glob: true
+          file: out/*.tar.gz
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,14 @@ jobs:
           tar czf polycli_${GITHUB_REF#refs/tags/}_linux_amd64.tar.gz polycli_${GITHUB_REF#refs/tags/}_linux_amd64/
 
       - name: Get git tag
-        id: get_tag
-        run: echo "::set-output name=tag::$(git describe --tags --exact-match HEAD)"
+        run: echo "tag=$(git describe --tags --exact-match HEAD)" >> $GITHUB_ENV
 
       - name: Publish binaries
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.get_tag.outputs.tag }}
-          release_name: ${{ steps.get_tag.outputs.tag }}
+          tag: ${{ env.tag }}
+          release_name: ${{ env.tag }}
           file_glob: true
           file: out/*.tar.gz
           overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -44,26 +44,26 @@ cross: $(BUILD_DIR) ## Cross-compile go binaries using CGO.
 # Notes:
 # - `-s -w` enables to strip debug and suppress warnings.
 # - `-linkmode external -extldflags "-static-libgo"` allows dynamic linking.
-	echo "Building linux-arm64-$(BIN_NAME)..."
+	echo "Building $(BIN_NAME)_$(GIT_TAG)_linux_arm64..."
 	CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build \
 			-ldflags '$(VERSION_FLAGS) -s -w -linkmode external -extldflags "-static-libgo"' \
 			-tags netgo \
-			-o $(BUILD_DIR)/linux-arm64-$(BIN_NAME) \
+			-o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_arm64 \
 			main.go
 
-	echo "Building linux-amd64-$(BIN_NAME)..."
+	echo "Building $(BIN_NAME)_$(GIT_TAG)_linux_amd64..."
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
 			-ldflags '$(VERSION_FLAGS) -s -w -linkmode external -extldflags "-static-libgo"' \
 			-tags netgo \
-			-o $(BUILD_DIR)/linux-amd64-$(BIN_NAME) \
+			-o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_amd64 \
 			main.go
 
 .PHONY: simplecross
 simplecross: $(BUILD_DIR) ## Cross-compile go binaries without using CGO.
-	GOOS=linux  GOARCH=arm64 go build -o $(BUILD_DIR)/linux-arm64-$(BIN_NAME)  main.go
-	GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/darwin-arm64-$(BIN_NAME) main.go
-	GOOS=linux  GOARCH=amd64 go build -o $(BUILD_DIR)/linux-amd64-$(BIN_NAME)  main.go
-	GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/darwin-amd64-$(BIN_NAME) main.go
+	GOOS=linux  GOARCH=arm64 go build -o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_arm64  main.go
+	GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_darwin_arm64 main.go
+	GOOS=linux  GOARCH=amd64 go build -o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_amd64  main.go
+	GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_darwin_amd64 main.go
 
 .PHONY: clean
 clean: ## Clean the binary folder.


### PR DESCRIPTION
# Description

Follow up of #145 and #149.

- **Fix release names**. Instead of having release names with long and detailed descriptions, they're going to be shortened to just the version numbers. For instance, rather than a name like "[v0.1.35: fix: polycli loadtest does not stop immediately when one tries to int…](https://github.com/maticnetwork/polygon-cli/releases/tag/v0.1.35)", it will be simplified to just `v0.1.35`. This change aims to make release names cleaner and more concise.
- Nit: rename `test.yml` workflow into `ci.yml`.

## Jira / Linear Tickets

- [DVT-1032](https://polygon.atlassian.net/browse/DVT-1032)

# Testing

Create a dummy tag called `test` and push it to trigger the `release` job.

<img width="1252" alt="Screenshot 2023-11-03 at 16 15 46" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/05c6d7b5-dc3d-4477-ab4d-453d9b35d3be">

<img width="805" alt="Screenshot 2023-11-03 at 16 16 13" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/1f110c65-3e3e-4ffe-830b-6e7ea4307b28">



[DVT-1032]: https://polygon.atlassian.net/browse/DVT-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ