### PR TITLE
fix: multimode panic fix

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"io"
 	"math/big"
 	"math/rand"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
 	"github.com/maticnetwork/polygon-cli/bindings/tester"
 	"github.com/maticnetwork/polygon-cli/bindings/tokens"
@@ -483,7 +484,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 
 	var erc20Addr ethcommon.Address
 	var erc20Contract *tokens.ERC20
-	if mode == loadTestModeERC20 || mode == loadTestModeRandom {
+	if hasMode(loadTestModeERC20, ltp.ParsedModes) || hasMode(loadTestModeRandom, ltp.ParsedModes) {
 		erc20Addr, erc20Contract, err = getERC20Contract(ctx, c, tops, cops)
 		if err != nil {
 			return err
@@ -493,7 +494,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 
 	var erc721Addr ethcommon.Address
 	var erc721Contract *tokens.ERC721
-	if mode == loadTestModeERC721 || mode == loadTestModeRandom {
+	if hasMode(loadTestModeERC721, ltp.ParsedModes) || hasMode(loadTestModeRandom, ltp.ParsedModes) {
 		erc721Addr, erc721Contract, err = getERC721Contract(ctx, c, tops, cops)
 		if err != nil {
 			return err
@@ -502,7 +503,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	}
 
 	var recallTransactions []rpctypes.PolyTransaction
-	if mode == loadTestModeRecall {
+	if hasMode(loadTestModeRecall, ltp.ParsedModes) {
 		recallTransactions, err = getRecallTransactions(ctx, c, rpc)
 		if err != nil {
 			return err
@@ -514,7 +515,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	}
 
 	var indexedActivity *IndexedActivity
-	if mode == loadTestModeRPC {
+	if hasMode(loadTestModeRPC, ltp.ParsedModes) {
 		indexedActivity, err = getIndexedRecentActivity(ctx, c, rpc)
 		if err != nil {
 			return err
@@ -531,7 +532,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 
 	var uniswapV3Config uniswapv3loadtest.UniswapV3Config
 	var poolConfig uniswapv3loadtest.PoolConfig
-	if mode == loadTestModeUniswapV3 {
+	if hasMode(loadTestModeUniswapV3, ltp.ParsedModes) {
 		uniswapAddresses := uniswapv3loadtest.UniswapV3Addresses{
 			FactoryV3:                          ethcommon.HexToAddress(*uniswapv3LoadTestParams.UniswapFactoryV3),
 			Multicall:                          ethcommon.HexToAddress(*uniswapv3LoadTestParams.UniswapMulticall),


### PR DESCRIPTION
# Description
`polycli loadtest --requests 500 --legacy --rpc-url http://127.0.0.1:8545 --verbosity 700 --rate-limit 3 --mode 2 --mode 7 --private-key <private_key>`

Value for mode when iterating multi node does not match the actual int values (e.g. `loadTestModeERC20 == 6`), so the if condition does not run. This applies to all modes using legacy `mode` to check the if condition.

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

## Jira / Linear Tickets

- [DVT-1346](https://polygon.atlassian.net/browse/DVT-1346)

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

## Before
```
$ polycli loadtest --requests 500 --legacy --rpc-url http://127.0.0.1:8545 --verbosity 700 --rate-limit 3 --mode "2,7" --private-key 83bc81ac77f59ba37b396874207abcf5216f6143194b2793efd969edc0eec00f
10:40AM TRC Starting logger in console mode
10:40AM INF Starting Load Test
10:40AM INF Connecting with RPC endpoint to initialize load test parameters
10:40AM TRC Retrieved current gas price gasprice=9
10:40AM TRC Current Block Number blocknumber=28943
10:40AM TRC Current account balance balance=999999961999996269809297
10:40AM DBG Eip-1559 support detected
10:40AM TRC Detected Chain ID chainID=1337
10:40AM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"BatchSize":999,"ByteCount":1024,"CallOnly":false,"CallOnlyLatestBlock":false,"ChainID":1337,"ChainSupportBaseFee":true,"Concurrency":1,"ContractAddress":"","ContractCallData":"","ContractCallFunctionArgs":[],"ContractCallFunctionSignature":"","ContractCallPayable":false,"ContractETHAddress":"0x0000000000000000000000000000000000000000","CurrentBaseFee":7,"CurrentGasPrice":9,"CurrentGasTipCap":null,"CurrentNonce":308,"DelAddress":null,"ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":59586045387608995827785870600470534484327439860436875463819040914864249683983,"X":79820130350321051026185670490161396551644082219794264524999367503013711399805,"Y":45583767661720460341893914596251226462806399262615831505282841662024418949504},"ERC20Address":"","ERC721Address":"","EthAmountInWei":0.001,"ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"ForcePriorityGasPrice":0,"FromETHAddress":"0x043fa327fe3b49499e5c1ecefe7c7d600df4b37d","Function":1,"InscriptionContent":"data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}","Iterations":1,"LegacyTransactionMode":true,"LtAddress":"","Mode":0,"Modes":["2","7"],"MultiMode":true,"ParsedModes":[6,7],"PrivateKey":"83bc81ac77f59ba37b396874207abcf5216f6143194b2793efd969edc0eec00f","RPCUrl":"http://127.0.0.1:8545","RateLimit":3,"RecallLength":50,"Requests":500,"Seed":123456,"SendAmount":1000000000000000,"SendOnly":false,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false}
10:40AM DBG Starting main load test loop currentNonce=308
10:40AM TRC Starting Thread routine=0
10:40AM TRC Finished starting go routines. Waiting..
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11ec4b9]

goroutine 51 [running]:
github.com/maticnetwork/polygon-cli/cmd/loadtest.loadTestERC20({0x1bccce0, 0x2816660}, 0xc00007ecf0, 0x134, 0x0, {0x0, 0x0, 0x0, 0x0, 0x0, ...})
	/home/jihwankim/polygon-cli/cmd/loadtest/loadtest.go:1090 +0x4f9
github.com/maticnetwork/polygon-cli/cmd/loadtest.mainLoop.func1(0x0)
	/home/jihwankim/polygon-cli/cmd/loadtest/loadtest.go:612 +0x5b9
created by github.com/maticnetwork/polygon-cli/cmd/loadtest.mainLoop in goroutine 67
	/home/jihwankim/polygon-cli/cmd/loadtest/loadtest.go:566 +0x15e5

```

## After
```
$ polycli loadtest --requests 500 --legacy --rpc-url http://127.0.0.1:8545 --verbosity 700 --rate-limit 3 --mode "2,7" --private-key 83bc81ac77f59ba37b396874207abcf5216f6143194b2793efd969edc0eec00f
10:40AM TRC Starting logger in console mode
10:40AM INF Starting Load Test
10:40AM INF Connecting with RPC endpoint to initialize load test parameters
10:40AM TRC Retrieved current gas price gasprice=9
10:40AM TRC Current Block Number blocknumber=28934
10:40AM TRC Current account balance balance=999999961999996525093586
10:40AM DBG Eip-1559 support detected
10:40AM TRC Detected Chain ID chainID=1337
10:40AM TRC Params Input Params={"AdaptiveBackoffFactor":2,"AdaptiveCycleDuration":10,"AdaptiveRateLimit":false,"AdaptiveRateLimitIncrement":50,"BatchSize":999,"ByteCount":1024,"CallOnly":false,"CallOnlyLatestBlock":false,"ChainID":1337,"ChainSupportBaseFee":true,"Concurrency":1,"ContractAddress":"","ContractCallData":"","ContractCallFunctionArgs":[],"ContractCallFunctionSignature":"","ContractCallPayable":false,"ContractETHAddress":"0x0000000000000000000000000000000000000000","CurrentBaseFee":7,"CurrentGasPrice":9,"CurrentGasTipCap":null,"CurrentNonce":292,"DelAddress":null,"ECDSAPrivateKey":{"Curve":{"B":7,"BitSize":256,"Gx":55066263022277343669578718895168534326250603453777594175500187360389116729240,"Gy":32670510020758816978083085130507043184471273380659243275938904335757337482424,"N":115792089237316195423570985008687907852837564279074904382605163141518161494337,"P":115792089237316195423570985008687907853269984665640564039457584007908834671663},"D":59586045387608995827785870600470534484327439860436875463819040914864249683983,"X":79820130350321051026185670490161396551644082219794264524999367503013711399805,"Y":45583767661720460341893914596251226462806399262615831505282841662024418949504},"ERC20Address":"","ERC20Mode":true,"ERC721Address":"","ERC721Mode":true,"EthAmountInWei":0.001,"ForceContractDeploy":false,"ForceGasLimit":0,"ForceGasPrice":0,"ForcePriorityGasPrice":0,"FromETHAddress":"0x043fa327fe3b49499e5c1ecefe7c7d600df4b37d","Function":1,"InscriptionContent":"data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}","Iterations":1,"LegacyTransactionMode":true,"LtAddress":"","Mode":0,"ModeRandom":false,"Modes":["2","7"],"MultiMode":true,"ParsedModes":[6,7],"PrivateKey":"83bc81ac77f59ba37b396874207abcf5216f6143194b2793efd969edc0eec00f","RPCUrl":"http://127.0.0.1:8545","RateLimit":3,"RecallLength":50,"Requests":500,"Seed":123456,"SendAmount":1000000000000000,"SendOnly":false,"ShouldProduceSummary":false,"SteadyStateTxPoolSize":1000,"SummaryOutputMode":"text","TimeLimit":-1,"ToAddress":"0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF","ToETHAddress":"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ToRandom":false}
10:40AM TRC ERC20 contract address contractaddress=0x8aa08e33f33b1f12dd9e746a5964e4d73b9f6862
10:40AM DBG Obtained erc 20 contract address erc20Addr=0x8Aa08e33f33B1f12Dd9E746A5964e4D73B9F6862
10:40AM TRC ERC721 contract address contractaddress=0x257c4f063d9dc41fc39d220957ae6fdae69368b9
10:40AM DBG Obtained erc 721 contract address erc721Addr=0x257C4F063d9Dc41FC39d220957Ae6FdaE69368b9
10:40AM DBG Starting main load test loop currentNonce=294
10:40AM TRC Starting Thread routine=0
10:40AM TRC Finished starting go routines. Waiting..
10:40AM TRC Request mode=loadTestModeERC20 nonce=294 request=0 routine=0
10:40AM TRC Request mode=loadTestModeERC721 nonce=295 request=1 routine=0
10:40AM TRC Request mode=loadTestModeERC20 nonce=296 request=2 routine=0
10:40AM TRC Request mode=loadTestModeERC721 nonce=297 request=3 routine=0
10:40AM TRC Request mode=loadTestModeERC20 nonce=298 request=4 routine=0
10:40AM TRC Request mode=loadTestModeERC721 nonce=299 request=5 routine=0
10:40AM TRC Request mode=loadTestModeERC20 nonce=300 request=6 routine=0
10:40AM TRC Request mode=loadTestModeERC721 nonce=301 request=7 routine=0
10:40AM TRC Request mode=loadTestModeERC20 nonce=302 request=8 routine=0
10:40AM TRC Request mode=loadTestModeERC721 nonce=303 request=9 routine=0
10:40AM TRC Request mode=loadTestModeERC20 nonce=304 request=10 routine=0
10:40AM TRC Request mode=loadTestModeERC721 nonce=305 request=11 routine=0
```

[DVT-1346]: https://polygon.atlassian.net/browse/DVT-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ