### PR TITLE
fix: `monitor` hangs if batch requests are disabled

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -22,6 +23,8 @@ import (
 	"github.com/maticnetwork/polygon-cli/rpctypes"
 	"github.com/rs/zerolog/log"
 )
+
+var errBatchRequestsNotSupported = errors.New("batch requests are not supported")
 
 var (
 	windowSize         int
@@ -87,6 +90,11 @@ func monitor(ctx context.Context) error {
 		return err
 	}
 	ec := ethclient.NewClient(rpc)
+
+	// Check if batch requests are supported.
+	if err := checkBatchRequestsSupport(ctx, ec.Client()); err != nil {
+		return errBatchRequestsNotSupported
+	}
 
 	ms := new(monitorStatus)
 	ms.BlocksLock.Lock()
@@ -240,11 +248,9 @@ func (ms *monitorStatus) getBlockRange(ctx context.Context, from, to *big.Int, r
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 3 * time.Minute
 	retryable := func() error {
-		err := rpc.BatchCallContext(ctx, blms)
-		return err
+		return rpc.BatchCallContext(ctx, blms)
 	}
-	err := backoff.Retry(retryable, b)
-	if err != nil {
+	if err := backoff.Retry(retryable, b); err != nil {
 		return err
 	}
 
@@ -702,4 +708,14 @@ func max(nums ...int) int {
 		}
 	}
 	return m
+}
+
+// checkBatchRequestsSupport checks if batch requests are supported by making a sample batch request.
+// https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber
+func checkBatchRequestsSupport(ctx context.Context, ec *ethrpc.Client) error {
+	batchRequest := []ethrpc.BatchElem{
+		{Method: "eth_blockNumber"},
+		{Method: "eth_blockNumber"},
+	}
+	return ec.BatchCallContext(ctx, batchRequest)
 }

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -92,7 +92,7 @@ func monitor(ctx context.Context) error {
 	ec := ethclient.NewClient(rpc)
 
 	// Check if batch requests are supported.
-	if err := checkBatchRequestsSupport(ctx, ec.Client()); err != nil {
+	if err = checkBatchRequestsSupport(ctx, ec.Client()); err != nil {
 		return errBatchRequestsNotSupported
 	}
 


### PR DESCRIPTION
# Description

`polycli monitor` hangs if batch requests are disabled. In order to fix this issue, we send a sample batch request to check if the RPC supports this kind of requests before fetching any blocks. If the call fails, we return a standard error.

## Jira / Linear Tickets

- [DVT-1120](https://polygon.atlassian.net/browse/DVT-1120)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

I didn't want to run the `zkevm` node so I wrote a very simple [proxy](https://github.com/leovct/polygon/tree/main/tools/proxy) server that can toggle batch request support on the fly using command-line flags. The proxy forwards requests to a local node running at `localhost:8545` and returns the response to the client.

- [x] Run the proxy and allow batch requests

```bash
$ go run main.go monitor --rpc-url http://localhost:8080
```

<img width="1788" alt="Screenshot 2023-11-23 at 10 38 05" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/fc5ed182-eb57-47b7-a9e8-4e139ed5f9b0">


- [x] Run the proxy and disable batch requests.

```bash
$ go run main.go monitor --rpc-url http://localhost:8080
Error: batch requests are not supported
Usage:
  polycli monitor [flags]

Flags:
  -b, --batch-size string   Number of requests per batch (default "auto")
  -c, --cache-limit int     Number of cached blocks for the LRU block data structure (Min 100) (default 100)
  -h, --help                help for monitor
  -i, --interval string     Amount of time between batch block rpc calls (default "5s")
  -r, --rpc-url string      The RPC endpoint url (default "http://localhost:8545")

Global Flags:
      --config string   config file (default is $HOME/.polygon-cli.yaml)
      --pretty-logs     Should logs be in pretty format or JSON (default true)
  -v, --verbosity int   0 - Silent
                        100 Fatal
                        200 Error
                        300 Warning
                        400 Info
                        500 Debug
                        600 Trace (default 400)

exit status 1
```


[DVT-1120]: https://polygon.atlassian.net/browse/DVT-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ