### PR TITLE
fix: read lock when reading from block cache

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -502,9 +502,10 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			blockInfo.Rows = []string{}
 
 			transactionInfo.ColumnWidths = getColumnWidths(transactionColumnRatio, transactionInfo.Dx())
-			if len(renderedBlocks) >= 1 {
-				transactionInfo.Rows = ui.GetBlockTxTable(renderedBlocks[len(renderedBlocks)-1], ms.ChainID)
-				transactionInfo.Title = fmt.Sprintf("Latest Transactions for Block #%s", renderedBlocks[len(renderedBlocks)-1].Number().String())
+if len(renderedBlocks) > 0 {
+	i := len(renderedBlocks)-1
+	transactionInfo.Rows = ui.GetBlockTxTable(renderedBlocks[i], ms.ChainID)
+	transactionInfo.Title = fmt.Sprintf("Latest Transactions for Block #%s", renderedBlocks[i].Number().String())
 			}
 		}
 

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -502,8 +502,10 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			blockInfo.Rows = []string{}
 
 			transactionInfo.ColumnWidths = getColumnWidths(transactionColumnRatio, transactionInfo.Dx())
-			transactionInfo.Rows = ui.GetBlockTxTable(renderedBlocks[len(renderedBlocks)-1], ms.ChainID)
-			transactionInfo.Title = fmt.Sprintf("Latest Transactions for Block #%s", renderedBlocks[len(renderedBlocks)-1].Number().String())
+			if len(renderedBlocks) >= 1 {
+				transactionInfo.Rows = ui.GetBlockTxTable(renderedBlocks[len(renderedBlocks)-1], ms.ChainID)
+				transactionInfo.Title = fmt.Sprintf("Latest Transactions for Block #%s", renderedBlocks[len(renderedBlocks)-1].Number().String())
+			}
 		}
 
 		termui.Render(grid)
@@ -592,7 +594,7 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 							toBlockNumber.SetInt64(0)
 						}
 
-						if !isBlockInCache(ms.BlockCache, toBlockNumber) {
+						if !ms.isBlockInCache(toBlockNumber) {
 							err := ms.getBlockRange(ctx, toBlockNumber, rpc)
 							if err != nil {
 								log.Warn().Err(err).Msg("Failed to fetch blocks on page down")
@@ -631,7 +633,7 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 						}
 
 						// Fetch the blocks in the new range if they are missing
-						if !isBlockInCache(ms.BlockCache, nextTopBlockNumber) {
+						if !ms.isBlockInCache(nextTopBlockNumber) {
 							err := ms.getBlockRange(ctx, new(big.Int).Add(nextTopBlockNumber, big.NewInt(int64(windowSize))), rpc)
 							if err != nil {
 								log.Warn().Err(err).Msg("Failed to fetch blocks on page up")
@@ -746,8 +748,10 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 	}
 }
 
-func isBlockInCache(cache *lru.Cache, blockNumber *big.Int) bool {
-	_, exists := cache.Get(blockNumber.String())
+func (ms *monitorStatus) isBlockInCache(blockNumber *big.Int) bool {
+	ms.BlocksLock.RLock()
+	_, exists := ms.BlockCache.Get(blockNumber.String())
+	ms.BlocksLock.RUnlock()
 	return exists
 }
 

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -502,10 +502,10 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			blockInfo.Rows = []string{}
 
 			transactionInfo.ColumnWidths = getColumnWidths(transactionColumnRatio, transactionInfo.Dx())
-if len(renderedBlocks) > 0 {
-	i := len(renderedBlocks)-1
-	transactionInfo.Rows = ui.GetBlockTxTable(renderedBlocks[i], ms.ChainID)
-	transactionInfo.Title = fmt.Sprintf("Latest Transactions for Block #%s", renderedBlocks[i].Number().String())
+			if len(renderedBlocks) > 0 {
+				i := len(renderedBlocks) - 1
+				transactionInfo.Rows = ui.GetBlockTxTable(renderedBlocks[i], ms.ChainID)
+				transactionInfo.Title = fmt.Sprintf("Latest Transactions for Block #%s", renderedBlocks[i].Number().String())
 			}
 		}
 


### PR DESCRIPTION
# Description

- Read lock when reading from block cache.

## Jira / Linear Tickets

- [DVT-1203](https://polygon.atlassian.net/browse/DVT-1203)

# Testing

- [x] `polycli monitor --verbosity 700 --rpc-url https://polygon-rpc.com`

<img width="1794" alt="Screenshot 2024-01-19 at 14 20 55" src="https://github.com/maticnetwork/polygon-cli/assets/28714795/b6a3dcc1-476c-45e6-9c8d-f51ef12d79ed">



[DVT-1203]: https://polygon.atlassian.net/browse/DVT-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ