### PR TITLE
sensor: update default mainnet fork-id

### DIFF
--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -360,7 +360,7 @@ significantly increase CPU and memory usage.`)
 	SensorCmd.Flags().StringVar(&inputSensorParams.RPC, "rpc", "https://polygon-rpc.com", "RPC endpoint used to fetch the latest block")
 	SensorCmd.Flags().StringVar(&inputSensorParams.GenesisFile, "genesis", "genesis.json", "Genesis file")
 	SensorCmd.Flags().StringVar(&inputSensorParams.GenesisHash, "genesis-hash", "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b", "The genesis block hash")
-	SensorCmd.Flags().BytesHexVar(&inputSensorParams.ForkID, "fork-id", []byte{220, 8, 134, 92}, "The hex encoded fork id (omit the 0x)")
+	SensorCmd.Flags().BytesHexVar(&inputSensorParams.ForkID, "fork-id", []byte{240, 151, 188, 19}, "The hex encoded fork id (omit the 0x)")
 	SensorCmd.Flags().IntVar(&inputSensorParams.DialRatio, "dial-ratio", 0,
 		`Ratio of inbound to dialed connections. A dial ratio of 2 allows 1/2 of
 connections to be dialed. Setting this to 0 defaults it to 3.`)

--- a/doc/polycli_p2p_sensor.md
+++ b/doc/polycli_p2p_sensor.md
@@ -28,7 +28,7 @@ If no nodes.json file exists, it will be created.
       --dial-ratio int           Ratio of inbound to dialed connections. A dial ratio of 2 allows 1/2 of
                                  connections to be dialed. Setting this to 0 defaults it to 3.
       --discovery-port int       UDP P2P discovery port (default 30303)
-      --fork-id bytesHex         The hex encoded fork id (omit the 0x) (default DC08865C)
+      --fork-id bytesHex         The hex encoded fork id (omit the 0x) (default F097BC13)
       --genesis string           Genesis file (default "genesis.json")
       --genesis-hash string      The genesis block hash (default "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b")
   -h, --help                     help for sensor


### PR DESCRIPTION
# Description

Update default fork-id post Cancun/Napoli HF on Polygon Mainnet.

# Testing

Earlier it wasn't able to connect to good peers due to failure in p2p Handshake. Post this fix, it is able to discover and connect to good peers.