### PR TITLE
chore: get block number instead of chain id to check if rpc is available

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -91,7 +91,7 @@ func monitor(ctx context.Context) error {
 		return err
 	}
 	ec := ethclient.NewClient(rpc)
-	if _, err = ec.ChainID(ctx); err != nil {
+	if _, err = ec.BlockNumber(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Description

Since chain id might not be implemented by all chains, let's get the latest block number to check if the RPC is available.

## Jira / Linear Tickets

- [DVT-1161](https://polygon.atlassian.net/browse/DVT-1161)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] Does it work?


[DVT-1161]: https://polygon.atlassian.net/browse/DVT-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ