### PR TITLE
Feat/inscription loadtest

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -252,7 +252,7 @@ cc, contract-call - call a contract method`)
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in `--mode contract-call`. This must be paired up with `--mode contract-call` and `--calldata`")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with `--mode contract-call` and `--contract-address`")
-	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the `--function-sig` is a `payable` function, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
+	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the function is payable, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
 
 	inputLoadTestParams = *ltp
 

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -75,6 +75,7 @@ type (
 		ContractAddress            *string
 		ContractCallData           *string
 		ContractCallPayable        *bool
+		InscriptionJsonContent     *string
 
 		// Computed
 		CurrentGasPrice     *big.Int
@@ -253,6 +254,7 @@ cc, contract-call - call a contract method`)
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in `--mode contract-call`. This must be paired up with `--mode contract-call` and `--calldata`")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with `--mode contract-call` and `--contract-address`")
 	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the function is payable, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
+	ltp.InscriptionJsonContent = LoadtestCmd.Flags().String("json-content", `{"p":"asc-20","op":"mint","tick":"TEST","amt":"1"}`, "The json content that will be encoded as calldata for an inscription. This must be paired up with `--mode inscription`")
 
 	inputLoadTestParams = *ltp
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1276,18 +1276,6 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 		log.Error().Err(err).Msg("Unable to decode calldata string")
 		return
 	}
-	estimateInput := ethereum.CallMsg{
-		From:  *ltp.FromETHAddress,
-		To:    to,
-		Value: amount,
-		Data:  calldata,
-	}
-	tops.GasLimit, err = c.EstimateGas(ctx, estimateInput)
-	if err != nil {
-		log.Error().Err(err).Msg("Unable to estimate gas for transaction")
-		return
-	}
-
 	var tx *ethtypes.Transaction
 	if *ltp.LegacyTransactionMode {
 		tx = ethtypes.NewTx(&ethtypes.LegacyTx{

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1276,6 +1276,24 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 		log.Error().Err(err).Msg("Unable to decode calldata string")
 		return
 	}
+
+	if tops.GasLimit == 0 {
+		estimateInput := ethereum.CallMsg{
+			From:      tops.From,
+			To:        to,
+			Value:     amount,
+			GasPrice:  tops.GasPrice,
+			GasTipCap: tops.GasTipCap,
+			GasFeeCap: tops.GasFeeCap,
+			Data:      calldata,
+		}
+		tops.GasLimit, err = c.EstimateGas(ctx, estimateInput)
+		if err != nil {
+			log.Error().Err(err).Msg("Unable to estimate gas for transaction. Manually setting gas-limit might be required")
+			return
+		}
+	}
+
 	var tx *ethtypes.Transaction
 	if *ltp.LegacyTransactionMode {
 		tx = ethtypes.NewTx(&ethtypes.LegacyTx{

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -58,6 +58,7 @@ const (
 	loadTestModeRecall
 	loadTestModeRPC
 	loadTestModeContractCall
+	loadTestModeInscription
 	loadTestModeUniswapV3
 
 	codeQualitySeed       = "code code code code code code code code code code code quality"
@@ -96,6 +97,8 @@ func characterToLoadTestMode(mode string) (loadTestMode, error) {
 		return loadTestModeRPC, nil
 	case "cc", "contract-call":
 		return loadTestModeContractCall, nil
+	case "inscription":
+		return loadTestModeInscription, nil
 	default:
 		return 0, fmt.Errorf("unrecognized load test mode: %s", mode)
 	}
@@ -616,6 +619,8 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 					startReq, endReq, tErr = loadTestRPC(ctx, c, myNonceValue, indexedActivity)
 				case loadTestModeContractCall:
 					startReq, endReq, tErr = loadTestContractCall(ctx, c, myNonceValue)
+				case loadTestModeInscription:
+					startReq, endReq, tErr = loadTestInscription(ctx, c, myNonceValue)
 				default:
 					log.Error().Str("mode", mode.String()).Msg("We've arrived at a load test mode that we don't recognize")
 				}
@@ -1277,6 +1282,82 @@ func loadTestContractCall(ctx context.Context, c *ethclient.Client, nonce uint64
 		return
 	}
 
+	if tops.GasLimit == 0 {
+		estimateInput := ethereum.CallMsg{
+			From:      tops.From,
+			To:        to,
+			Value:     amount,
+			GasPrice:  tops.GasPrice,
+			GasTipCap: tops.GasTipCap,
+			GasFeeCap: tops.GasFeeCap,
+			Data:      calldata,
+		}
+		tops.GasLimit, err = c.EstimateGas(ctx, estimateInput)
+		if err != nil {
+			log.Error().Err(err).Msg("Unable to estimate gas for transaction. Manually setting gas-limit might be required")
+			return
+		}
+	}
+
+	var tx *ethtypes.Transaction
+	if *ltp.LegacyTransactionMode {
+		tx = ethtypes.NewTx(&ethtypes.LegacyTx{
+			Nonce:    nonce,
+			To:       to,
+			Value:    amount,
+			Gas:      tops.GasLimit,
+			GasPrice: gasPrice,
+			Data:     calldata,
+		})
+	} else {
+		tx = ethtypes.NewTx(&ethtypes.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     nonce,
+			To:        to,
+			Gas:       tops.GasLimit,
+			GasFeeCap: gasPrice,
+			GasTipCap: gasTipCap,
+			Data:      calldata,
+			Value:     amount,
+		})
+	}
+	log.Trace().Interface("tx", tx).Msg("Contract call data")
+
+	stx, err := tops.Signer(*ltp.FromETHAddress, tx)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable to sign transaction")
+		return
+	}
+
+	t1 = time.Now()
+	defer func() { t2 = time.Now() }()
+	if *ltp.CallOnly {
+		_, err = c.CallContract(ctx, txToCallMsg(stx), nil)
+	} else {
+		err = c.SendTransaction(ctx, stx)
+	}
+	return
+}
+
+func loadTestInscription(ctx context.Context, c *ethclient.Client, nonce uint64) (t1 time.Time, t2 time.Time, err error) {
+	ltp := inputLoadTestParams
+
+	to := ltp.FromETHAddress
+
+	chainID := new(big.Int).SetUint64(*ltp.ChainID)
+	privateKey := ltp.ECDSAPrivateKey
+
+	tops, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
+	if err != nil {
+		log.Error().Err(err).Msg("Unable create transaction signer")
+		return
+	}
+
+	amount := big.NewInt(0)
+	tops = configureTransactOpts(tops)
+	gasPrice, gasTipCap := getSuggestedGasPrices(ctx, c)
+
+	calldata := []byte(*ltp.InscriptionJsonContent)
 	if tops.GasLimit == 0 {
 		estimateInput := ethereum.CallMsg{
 			From:      tops.From,

--- a/cmd/loadtest/loadtestmode_string.go
+++ b/cmd/loadtest/loadtestmode_string.go
@@ -22,12 +22,13 @@ func _() {
 	_ = x[loadTestModeRecall-11]
 	_ = x[loadTestModeRPC-12]
 	_ = x[loadTestModeContractCall-13]
-	_ = x[loadTestModeUniswapV3-14]
+	_ = x[loadTestModeInscription-14]
+	_ = x[loadTestModeUniswapV3-15]
 }
 
-const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeContractCallloadTestModeUniswapV3"
+const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeContractCallloadTestModeInscriptionloadTestModeUniswapV3"
 
-var _loadTestMode_index = [...]uint16{0, 23, 41, 57, 77, 92, 109, 126, 144, 176, 207, 225, 243, 258, 282, 303}
+var _loadTestMode_index = [...]uint16{0, 23, 41, 57, 77, 92, 109, 126, 144, 176, 207, 225, 243, 258, 282, 305, 326}
 
 func (i loadTestMode) String() string {
 	if i < 0 || i >= loadTestMode(len(_loadTestMode_index)-1) {

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -124,6 +124,7 @@ The codebase has a contract that used for load testing. It's written in Yul and 
       --gas-price uint                          In environments where the gas price can't be determined automatically, we can specify it manually
   -h, --help                                    help for loadtest
   -i, --iterations uint                         If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
+      --json-content --mode inscription         The json content that will be encoded as calldata for an inscription. This must be paired up with --mode inscription (default "{\"p\":\"asc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
       --legacy                                  Send a legacy transaction instead of an EIP1559 transaction.
       --lt-address string                       The address of a pre-deployed load test contract
   -m, --mode strings                            The testing mode to use. It can be multiple like: "t,c,d,f"

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -114,7 +114,7 @@ The codebase has a contract that used for load testing. It's written in Yul and 
       --chain-id uint                           The chain id for the transactions.
   -c, --concurrency int                         Number of requests to perform concurrently. Default is one request at a time. (default 1)
       --contract-address --mode contract-call   The address of the contract that will be used in --mode contract-call. This must be paired up with `--mode contract-call` and `--calldata`
-      --contract-call-payable --function-sig    Use this flag if the --function-sig is a `payable` function, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`
+      --contract-call-payable --eth-amount      Use this flag if the function is payable, the value amount passed will be from --eth-amount. This must be paired up with `--mode contract-call` and `--contract-address`
       --erc20-address string                    The address of a pre-deployed ERC20 contract
       --erc721-address string                   The address of a pre-deployed ERC721 contract
       --eth-amount float                        The amount of ether to send on every transaction (default 0.001)


### PR DESCRIPTION
# Description

Loadtest with inscriptions.

Usage:
```
$ go run main.go loadtest \
                --verbosity 700 \
                --mode inscription \
                --json-content '{"p":"asc-20","op":"mint","tick":"TESTTTT","amt":"100000"}' \
                --rate-limit 5 \
                --concurrency 5 \
                --requests 5 \
                --rpc-url http://localhost:8545
```

<img width="910" alt="Screenshot 2023-12-18 at 11 28 18 PM" src="https://github.com/maticnetwork/polygon-cli/assets/14638987/97258c85-b223-4ad8-96b5-86d1c561b867">

View from `polycli monitor`:
<img width="746" alt="Screenshot 2023-12-18 at 11 28 49 PM" src="https://github.com/maticnetwork/polygon-cli/assets/14638987/1172f3ac-e7b2-4272-a84a-240d6aecf24b">

# Testing

- [x] Successful loadtest
- [x] Works with `--call-only`
