### PR TITLE
feat: track queued txs along with pending

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -408,12 +408,13 @@ func updateRateLimit(ctx context.Context, rl *rate.Limiter, rpc *ethrpc.Client, 
 	for {
 		select {
 		case <-ticker.C:
-			txPoolSize, err := util.GetTxPoolSize(rpc)
+			pendingTx, queuedTx, err := util.GetTxPoolStatus(rpc)
 			if err != nil {
 				log.Error().Err(err).Msg("Error getting txpool size")
 				return
 			}
 
+			txPoolSize := pendingTx + queuedTx
 			if txPoolSize < steadyStateQueueSize {
 				// additively increment requests per second if txpool less than queue steady state
 				newRateLimit := rate.Limit(float64(rl.Limit()) + float64(rateLimitIncrement))

--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -31,7 +31,7 @@ type UiSkeleton struct {
 	Receipts        *widgets.List
 }
 
-func GetCurrentBlockInfo(headBlock *big.Int, gasPrice *big.Int, peerCount uint64, pendingCount uint64, chainID *big.Int, blocks []rpctypes.PolyBlock, dx int, dy int) string {
+func GetCurrentBlockInfo(headBlock *big.Int, gasPrice *big.Int, peerCount uint64, pendingCount uint64, queuedCount uint64, chainID *big.Int, blocks []rpctypes.PolyBlock, dx int, dy int) string {
 	// Return an appropriate message if dy is 0 or less.
 	if dy <= 0 {
 		return "Invalid display configuration."
@@ -42,9 +42,10 @@ func GetCurrentBlockInfo(headBlock *big.Int, gasPrice *big.Int, peerCount uint64
 	gasPriceString := fmt.Sprintf("Gas Price: %s gwei", new(big.Int).Div(gasPrice, metrics.UnitShannon).String())
 	peers := fmt.Sprintf("Peers: %d", peerCount)
 	pendingTx := fmt.Sprintf("Pending Tx: %d", pendingCount)
+	queuedTx := fmt.Sprintf("Queued Tx: %d", queuedCount)
 	chainIdString := fmt.Sprintf("Chain ID: %s", chainID.String())
 
-	info := []string{height, timeInfo, gasPriceString, peers, pendingTx, chainIdString}
+	info := []string{height, timeInfo, gasPriceString, peers, pendingTx, queuedTx, chainIdString}
 	columns := len(info) / dy
 	if len(info)%dy != 0 {
 		columns += 1 // Add an extra column for the remaining items

--- a/util/util.go
+++ b/util/util.go
@@ -203,6 +203,24 @@ func GetTxPoolSize(rpc *ethrpc.Client) (uint64, error) {
 	return pendingCount + queuedCount, nil
 }
 
+func GetTxPoolStatus(rpc *ethrpc.Client) (uint64, uint64, error) {
+	var status = new(txpoolStatus)
+	err := rpc.Call(status, "txpool_status")
+	if err != nil {
+		return 0, 0, err
+	}
+	pendingCount, err := tryCastToUint64(status.Pending)
+	if err != nil {
+		return 0, 0, err
+	}
+	queuedCount, err := tryCastToUint64(status.Queued)
+	if err != nil {
+		return pendingCount, 0, err
+	}
+
+	return pendingCount, queuedCount, nil
+}
+
 func tryCastToUint64(val any) (uint64, error) {
 	switch t := val.(type) {
 	case float64:

--- a/util/util.go
+++ b/util/util.go
@@ -185,24 +185,6 @@ func GetReceipts(ctx context.Context, rawBlocks []*json.RawMessage, c *ethrpc.Cl
 	return receipts, nil
 }
 
-func GetTxPoolSize(rpc *ethrpc.Client) (uint64, error) {
-	var status = new(txpoolStatus)
-	err := rpc.Call(status, "txpool_status")
-	if err != nil {
-		return 0, err
-	}
-	pendingCount, err := tryCastToUint64(status.Pending)
-	if err != nil {
-		return 0, err
-	}
-	queuedCount, err := tryCastToUint64(status.Queued)
-	if err != nil {
-		return 0, err
-	}
-
-	return pendingCount + queuedCount, nil
-}
-
 func GetTxPoolStatus(rpc *ethrpc.Client) (uint64, uint64, error) {
 	var status = new(txpoolStatus)
 	err := rpc.Call(status, "txpool_status")


### PR DESCRIPTION
# Description

This PR adds the ability to track queued transactions as well along with pending txs in the `monitor` command as it's helpful for load testing.

# Testing

Tested it on a devnet and queued tx count shows up correctly

![Screenshot 2024-02-07 at 6 36 16 PM](https://github.com/maticnetwork/polygon-cli/assets/36959497/cee8cc5c-36f0-41f8-8b1c-e9d095394f46)
