### PR TITLE
feat: loadtest with arbitrary contract function calls

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -36,46 +36,48 @@ type (
 	}
 	loadTestParams struct {
 		// inputs
-		RPCUrl                     *string
-		Requests                   *int64
-		Concurrency                *int64
-		BatchSize                  *uint64
-		TimeLimit                  *int64
-		ToRandom                   *bool
-		CallOnly                   *bool
-		CallOnlyLatestBlock        *bool
-		ChainID                    *uint64
-		PrivateKey                 *string
-		ToAddress                  *string
-		EthAmountInWei             *float64
-		RateLimit                  *float64
-		AdaptiveRateLimit          *bool
-		SteadyStateTxPoolSize      *uint64
-		AdaptiveRateLimitIncrement *uint64
-		AdaptiveCycleDuration      *uint64
-		AdaptiveBackoffFactor      *float64
-		Modes                      *[]string
-		Function                   *uint64
-		Iterations                 *uint64
-		ByteCount                  *uint64
-		Seed                       *int64
-		LtAddress                  *string
-		ERC20Address               *string
-		ERC721Address              *string
-		DelAddress                 *string
-		ForceContractDeploy        *bool
-		ForceGasLimit              *uint64
-		ForceGasPrice              *uint64
-		ForcePriorityGasPrice      *uint64
-		ShouldProduceSummary       *bool
-		SummaryOutputMode          *string
-		LegacyTransactionMode      *bool
-		SendOnly                   *bool
-		RecallLength               *uint64
-		ContractAddress            *string
-		ContractCallData           *string
-		ContractCallPayable        *bool
-		InscriptionContent         *string
+		RPCUrl                        *string
+		Requests                      *int64
+		Concurrency                   *int64
+		BatchSize                     *uint64
+		TimeLimit                     *int64
+		ToRandom                      *bool
+		CallOnly                      *bool
+		CallOnlyLatestBlock           *bool
+		ChainID                       *uint64
+		PrivateKey                    *string
+		ToAddress                     *string
+		EthAmountInWei                *float64
+		RateLimit                     *float64
+		AdaptiveRateLimit             *bool
+		SteadyStateTxPoolSize         *uint64
+		AdaptiveRateLimitIncrement    *uint64
+		AdaptiveCycleDuration         *uint64
+		AdaptiveBackoffFactor         *float64
+		Modes                         *[]string
+		Function                      *uint64
+		Iterations                    *uint64
+		ByteCount                     *uint64
+		Seed                          *int64
+		LtAddress                     *string
+		ERC20Address                  *string
+		ERC721Address                 *string
+		DelAddress                    *string
+		ForceContractDeploy           *bool
+		ForceGasLimit                 *uint64
+		ForceGasPrice                 *uint64
+		ForcePriorityGasPrice         *uint64
+		ShouldProduceSummary          *bool
+		SummaryOutputMode             *string
+		LegacyTransactionMode         *bool
+		SendOnly                      *bool
+		RecallLength                  *uint64
+		ContractAddress               *string
+		ContractCallData              *string
+		ContractCallFunctionSignature *string
+		ContractCallFunctionArgs      *[]string
+		ContractCallPayable           *bool
+		InscriptionContent            *string
 
 		// Computed
 		CurrentGasPrice     *big.Int
@@ -254,6 +256,8 @@ inscription - sending inscription transactions`)
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in `--mode contract-call`. This must be paired up with `--mode contract-call` and `--calldata`")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with `--mode contract-call` and `--contract-address`")
+	ltp.ContractCallFunctionSignature = LoadtestCmd.Flags().String("function-signature", "", "The contract's function signature that will be called. The format is '<function name>(<types...>)'. This must be paired up with `--mode contract-call` and `--contract-address`. If the function requires parameters you can pass them with `--function-arg <value>`.")
+	ltp.ContractCallFunctionArgs = LoadtestCmd.Flags().StringSlice("function-arg", []string{}, `The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.`)
 	ltp.ContractCallPayable = LoadtestCmd.Flags().Bool("contract-call-payable", false, "Use this flag if the function is payable, the value amount passed will be from `--eth-amount`. This must be paired up with `--mode contract-call` and `--contract-address`")
 	ltp.InscriptionContent = LoadtestCmd.Flags().String("inscription-content", `data:,{"p":"erc-20","op":"mint","tick":"TEST","amt":"1"}`, "The inscription content that will be encoded as calldata. This must be paired up with `--mode inscription`")
 

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -102,61 +102,63 @@ The codebase has a contract that used for load testing. It's written in Yul and 
 ## Flags
 
 ```bash
-      --adaptive-backoff-factor float            When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
-      --adaptive-cycle-duration-seconds uint     When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
-      --adaptive-rate-limit                      Enable AIMD-style congestion control to automatically adjust request rate
-      --adaptive-rate-limit-increment uint       When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
-      --batch-size uint                          Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
-  -b, --byte-count uint                          If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
-      --call-only                                When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
-      --call-only-latest                         When using call only mode with recall, should we execute on the latest block or on the original block
-      --calldata --mode contract-call            The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and `--contract-address`
-      --chain-id uint                            The chain id for the transactions.
-  -c, --concurrency int                          Number of requests to perform concurrently. Default is one request at a time. (default 1)
-      --contract-address --mode contract-call    The address of the contract that will be used in --mode contract-call. This must be paired up with `--mode contract-call` and `--calldata`
-      --contract-call-payable --eth-amount       Use this flag if the function is payable, the value amount passed will be from --eth-amount. This must be paired up with `--mode contract-call` and `--contract-address`
-      --erc20-address string                     The address of a pre-deployed ERC20 contract
-      --erc721-address string                    The address of a pre-deployed ERC721 contract
-      --eth-amount float                         The amount of ether to send on every transaction (default 0.001)
-      --force-contract-deploy                    Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
-  -f, --function --mode f                        A specific function to be called if running with --mode f or a specific precompiled contract when running with `--mode a` (default 1)
-      --gas-limit uint                           In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
-      --gas-price uint                           In environments where the gas price can't be determined automatically, we can specify it manually
-  -h, --help                                     help for loadtest
-      --inscription-content --mode inscription   The inscription content that will be encoded as calldata. This must be paired up with --mode inscription (default "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
-  -i, --iterations uint                          If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
-      --legacy                                   Send a legacy transaction instead of an EIP1559 transaction.
-      --lt-address string                        The address of a pre-deployed load test contract
-  -m, --mode strings                             The testing mode to use. It can be multiple like: "t,c,d,f"
-                                                 t - sending transactions
-                                                 d - deploy contract
-                                                 c - call random contract functions
-                                                 f - call specific contract function
-                                                 p - call random precompiled contracts
-                                                 a - call a specific precompiled contract address
-                                                 s - store mode
-                                                 r - random modes
-                                                 2 - ERC20 transfers
-                                                 7 - ERC721 mints
-                                                 v3 - UniswapV3 swaps
-                                                 R - total recall
-                                                 rpc - call random rpc methods
-                                                 cc, contract-call - call a contract method
-                                                 inscription - sending inscription transactions (default [t])
-      --output-mode string                       Format mode for summary output (json | text) (default "text")
-      --priority-gas-price uint                  Specify Gas Tip Price in the case of EIP-1559
-      --private-key string                       The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
-      --rate-limit float                         An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
-      --recall-blocks uint                       The number of blocks that we'll attempt to fetch for recall (default 50)
-  -n, --requests int                             Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
-  -r, --rpc-url string                           The RPC endpoint url (default "http://localhost:8545")
-      --seed int                                 A seed for generating random values and addresses (default 123456)
-      --send-only                                Send transactions and load without waiting for it to be mined.
-      --steady-state-tx-pool-size uint           When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
-      --summarize                                Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
-  -t, --time-limit int                           Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
-      --to-address string                        The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
-      --to-random                                When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
+      --adaptive-backoff-factor float             When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
+      --adaptive-cycle-duration-seconds uint      When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
+      --adaptive-rate-limit                       Enable AIMD-style congestion control to automatically adjust request rate
+      --adaptive-rate-limit-increment uint        When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --batch-size uint                           Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
+  -b, --byte-count uint                           If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
+      --call-only                                 When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
+      --call-only-latest                          When using call only mode with recall, should we execute on the latest block or on the original block
+      --calldata --mode contract-call             The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and `--contract-address`
+      --chain-id uint                             The chain id for the transactions.
+  -c, --concurrency int                           Number of requests to perform concurrently. Default is one request at a time. (default 1)
+      --contract-address --mode contract-call     The address of the contract that will be used in --mode contract-call. This must be paired up with `--mode contract-call` and `--calldata`
+      --contract-call-payable --eth-amount        Use this flag if the function is payable, the value amount passed will be from --eth-amount. This must be paired up with `--mode contract-call` and `--contract-address`
+      --erc20-address string                      The address of a pre-deployed ERC20 contract
+      --erc721-address string                     The address of a pre-deployed ERC721 contract
+      --eth-amount float                          The amount of ether to send on every transaction (default 0.001)
+      --force-contract-deploy                     Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
+  -f, --function --mode f                         A specific function to be called if running with --mode f or a specific precompiled contract when running with `--mode a` (default 1)
+      --function-arg strings                      The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.
+      --function-signature --mode contract-call   The contract's function signature that will be called. The format is '<function name>(<types...>)'. This must be paired up with --mode contract-call and `--contract-address`. If the function requires parameters you can pass them with `--function-arg <value>`.
+      --gas-limit uint                            In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
+      --gas-price uint                            In environments where the gas price can't be determined automatically, we can specify it manually
+  -h, --help                                      help for loadtest
+      --inscription-content --mode inscription    The inscription content that will be encoded as calldata. This must be paired up with --mode inscription (default "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
+  -i, --iterations uint                           If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
+      --legacy                                    Send a legacy transaction instead of an EIP1559 transaction.
+      --lt-address string                         The address of a pre-deployed load test contract
+  -m, --mode strings                              The testing mode to use. It can be multiple like: "t,c,d,f"
+                                                  t - sending transactions
+                                                  d - deploy contract
+                                                  c - call random contract functions
+                                                  f - call specific contract function
+                                                  p - call random precompiled contracts
+                                                  a - call a specific precompiled contract address
+                                                  s - store mode
+                                                  r - random modes
+                                                  2 - ERC20 transfers
+                                                  7 - ERC721 mints
+                                                  v3 - UniswapV3 swaps
+                                                  R - total recall
+                                                  rpc - call random rpc methods
+                                                  cc, contract-call - call a contract method
+                                                  inscription - sending inscription transactions (default [t])
+      --output-mode string                        Format mode for summary output (json | text) (default "text")
+      --priority-gas-price uint                   Specify Gas Tip Price in the case of EIP-1559
+      --private-key string                        The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
+      --rate-limit float                          An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
+      --recall-blocks uint                        The number of blocks that we'll attempt to fetch for recall (default 50)
+  -n, --requests int                              Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
+  -r, --rpc-url string                            The RPC endpoint url (default "http://localhost:8545")
+      --seed int                                  A seed for generating random values and addresses (default 123456)
+      --send-only                                 Send transactions and load without waiting for it to be mined.
+      --steady-state-tx-pool-size uint            When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
+      --summarize                                 Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
+  -t, --time-limit int                            Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
+      --to-address string                         The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
+      --to-random                                 When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
 ```
 
 The command also inherits flags from parent commands.


### PR DESCRIPTION
# Description

This PR introduces an easy way of loadtesting arbitrary contract functions with simple function names and arguments.

It introduces 2 new flags for the `--mode contract-call` option:
- `--function-signature`: The contract's function signature that will be called. The format is `<function name>(<types...>)`
- `--function-arg`: The arguments that will be passed to the function call. Args can be passed multiple times like: `--function-arg "test" --function-arg 999` or comma separated values `--function-arg "test",9`. The ordering of the arguments must match the ordering of the function parameters.

# Testing

This is a sample loadtest against the ERC721 contract.

Spin up geth in dev mode:
```
$ geth --dev --dev.period 2 --http --rpc.gascap 5000000000 --miner.gaslimit 5000000000 --dev.gaslimit 5000000000 --http.api 'admin,debug,web3,eth,txpool,personal,miner,net
$ geth attach "http://127.0.0.1:8545"
> eth.sendTransaction({from: eth.coinbase, to: "0x85da99c8a7c2c95964c8efd687e95e632fc533d6", value: web3.toWei(50000000000, "ether")})
```

Deploy `ERC721` contract:
```bash
$ CONTRACT_ADDRESS=`cast send \
    --from 0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6 \
    --private-key 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa \
    --rpc-url localhost:8545 \
    --json \
    --create \
    "$(cat bindings/tokens/ERC721.bin)" | jq -r ".contractAddress"`
echo $CONTRACT_ADDRESS
```

Before we loadtest, let's inspect the ERC721 contract:
```solidity
// SPDX-License-Identifier: GPL-3.0
pragma solidity ^0.8.23;

import {ERC721 as OZ_ERC721} from "@openzeppelin/token/ERC721/ERC721.sol";

contract ERC721 is OZ_ERC721 {
    uint256 public currentTokenId = 0;

    constructor() OZ_ERC721("MyNFT", "MNFT") {
        mintBatch(msg.sender, 1000);
    }

    function mintBatch(address to, uint256 amount) public {
       for (uint256 i = 0; i < amount; i++) {
            uint256 newTokenId = ++currentTokenId;
            _safeMint(to, newTokenId);
        }
    }
}

```

Let's loadtest `mintBatch`:
```
$ go run main.go loadtest \
                --verbosity 700 \
                --mode cc \
                --contract-address $CONTRACT_ADDRESS \
                --function-signature "mintBatch(address,uint256)" \
                --function-arg 0xcfe521bdf015C7Cad2Da8766CDC242FCB28Ef028 \
                --function-arg 1000 \
                --rate-limit 5 \
                --concurrency 5 \
                --requests 5 \
                --rpc-url http://localhost:8545
```

We can then validate that it worked by checking the balance of the address (`0xcfe521bdf015C7Cad2Da8766CDC242FCB28Ef028`) we've minted to:
```
$ polycli abi decode --file ./bindings/tokens/ERC721.abi
Selector:095ea7b3       Signature:approve(address,uint256)
Selector:248b71fc       Signature:mintBatch(address,uint256)
Selector:a22cb465       Signature:setApprovalForAll(address,bool)
Selector:c87b56dd       Signature:tokenURI(uint256)(string)
Selector:009a9b7b       Signature:currentTokenId()(uint256)
Selector:06fdde03       Signature:name()(string)
Selector:42842e0e       Signature:safeTransferFrom(address,address,uint256)
Selector:01ffc9a7       Signature:supportsInterface(bytes4)(bool)
Selector:081812fc       Signature:getApproved(uint256)(address)
Selector:e985e9c5       Signature:isApprovedForAll(address,address)(bool)
Selector:6352211e       Signature:ownerOf(uint256)(address)
Selector:95d89b41       Signature:symbol()(string)
Selector:23b872dd       Signature:transferFrom(address,address,uint256)
Selector:70a08231       Signature:balanceOf(address)(uint256)
Selector:b88d4fde       Signature:safeTransferFrom(address,address,uint256,bytes)

$ cast call $CONTRACT_ADDRESS "balanceOf(address)(uint256)" 0xcfe521bdf015C7Cad2Da8766CDC242FCB28Ef028

25000 [2.5e4]
```

Resulting balance is `25000` which matches the resulting total amount of `mintBatch(0xcfe521bdf015C7Cad2Da8766CDC242FCB28Ef028,1000)` 25 times (`5 concurrency * 5 requests`).

## Jira / Linear Tickets

- [DVT-1149](https://polygon.atlassian.net/browse/DVT-1149)
- This is also a follow up feature from https://github.com/maticnetwork/polygon-cli/pull/171 and https://github.com/maticnetwork/polygon-cli/pull/172



[DVT-1149]: https://polygon.atlassian.net/browse/DVT-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ