### PR TITLE
fix(ci): do not run sonarqube job on dependabot's PRs

### DIFF
--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -2,6 +2,9 @@ name: Security Build
 
 on:
   pull_request:
+    branches:
+      # Do not run SonarQube job on Dependabot's PRs.
+      - '!dependabot/**'
   merge_group:
   push:
     branches: [main]


### PR DESCRIPTION
# Description

When dependabot creates multiple PRs to update go dependencies, it runs the entire CI workflow without certain environment secrets such as SonarQube credentials. As a result, the security build job (sonarqube) fails. It's not a big deal, but it's annoying when we merge the different dependabot PRs. The annoying part is that we can't use the `@dependabot squash and merge` command which automatically rebases all PRs according to new commits made on the `main` branch, checks the CI and merges the PR automatically if the CI passes. Because this job fails, it's not possible to use this command and we have to manually merge each PR one by one.

## Jira / Linear Tickets

x

# Testing

x
