### PR TITLE
fix(ci): check generated files should be reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ concurrency:
 env:
   GO_VERSION: "1.21"                  # https://go.dev/dl/
   STRINGER_VERSION: "0.15.0"          # https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
-  FOUNDRY_SOLC_VERSION: "0.8.24"      # https://github.com/ethereum/solidity/releases
   # Protoc dependencies.
   PROTOC_VERSION: "25.1"              # https://github.com/protocolbuffers/protobuf/releases
   PROTOC_GEN_GO_VERSION: "1.31.0"     # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.21"         # https://go.dev/dl/
-  STRINGER_VERSION: "0.15.0" # https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
+  GO_VERSION: "1.21"                  # https://go.dev/dl/
+  STRINGER_VERSION: "0.15.0"          # https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
+  FOUNDRY_SOLC_VERSION: "0.8.24"      # https://github.com/ethereum/solidity/releases
   # Protoc dependencies.
   PROTOC_VERSION: "25.1"              # https://github.com/protocolbuffers/protobuf/releases
   PROTOC_GEN_GO_VERSION: "1.31.0"     # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 remappings = [
   '@openzeppelin/=lib/openzeppelin-contracts/contracts',
 ]
+solc_version = "0.8.23" # https://github.com/ethereum/solidity/releases
 
 # Lite profile with Yul optimiser disabled.
 [profile.lite.optimizer_details]


### PR DESCRIPTION
Use a specific `solc` version when generating files to make sure a new `solc` release doesn't break our CI job.
See https://github.com/maticnetwork/polygon-cli/pull/192#issuecomment-1912399511

We'll migrate to `solc 0.8.24` once `forge` supports it: https://github.com/foundry-rs/foundry/issues/6903