### PR TITLE
EIP-55 Addresses

### DIFF
--- a/hdwallet/hdwallet.go
+++ b/hdwallet/hdwallet.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/btcsuite/btcutil/base58"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
 	"github.com/tyler-smith/go-bip32"
@@ -321,7 +322,8 @@ func toETHAddress(prvKey *bip32.Key) string {
 	h := sha3.NewLegacyKeccak256()
 	h.Write(concat)
 	b := h.Sum(nil)
-	return fmt.Sprintf("0x%s", hex.EncodeToString(b[len(b)-20:]))
+	addr := ethcommon.BytesToAddress(b)
+	return addr.String()
 }
 func toUncompressedPubKey(prvKey *bip32.Key) []byte {
 	// the GetPublicKey method returns a compressed key so we'll manually get the public key from the curve


### PR DESCRIPTION
# Description

The output from `polycli wallet` outputs normal hex formatted ETH addresses. This is causing validation issues in some cases:
![image](https://github.com/maticnetwork/polygon-cli/assets/429588/431a5dae-60ea-4445-9c08-8650fad56021)

To fix, I'm just using the go-etherum/common package to convert the bytes to an address and then using `String()` which seems to be [EIP-55](https://github.com/ethereum/ercs/blob/master/ERCS/erc-55.md) friendly.

# Tests
![image](https://github.com/maticnetwork/polygon-cli/assets/429588/3275b808-176f-455a-9907-73cbcbc89cef)

```
polycli wallet inspect --mnemonic 'code code code code code code code code code code code quality' | jq '.Addresses[0].ETHAddress'
```
