### PR TITLE
Fixing issue with hex keys that start with 0x

### DIFF
--- a/cmd/parseethwallet/parseethwallet.go
+++ b/cmd/parseethwallet/parseethwallet.go
@@ -41,8 +41,9 @@ var ParseETHWalletCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// it would be nice to have a generic reader
 		if *inputRawHexPrivateKey != "" {
+			trimmedHexPrivateKey := strings.TrimPrefix(*inputRawHexPrivateKey, "0x")
 			ks := keystore.NewKeyStore(*inputKeyStoreDirectory, keystore.StandardScryptN, keystore.StandardScryptP)
-			pk, err := crypto.HexToECDSA(*inputRawHexPrivateKey)
+			pk, err := crypto.HexToECDSA(trimmedHexPrivateKey)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

A command like this fails now:
```
polycli parseethwallet --hexkey 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa --password some-password --keystore some.keystore
```
with the error `Error: invalid hex character 'x' in private key` which is a little silly. This is a small fix to strip the `0x` from the key so that both formats work.

# Testing

- [x] `polycli parseethwallet --hexkey 42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa --password some-password --keystore some.keystore` 
- [X] `polycli parseethwallet --hexkey 0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa --password some-password --keystore some.keystore` 

