### PR TITLE
fix(loadtest): use pending nonce instead of latest

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -287,7 +287,8 @@ func initNonce(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) err
 		return err
 	}
 
-	currentNonce, err = c.NonceAt(ctx, *inputLoadTestParams.FromETHAddress, new(big.Int).SetUint64(startBlockNumber))
+	// Get pending nonce to be prevent nonce collision (if tx from same sender is already present)
+	currentNonce, err = c.PendingNonceAt(ctx, *inputLoadTestParams.FromETHAddress)
 	startNonce = currentNonce
 
 	if err != nil {


### PR DESCRIPTION
# Description

While starting load test for let's say ERC 721 mints, we make a `BatchMint` call while initialising. I am not sure if making this call while initialising is expected but when this is the case, we use the latest nonce from sender during the loadtest. As the first transaction hasn't gone through yet, we receive the old nonce. I think we should use `PendingNonce` to handle such cases (or any other case where there are some pending txs already present from same sender). This PR does that. I am not sure of the repercussions of this change so would like to know your thoughts. Thanks! 

### Steps to reproduce error

1. Create an empty devnet
2. Run load test using the following command
```
 ~/polygon/polygon-cli │ main !1  polycli loadtest --legacy --verbosity 501 --private-key <pk> --mode 7 --rate-limit 500 --requests 1 --concurrency 1 --iterations 1 --erc721-address <address> --rpc-url http://localhost:8545

6:56PM INF Starting Load Test
6:56PM INF Connecting with RPC endpoint to initialize load test parameters
6:56PM DBG Eip-1559 support detected
6:56PM DBG Obtained erc 721 contract address erc721Addr=0x69bFA9e656a2e968DC3b0afb1d687D6aA7Af56C9
6:56PM DBG Starting main load test loop currentNonce=30
6:56PM ERR Recorded an error while sending transactions error="INTERNAL_ERROR: could not replace existing tx" nonce=30 request time=38
6:56PM DBG Retry for nonce retryForNonce=true
6:56PM DBG Finished main load test loop lastNonce=31 startNonce=30
6:56PM DBG Waiting for remaining transactions to be completed and mined
6:56PM DBG Got final block number currentNonce=31 final block number=932
6:56PM INF * Results
6:56PM INF Samples samples=1
6:56PM INF Start time of loadtest (first transaction sent) startTime=2024-04-03T18:56:43+05:30
6:56PM INF End time of loadtest (final transaction mined) endTime=2024-04-03T18:56:48+05:30
6:56PM INF Overall Requests Per Second tps=0.1981485691221221
6:56PM INF Request Latency Stats max=0.038625709 mean=0.038625709 median=0.038625709 min=0.038625709 stddev=0
6:56PM INF Rough test summary finalRateLimit=500 testDuration=5.04671825
6:56PM INF Num errors numErrors=1
6:56PM INF Finished
```

As you see, it throws an `could not replace existing tx` error as a tx with same nonce from same sender already exists in tx pool. 

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [ ] Test A
- [ ] Test B
