### PR TITLE
Fix contract-call mode

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -252,7 +252,7 @@ cc, contract-call - call a contract method`)
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in `--mode contract-call`. This must be paired up with `--mode contract-call` and `--calldata`")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with `--mode contract-call` and `--contract-address`")
-	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the `--function-sig` is a `payable` function, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
+	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the function is payable, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
 
 	inputLoadTestParams = *ltp
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1276,18 +1276,6 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 		log.Error().Err(err).Msg("Unable to decode calldata string")
 		return
 	}
-	estimateInput := ethereum.CallMsg{
-		From:  *ltp.FromETHAddress,
-		To:    to,
-		Value: amount,
-		Data:  calldata,
-	}
-	tops.GasLimit, err = c.EstimateGas(ctx, estimateInput)
-	if err != nil {
-		log.Error().Err(err).Msg("Unable to estimate gas for transaction")
-		return
-	}
-
 	var tx *ethtypes.Transaction
 	if *ltp.LegacyTransactionMode {
 		tx = ethtypes.NewTx(&ethtypes.LegacyTx{

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1276,6 +1276,24 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 		log.Error().Err(err).Msg("Unable to decode calldata string")
 		return
 	}
+
+	if tops.GasLimit == 0 {
+		estimateInput := ethereum.CallMsg{
+			From:      tops.From,
+			To:        to,
+			Value:     amount,
+			GasPrice:  tops.GasPrice,
+			GasTipCap: tops.GasTipCap,
+			GasFeeCap: tops.GasFeeCap,
+			Data:      calldata,
+		}
+		tops.GasLimit, err = c.EstimateGas(ctx, estimateInput)
+		if err != nil {
+			log.Error().Err(err).Msg("Unable to estimate gas for transaction. Manually setting gas-limit might be required")
+			return
+		}
+	}
+
 	var tx *ethtypes.Transaction
 	if *ltp.LegacyTransactionMode {
 		tx = ethtypes.NewTx(&ethtypes.LegacyTx{

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -114,7 +114,7 @@ The codebase has a contract that used for load testing. It's written in Yul and 
       --chain-id uint                           The chain id for the transactions.
   -c, --concurrency int                         Number of requests to perform concurrently. Default is one request at a time. (default 1)
       --contract-address --mode contract-call   The address of the contract that will be used in --mode contract-call. This must be paired up with `--mode contract-call` and `--calldata`
-      --contract-call-payable --function-sig    Use this flag if the --function-sig is a `payable` function, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`
+      --contract-call-payable --eth-amount      Use this flag if the function is payable, the value amount passed will be from --eth-amount. This must be paired up with `--mode contract-call` and `--contract-address`
       --erc20-address string                    The address of a pre-deployed ERC20 contract
       --erc721-address string                   The address of a pre-deployed ERC721 contract
       --eth-amount float                        The amount of ether to send on every transaction (default 0.001)


### PR DESCRIPTION
# Description

I _think_ that gas estimation shouldn't be required at this level. It's done within the library if the `GasLimit` is NOT specified. The fact that we're manually calling it here is breaking the `--gas-limit` flag which is needed for some of the tests that I'm running