### PR TITLE
Adding light summary for rpc mode

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -3,7 +3,7 @@ package loadtest
 import (
 	"crypto/ecdsa"
 	_ "embed"
-	"errors"
+	"fmt"
 	"math/big"
 	"math/rand"
 	"sync"
@@ -180,14 +180,14 @@ func checkLoadtestFlags() error {
 
 	// Check `rpc-url` flag.
 	if ltp.RPCUrl == nil {
-		panic("RPC URL is empty")
+		return fmt.Errorf("RPC URL is empty")
 	}
 	if err := util.ValidateUrl(*ltp.RPCUrl); err != nil {
 		return err
 	}
 
 	if ltp.AdaptiveBackoffFactor != nil && *ltp.AdaptiveBackoffFactor <= 0.0 {
-		return errors.New("the backoff factor needs to be non-zero positive")
+		return fmt.Errorf("the backoff factor needs to be non-zero positive. Given: %d", *ltp.AdaptiveBackoffFactor)
 	}
 
 	return nil

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -187,7 +187,7 @@ func checkLoadtestFlags() error {
 	}
 
 	if ltp.AdaptiveBackoffFactor != nil && *ltp.AdaptiveBackoffFactor <= 0.0 {
-		return fmt.Errorf("the backoff factor needs to be non-zero positive. Given: %d", *ltp.AdaptiveBackoffFactor)
+		return fmt.Errorf("the backoff factor needs to be non-zero positive. Given: %f", *ltp.AdaptiveBackoffFactor)
 	}
 
 	return nil

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	_ "embed"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"io"
 	"math/big"
 	"math/rand"
@@ -1185,13 +1187,22 @@ func loadTestRPC(ctx context.Context, c *ethclient.Client, nonce uint64, ia *Ind
 		_, err = c.SuggestGasPrice(ctx)
 	} else if funcNum < 21 {
 		log.Trace().Msg("eth_estimateGas")
-		var tx *ethtypes.Transaction
-		tx, _, err = c.TransactionByHash(ctx, ethcommon.HexToHash(ia.TransactionIDs[randSrc.Intn(len(ia.TransactionIDs))]))
+		var rawTxData []byte
+		pt := ia.Transactions[randSrc.Intn(len(ia.TransactionIDs))]
+		rawTxData, err = pt.MarshalJSON()
 		if err != nil {
-			log.Error().Err(err).Msg("Unable to get the transaction hash")
+			log.Error().Err(err).Str("txHash", pt.Hash().String()).Msg("issue converting poly transaction to json")
 			return
 		}
-		_, err = c.EstimateGas(ctx, txToCallMsg(tx))
+		var tx apitypes.SendTxArgs
+		err = json.Unmarshal(rawTxData, &tx)
+		if err != nil {
+			log.Error().Err(err).Str("txHash", pt.Hash().String()).Msg("unable to unmarshal poly transaction to json.")
+			return
+		}
+		cm := txToCallMsg(tx.ToTransaction())
+		cm.From = pt.From()
+		_, err = c.EstimateGas(ctx, cm)
 	} else if funcNum < 33 {
 		log.Trace().Msg("eth_getTransactionCount")
 		_, err = c.NonceAt(ctx, ethcommon.HexToAddress(ia.Addresses[randSrc.Intn(len(ia.Addresses))]), nil)

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -311,14 +311,16 @@ func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Clie
 	if len(loadTestResults) == 0 {
 		return errors.New("no transactions observed")
 	}
-	if *inputLoadTestParams.CallOnly {
-		log.Info().Msg("CallOnly mode enabled - blocks aren't mined")
-		return nil
-	}
 
 	startTime := loadTestResults[0].RequestTime
 	endTime := time.Now()
 	log.Debug().Uint64("currentNonce", currentNonce).Uint64("final block number", finalBlockNumber).Msg("Got final block number")
+
+	if *inputLoadTestParams.CallOnly {
+		log.Info().Msg("CallOnly mode enabled - blocks aren't mined")
+		lightSummary(loadTestResults, startTime, endTime, rl)
+		return nil
+	}
 
 	if *inputLoadTestParams.ShouldProduceSummary {
 		err = summarizeTransactions(ctx, c, rpc, startBlockNumber, startNonce, finalBlockNumber, currentNonce)

--- a/cmd/loadtest/recall.go
+++ b/cmd/loadtest/recall.go
@@ -56,6 +56,7 @@ type IndexedActivity struct {
 	ERC721Addresses []string
 	Contracts       []string
 	BlockNumber     uint64
+	Transactions    []rpctypes.PolyTransaction
 }
 
 func getIndexedRecentActivity(ctx context.Context, ec *ethclient.Client, c *ethrpc.Client) (*IndexedActivity, error) {
@@ -67,6 +68,7 @@ func getIndexedRecentActivity(ctx context.Context, ec *ethclient.Client, c *ethr
 	ia := new(IndexedActivity)
 	ia.BlockNumbers = make([]string, 0)
 	ia.TransactionIDs = make([]string, 0)
+	ia.Transactions = make([]rpctypes.PolyTransaction, 0)
 	ia.BlockIDs = make([]string, 0)
 	ia.Addresses = make([]string, 0)
 	ia.ERC20Addresses = make([]string, 0)
@@ -83,6 +85,7 @@ func getIndexedRecentActivity(ctx context.Context, ec *ethclient.Client, c *ethr
 		for k := range pb.Transactions {
 			pt := rpctypes.NewPolyTransaction(&pb.Transactions[k])
 			ia.TransactionIDs = append(ia.TransactionIDs, pt.Hash().String())
+			ia.Transactions = append(ia.Transactions, pt)
 			ia.Addresses = append(ia.Addresses, pt.From().String(), pt.To().String())
 
 			// balanceOf(address)

--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8oh
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/multiformats/go-base32 v0.1.0 h1:pVx9xoSPqEIQG8o+UbAe7DNi51oej1NtK+aGkbLYxPE=


### PR DESCRIPTION
This is a minor change to support light summarization even when using rpc mode or `--call-only`. Additionally, we're changing the approach for `eth_estimateGas` to avoid making unnecessary calls to get the transaction since we already have it. This also fixes the issue where the `from` field for all of the transactions was rong.