### PR TITLE
feat: `--mode contract-call` added

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -72,6 +72,9 @@ type (
 		LegacyTransactionMode      *bool
 		SendOnly                   *bool
 		RecallLength               *uint64
+		ContractAddress            *string
+		ContractCallData           *string
+		ContractCallPayable        *bool
 
 		// Computed
 		CurrentGasPrice     *big.Int
@@ -80,6 +83,7 @@ type (
 		ECDSAPrivateKey     *ecdsa.PrivateKey
 		FromETHAddress      *ethcommon.Address
 		ToETHAddress        *ethcommon.Address
+		ContractETHAddress  *ethcommon.Address
 		SendAmount          *big.Int
 		CurrentBaseFee      *big.Int
 		ChainSupportBaseFee bool
@@ -237,7 +241,8 @@ r - random modes
 7 - ERC721 mints
 v3 - UniswapV3 swaps
 R - total recall
-rpc - call random rpc methods`)
+rpc - call random rpc methods
+cc, contract-call - call a contract method`)
 	ltp.Function = LoadtestCmd.Flags().Uint64P("function", "f", 1, "A specific function to be called if running with `--mode f` or a specific precompiled contract when running with `--mode a`")
 	ltp.ByteCount = LoadtestCmd.Flags().Uint64P("byte-count", "b", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
 	ltp.LtAddress = LoadtestCmd.Flags().String("lt-address", "", "The address of a pre-deployed load test contract")
@@ -245,6 +250,9 @@ rpc - call random rpc methods`)
 	ltp.ERC721Address = LoadtestCmd.Flags().String("erc721-address", "", "The address of a pre-deployed ERC721 contract")
 	ltp.ForceContractDeploy = LoadtestCmd.Flags().Bool("force-contract-deploy", false, "Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.")
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
+	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in `--mode contract-call`. This must be paired up with `--mode contract-call` and `--calldata`")
+	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with `--mode contract-call` and `--contract-address`")
+	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the `--function-sig` is a `payable` function, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
 
 	inputLoadTestParams = *ltp
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1277,6 +1277,7 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 		return
 	}
 	estimateInput := ethereum.CallMsg{
+		From:  *ltp.FromETHAddress,
 		To:    to,
 		Value: amount,
 		Data:  calldata,

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -3,6 +3,7 @@ package loadtest
 import (
 	"context"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -56,6 +57,7 @@ const (
 	loadTestModeRandom
 	loadTestModeRecall
 	loadTestModeRPC
+	loadTestModeContractCall
 	loadTestModeUniswapV3
 
 	codeQualitySeed       = "code code code code code code code code code code code quality"
@@ -92,6 +94,8 @@ func characterToLoadTestMode(mode string) (loadTestMode, error) {
 		return loadTestModeUniswapV3, nil
 	case "rpc":
 		return loadTestModeRPC, nil
+	case "cc", "contract-call":
+		return loadTestModeContractCall, nil
 	default:
 		return 0, fmt.Errorf("unrecognized load test mode: %s", mode)
 	}
@@ -210,6 +214,9 @@ func initializeLoadTestParams(ctx context.Context, c *ethclient.Client) error {
 		return errors.New("the adaptive rate limit is based on the pending transaction pool. It doesn't use this feature while also using call only")
 	}
 
+	contractAddr := ethcommon.HexToAddress(*inputLoadTestParams.ContractAddress)
+	inputLoadTestParams.ContractETHAddress = &contractAddr
+
 	inputLoadTestParams.ToETHAddress = &toAddr
 	inputLoadTestParams.SendAmount = amt
 	inputLoadTestParams.CurrentGasPrice = gas
@@ -236,6 +243,7 @@ func initializeLoadTestParams(ctx context.Context, c *ethclient.Client) error {
 	}
 
 	if len(modes) > 1 {
+		log.Debug().Msgf("FOUND MORE THAN 1 MODE %+v", modes)
 		inputLoadTestParams.MultiMode = true
 	} else {
 		inputLoadTestParams.MultiMode = false
@@ -250,6 +258,9 @@ func initializeLoadTestParams(ctx context.Context, c *ethclient.Client) error {
 	} else if hasMode(loadTestModeRPC, inputLoadTestParams.ParsedModes) {
 		log.Trace().Msg("Setting call only mode since we're doing RPC testing")
 		*inputLoadTestParams.CallOnly = true
+	}
+	if hasMode(loadTestModeContractCall, inputLoadTestParams.ParsedModes) && (*inputLoadTestParams.ContractAddress == "" || *inputLoadTestParams.ContractCallData == "") {
+		return errors.New("`--contract-call` and `--contract-send` requires both `--contract-address` and `--calldata` args.")
 	}
 	// TODO check for duplicate modes?
 
@@ -295,6 +306,7 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 		log.Error().Err(err).Msg("There was an issue waiting for all transactions to be mined")
 	}
 	if len(loadTestResults) == 0 {
+		log.Info().Msg("CallOnly mode enabled - blocks aren't mined")
 		return errors.New("no transactions observed")
 	}
 
@@ -600,6 +612,8 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 					startReq, endReq, tErr = runUniswapV3Loadtest(ctx, c, myNonceValue, uniswapV3Config, poolConfig, swapAmountIn)
 				case loadTestModeRPC:
 					startReq, endReq, tErr = loadTestRPC(ctx, c, myNonceValue, indexedActivity)
+				case loadTestModeContractCall:
+					startReq, endReq, tErr = loadTestContractCall(ctx, c, myNonceValue)
 				default:
 					log.Error().Str("mode", mode.String()).Msg("We've arrived at a load test mode that we don't recognize")
 				}
@@ -1233,6 +1247,80 @@ func loadTestRPC(ctx context.Context, c *ethclient.Client, nonce uint64, ia *Ind
 	return
 }
 
+func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64) (t1 time.Time, t2 time.Time, err error) {
+	ltp := inputLoadTestParams
+
+	to := ltp.ContractETHAddress
+
+	chainID := new(big.Int).SetUint64(*ltp.ChainID)
+	privateKey := ltp.ECDSAPrivateKey
+
+	tops, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable create transaction signer")
+		return
+	}
+
+	amount := big.NewInt(0)
+	if *ltp.ContractCallPayable {
+		amount = ltp.SendAmount
+	}
+
+	tops = configureTransactOpts(tops)
+	gasPrice, gasTipCap := getSuggestedGasPrices(ctx, c)
+
+	calldata, err := hex.DecodeString(strings.TrimPrefix(*ltp.ContractCallData, "0x"))
+	estimateInput := ethereum.CallMsg{
+		To:    to,
+		Value: amount,
+		Data:  calldata,
+	}
+	tops.GasLimit, err = c.EstimateGas(ctx, estimateInput)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to estimate gas for transaction")
+		return
+	}
+
+	var tx *ethtypes.Transaction
+	if *ltp.LegacyTransactionMode {
+		tx = ethtypes.NewTx(&ethtypes.LegacyTx{
+			Nonce:    nonce,
+			To:       to,
+			Value:    amount,
+			Gas:      tops.GasLimit,
+			GasPrice: gasPrice,
+			Data:     calldata,
+		})
+	} else {
+		tx = ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     nonce,
+			To:        to,
+			Gas:       tops.GasLimit,
+			GasFeeCap: gasPrice,
+			GasTipCap: gasTipCap,
+			Data:      calldata,
+			Value:     amount,
+		})
+	}
+	log.Trace().Interface("tx", tx).Msg("Contract call data")
+
+	stx, err := tops.Signer(*ltp.FromETHAddress, tx)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to sign transaction")
+		return
+	}
+
+	t1 = time.Now()
+	defer func() { t2 = time.Now() }()
+	if *ltp.CallOnly {
+		_, err = c.CallContract(ctx, txToCallMsg(stx), nil)
+	} else {
+		err = c.SendTransaction(ctx, stx)
+	}
+	return
+}
+
 func recordSample(goRoutineID, requestID int64, err error, start, end time.Time, nonce uint64) {
 	s := loadTestSample{}
 	s.GoRoutineID = goRoutineID
@@ -1317,6 +1405,9 @@ func waitForFinalBlock(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Cli
 		if err != nil {
 			return 0, err
 		}
+		if *ltp.CallOnly {
+			return lastBlockNumber, nil
+		}
 		currentNonceForFinalBlock, err = c.NonceAt(ctx, *ltp.FromETHAddress, new(big.Int).SetUint64(lastBlockNumber))
 		if err != nil {
 			return 0, err
@@ -1328,6 +1419,7 @@ func waitForFinalBlock(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Cli
 				maxWaitCount = maxWaitCount - 1 // only decrement if currentNonceForFinalBlock doesn't progress
 			}
 			prevNonceForFinalBlock = currentNonceForFinalBlock
+			log.Trace().Int("Remaining Attempts", maxWaitCount).Msg("Retrying...")
 			continue
 		}
 		if maxWaitCount <= 0 {

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1270,6 +1270,10 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 	gasPrice, gasTipCap := getSuggestedGasPrices(ctx, c)
 
 	calldata, err := hex.DecodeString(strings.TrimPrefix(*ltp.ContractCallData, "0x"))
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to decode calldata string")
+		return
+	}
 	estimateInput := ethereum.CallMsg{
 		To:    to,
 		Value: amount,

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -243,7 +243,6 @@ func initializeLoadTestParams(ctx context.Context, c *ethclient.Client) error {
 	}
 
 	if len(modes) > 1 {
-		log.Debug().Msgf("FOUND MORE THAN 1 MODE %+v", modes)
 		inputLoadTestParams.MultiMode = true
 	} else {
 		inputLoadTestParams.MultiMode = false
@@ -306,8 +305,11 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 		log.Error().Err(err).Msg("There was an issue waiting for all transactions to be mined")
 	}
 	if len(loadTestResults) == 0 {
-		log.Info().Msg("CallOnly mode enabled - blocks aren't mined")
 		return errors.New("no transactions observed")
+	}
+	if *inputLoadTestParams.CallOnly {
+		log.Info().Msg("CallOnly mode enabled - blocks aren't mined")
+		return nil
 	}
 
 	startTime := loadTestResults[0].RequestTime

--- a/cmd/loadtest/loadtestmode_string.go
+++ b/cmd/loadtest/loadtestmode_string.go
@@ -21,12 +21,13 @@ func _() {
 	_ = x[loadTestModeRandom-10]
 	_ = x[loadTestModeRecall-11]
 	_ = x[loadTestModeRPC-12]
-	_ = x[loadTestModeUniswapV3-13]
+	_ = x[loadTestModeContractCall-13]
+	_ = x[loadTestModeUniswapV3-14]
 }
 
-const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeUniswapV3"
+const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeContractCallloadTestModeUniswapV3"
 
-var _loadTestMode_index = [...]uint16{0, 23, 41, 57, 77, 92, 109, 126, 144, 176, 207, 225, 243, 258, 279}
+var _loadTestMode_index = [...]uint16{0, 23, 41, 57, 77, 92, 109, 126, 144, 176, 207, 225, 243, 258, 282, 303}
 
 func (i loadTestMode) String() string {
 	if i < 0 || i >= loadTestMode(len(_loadTestMode_index)-1) {

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -102,55 +102,59 @@ The codebase has a contract that used for load testing. It's written in Yul and 
 ## Flags
 
 ```bash
-      --adaptive-backoff-factor float          When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
-      --adaptive-cycle-duration-seconds uint   When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
-      --adaptive-rate-limit                    Enable AIMD-style congestion control to automatically adjust request rate
-      --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
-      --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
-  -b, --byte-count uint                        If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
-      --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
-      --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
-      --chain-id uint                          The chain id for the transactions.
-  -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
-      --erc20-address string                   The address of a pre-deployed ERC20 contract
-      --erc721-address string                  The address of a pre-deployed ERC721 contract
-      --eth-amount float                       The amount of ether to send on every transaction (default 0.001)
-      --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
-  -f, --function --mode f                      A specific function to be called if running with --mode f or a specific precompiled contract when running with `--mode a` (default 1)
-      --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
-      --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually
-  -h, --help                                   help for loadtest
-  -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
-      --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
-      --lt-address string                      The address of a pre-deployed load test contract
-  -m, --mode strings                           The testing mode to use. It can be multiple like: "t,c,d,f"
-                                               t - sending transactions
-                                               d - deploy contract
-                                               c - call random contract functions
-                                               f - call specific contract function
-                                               p - call random precompiled contracts
-                                               a - call a specific precompiled contract address
-                                               s - store mode
-                                               r - random modes
-                                               2 - ERC20 transfers
-                                               7 - ERC721 mints
-                                               v3 - UniswapV3 swaps
-                                               R - total recall
-                                               rpc - call random rpc methods (default [t])
-      --output-mode string                     Format mode for summary output (json | text) (default "text")
-      --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
-      --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
-      --rate-limit float                       An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
-      --recall-blocks uint                     The number of blocks that we'll attempt to fetch for recall (default 50)
-  -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
-  -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
-      --seed int                               A seed for generating random values and addresses (default 123456)
-      --send-only                              Send transactions and load without waiting for it to be mined.
-      --steady-state-tx-pool-size uint         When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
-      --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
-  -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
-      --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
-      --to-random                              When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
+      --adaptive-backoff-factor float           When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
+      --adaptive-cycle-duration-seconds uint    When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
+      --adaptive-rate-limit                     Enable AIMD-style congestion control to automatically adjust request rate
+      --adaptive-rate-limit-increment uint      When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --batch-size uint                         Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
+  -b, --byte-count uint                         If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
+      --call-only                               When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
+      --call-only-latest                        When using call only mode with recall, should we execute on the latest block or on the original block
+      --calldata --mode contract-call           The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and `--contract-address`
+      --chain-id uint                           The chain id for the transactions.
+  -c, --concurrency int                         Number of requests to perform concurrently. Default is one request at a time. (default 1)
+      --contract-address --mode contract-call   The address of the contract that will be used in --mode contract-call. This must be paired up with `--mode contract-call` and `--calldata`
+      --contract-call-payable --function-sig    Use this flag if the --function-sig is a `payable` function, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`
+      --erc20-address string                    The address of a pre-deployed ERC20 contract
+      --erc721-address string                   The address of a pre-deployed ERC721 contract
+      --eth-amount float                        The amount of ether to send on every transaction (default 0.001)
+      --force-contract-deploy                   Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
+  -f, --function --mode f                       A specific function to be called if running with --mode f or a specific precompiled contract when running with `--mode a` (default 1)
+      --gas-limit uint                          In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
+      --gas-price uint                          In environments where the gas price can't be determined automatically, we can specify it manually
+  -h, --help                                    help for loadtest
+  -i, --iterations uint                         If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
+      --legacy                                  Send a legacy transaction instead of an EIP1559 transaction.
+      --lt-address string                       The address of a pre-deployed load test contract
+  -m, --mode strings                            The testing mode to use. It can be multiple like: "t,c,d,f"
+                                                t - sending transactions
+                                                d - deploy contract
+                                                c - call random contract functions
+                                                f - call specific contract function
+                                                p - call random precompiled contracts
+                                                a - call a specific precompiled contract address
+                                                s - store mode
+                                                r - random modes
+                                                2 - ERC20 transfers
+                                                7 - ERC721 mints
+                                                v3 - UniswapV3 swaps
+                                                R - total recall
+                                                rpc - call random rpc methods
+                                                cc, contract-call - call a contract method (default [t])
+      --output-mode string                      Format mode for summary output (json | text) (default "text")
+      --priority-gas-price uint                 Specify Gas Tip Price in the case of EIP-1559
+      --private-key string                      The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
+      --rate-limit float                        An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
+      --recall-blocks uint                      The number of blocks that we'll attempt to fetch for recall (default 50)
+  -n, --requests int                            Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
+  -r, --rpc-url string                          The RPC endpoint url (default "http://localhost:8545")
+      --seed int                                A seed for generating random values and addresses (default 123456)
+      --send-only                               Send transactions and load without waiting for it to be mined.
+      --steady-state-tx-pool-size uint          When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
+      --summarize                               Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
+  -t, --time-limit int                          Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
+      --to-address string                       The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
+      --to-random                               When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
 ```
 
 The command also inherits flags from parent commands.


### PR DESCRIPTION
# Description

This PR introduces a new polycli loadtest mode, `--mode contract-call`, which allows the calling of any arbitrary contract method. In order to use `--mode contract-call`, the following must be passed in:
- `--contract-address`
- `--calldata`
- if the contract function is `payable`, then the `--contract-call-payable` should also be passed in and it will use the `--eth-amount` flag as the value passed in.

Essentially, invoking `cast call` or `cast send` in a loadtest.

Some follow-up tasks would be to add:
- [ ] Allow function signatures and args to be passed like `--function-sig "setNumber(uint)" --args 10`

## Jira / Linear Tickets

- [DVT-1072](https://polygon.atlassian.net/browse/DVT-1072)

# Testing

## tl;dr

A simple non-state changing call (i.e. no transactions created):
```
$ cast calldata "getNumber()(uint)"
0xf2c9ecd8
$ go run main.go loadtest \
                --verbosity 700 \
                --mode contract-call \
                --contract-address $CONTRACT_ADDRESS \
                --calldata "0xf2c9ecd8" \
                --call-only \
                --rpc-url http://localhost:8545
```

Example state-changing (i.e. sends a transaction) function call with args:
```
$ cast calldata "setNumber(uint)" 21
0x3fb5c1cb0000000000000000000000000000000000000000000000000000000000000015
$ go run main.go loadtest \
                --verbosity 700 \
                --mode contract-call \
                --contract-address $CONTRACT_ADDRESS \
                --calldata "0x3fb5c1cb0000000000000000000000000000000000000000000000000000000000000015" \
                --rpc-url http://localhost:8545
```

A `payable` function:
```
$ cast calldata "storeEther()"
0xa7cc190a
$ go run main.go loadtest \
                --verbosity 700 \
                --mode cc \
                --contract-address $CONTRACT_ADDRESS \
                --contract-call-payable \
                --calldata "0xa7cc190a" \
                --eth-amount 0.00000003 \
                --rpc-url http://localhost:8545
```

A multiarg call:
```
$ cast calldata "getMultipliedAndAddNumber(uint,uint)(uint)" 10 3
0xdd0974e2000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003
go run main.go loadtest \
                --verbosity 700 \
                --mode contract-call \
                --contract-address $CONTRACT_ADDRESS \
                --calldata "0xdd0974e2000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003" \
                --call-only \
                --rpc-url http://localhost:8545
```

## Test Process

Testing this, I had the following in mind:
1. Create a simple Solidity contract that has functions that are of mixtures of a free method, non-free method, payable, and multi-arg.
2. Generate `bin`
3. Deploy the sample contract with `cast send`
4. Test calls for the different types of methods in `polycli loadtest --mode contract-call`

Before we start, let's run `geth` in dev mode and fund our loadtest account `0x85da99c8a7c2c95964c8efd687e95e632fc533d6` (`code code...code code quality` mnemonic):
```
$ geth --dev --dev.period 2 --http --rpc.gascap 5000000000 --miner.gaslimit 5000000000 --dev.gaslimit 5000000000 --http.api 'admin,debug,web3,eth,txpool,personal,miner,net
$ geth attach "http://127.0.0.1:8545"
> eth.sendTransaction({from: eth.coinbase, to: "0x85da99c8a7c2c95964c8efd687e95e632fc533d6", value: web3.toWei(50000000000, "ether")})
```

### 1. Create Solidity Contract

This is a sample contract that I used:
```
// SPDX-License-Identifier: GPL-3.0
pragma solidity ^0.8.23;

contract MinimalContractTest {
    uint public myNumber;
    mapping(address => uint) public balances;

    function storeEther() public payable {
        require(msg.value > 0, "Must send more than 0 ether");
        balances[msg.sender] += msg.value;
    }

    function checkBalance() public view returns (uint) {
        return balances[msg.sender];
    }

    function withdrawEther() public {
        uint balance = balances[msg.sender];
        require(balance <= 0, "No Ether to withdraw");

        balances[msg.sender] = 0;

        (bool sent, ) = msg.sender.call{value: balance}("");
        require(sent, "Failed to send Ether");
    }

    function getContractBalance() public view returns (uint) {
        return address(this).balance;
    }

    function setNumber(uint _number) public {
        myNumber = _number;
    }

    function getNumber() public view returns (uint) {
        return myNumber;
    }

    function getMultipliedNumber(uint multiplier) public view returns (uint) {
        return multiplier * myNumber;
    }

    function getMultipliedAndAddNumber(uint multiplier, uint adder) public view returns (uint) {
        return myNumber * multiplier + adder;
    }
}
```

### 3. Generate `bin`

Using `forge`:
```
FOUNDRY_PROFILE=lite forge build --force
```

### 3. Deploy the contract with `cast send`
```
CONTRACT_ADDRESS=`cast send \
    --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
    --private-key 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa \
    --rpc-url localhost:8545 \
    --json \
    --create \
    "$(cat out/MinimalContractTest.sol/MinimalContractTest.json | jq -r '.bytecode.object')" | jq -r ".contractAddress"`
echo $CONTRACT_ADDRESS
```

### 4. Test calls for the different types of methods in `polycli loadtest --mode contract-call`

A simple non-state changing call (i.e. no transactions created):
```
$ cast calldata "getNumber()(uint)"
0xf2c9ecd8
$ go run main.go loadtest \
                --verbosity 700 \
                --mode contract-call \
                --contract-address $CONTRACT_ADDRESS \
                --calldata "0xf2c9ecd8" \
                --call-only \
                --rpc-url http://localhost:8545
```

Example state-changing (i.e. sends a transaction) function call with args:
```
$ cast calldata "setNumber(uint)" 21
0x3fb5c1cb0000000000000000000000000000000000000000000000000000000000000015
$ go run main.go loadtest \
                --verbosity 700 \
                --mode contract-call \
                --contract-address $CONTRACT_ADDRESS \
                --calldata "0x3fb5c1cb0000000000000000000000000000000000000000000000000000000000000015" \
                --rpc-url http://localhost:8545
```

A `payable` function:
```
$ cast calldata "storeEther()"
0xa7cc190a
$ go run main.go loadtest \
                --verbosity 700 \
                --mode cc \
                --contract-address $CONTRACT_ADDRESS \
                --contract-call-payable \
                --calldata "0xa7cc190a" \
                --eth-amount 0.00000003 \
                --rpc-url http://localhost:8545
```

A multiarg call:
```
$ cast calldata "getMultipliedAndAddNumber(uint,uint)(uint)" 10 3
0xdd0974e2000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003
go run main.go loadtest \
                --verbosity 700 \
                --mode contract-call \
                --contract-address $CONTRACT_ADDRESS \
                --calldata "0xdd0974e2000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003" \
                --call-only \
                --rpc-url http://localhost:8545
```

To validate it's actually working, check initial balance:
```
$ cast call $CONTRACT_ADDRESS "checkBalance()(uint)" --mnemonic 'code code code code code code code code code code code quality'
0
```

Then store some ether using the loadtest:
```
$ cast calldata "storeEther()"
0xa7cc190a
$ go run main.go loadtest \
                --verbosity 700 \
                --mode cc \
                --contract-address $CONTRACT_ADDRESS \
                --contract-call-payable \
                --calldata "0xa7cc190a" \
                --eth-amount 0.00000003 \
                --rate-limit 5 \
                --concurrency 5 \
                --requests 5 \
                --rpc-url http://localhost:8545
```
> NOTE: `storeEther()` is payable so `--contract-call-payable` is passed

Then check balances again:
```
$ cast call $CONTRACT_ADDRESS "checkBalance()(uint)" --mnemonic 'code code code code code code code code code code code quality'
749999999975 [7.499e11]
```

- [x] non-state changing call (i.e. no transactions created) working
- [x] state-changing (i.e. sends a transaction) function call with args working
- [x] `payable` function call working
- [x] multiarg function call working

[DVT-1072]: https://polygon.atlassian.net/browse/DVT-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ