### PR TITLE
fix: misleading error message in `polycli monitor`

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -84,12 +84,16 @@ const (
 )
 
 func monitor(ctx context.Context) error {
+	// Dial rpc
 	rpc, err := ethrpc.DialContext(ctx, rpcUrl)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to dial rpc")
 		return err
 	}
 	ec := ethclient.NewClient(rpc)
+	if _, err = ec.ChainID(ctx); err != nil {
+		return err
+	}
 
 	// Check if batch requests are supported.
 	if err = checkBatchRequestsSupport(ctx, ec.Client()); err != nil {

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -84,7 +84,7 @@ const (
 )
 
 func monitor(ctx context.Context) error {
-	// Dial rpc
+	// Dial rpc.
 	rpc, err := ethrpc.DialContext(ctx, rpcUrl)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to dial rpc")


### PR DESCRIPTION
# Description

After creating the RPC, send a dummy transaction (e.g. get the chain ID) to check if the RPC is available. If not, return the error message. Then we can check if the RPC supports batch requests.

## Before the fix

<img width="769" alt="Screenshot 2023-12-14 at 09 34 03" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/b44797e6-4060-41d2-b243-585bab76af7f">

## After the fix

<img width="771" alt="Screenshot 2023-12-14 at 09 31 22" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/5a992ecb-f507-430f-817d-e38d7d710f7e">

## Jira / Linear Tickets

- [DVT-1161](https://polygon.atlassian.net/browse/DVT-1161)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] Test that the error message is correct when the rpc is not available.
- [x] Test that it still works well when the rpc is available.


[DVT-1161]: https://polygon.atlassian.net/browse/DVT-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ