### PR TITLE
p2p: add query header support

### DIFF
--- a/cmd/p2p/p2p.go
+++ b/cmd/p2p/p2p.go
@@ -8,6 +8,7 @@ import (
 	"github.com/maticnetwork/polygon-cli/cmd/p2p/crawl"
 	"github.com/maticnetwork/polygon-cli/cmd/p2p/nodelist"
 	"github.com/maticnetwork/polygon-cli/cmd/p2p/ping"
+	"github.com/maticnetwork/polygon-cli/cmd/p2p/query"
 	"github.com/maticnetwork/polygon-cli/cmd/p2p/sensor"
 )
 
@@ -25,4 +26,5 @@ func init() {
 	P2pCmd.AddCommand(nodelist.NodeListCmd)
 	P2pCmd.AddCommand(ping.PingCmd)
 	P2pCmd.AddCommand(sensor.SensorCmd)
+	P2pCmd.AddCommand(query.QueryCmd)
 }

--- a/cmd/p2p/query/query.go
+++ b/cmd/p2p/query/query.go
@@ -23,7 +23,7 @@ var (
 
 var QueryCmd = &cobra.Command{
 	Use:   "query [enode/enr]",
-	Short: "Query block header(s) from node and return the output.",
+	Short: "Query block header(s) from node and prints the output.",
 	Long: `Query header of single block or range of blocks given a single enode/enr.
 	
 This command will initially establish a handshake and exchange status message

--- a/cmd/p2p/query/query.go
+++ b/cmd/p2p/query/query.go
@@ -1,0 +1,111 @@
+package query
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/maticnetwork/polygon-cli/p2p"
+)
+
+type (
+	queryParams struct {
+		StartBlock uint64
+		Amount     uint64
+	}
+)
+
+var (
+	inputQueryParams queryParams
+)
+
+var QueryCmd = &cobra.Command{
+	Use:   "query [enode/enr]",
+	Short: "Query block header(s) from node and return the output.",
+	Long: `Query header of single block or range of blocks given a single enode/enr.
+	
+This command will initially establish a handshake and exchange status message
+from the peer. Then, it will query the node for block(s) given the start block
+and the amount of blocks to query and print the results.`,
+	Args: cobra.MinimumNArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if inputQueryParams.Amount < 1 {
+			return fmt.Errorf("amount must be greater than 0")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		node, err := p2p.ParseNode(args[0])
+		if err != nil {
+			log.Error().Err(err).Msg("Unable to parse enode")
+			return
+		}
+
+		var (
+			hello  *p2p.Hello
+			status *p2p.Status
+			start  uint64 = inputQueryParams.StartBlock
+			amount uint64 = inputQueryParams.Amount
+		)
+
+		conn, err := p2p.Dial(node)
+		if err != nil {
+			log.Error().Err(err).Msg("Dial failed")
+			return
+		}
+		defer conn.Close()
+		if hello, status, err = conn.Peer(); err != nil {
+			log.Error().Err(err).Msg("Peer failed")
+			return
+		}
+
+		log.Info().Interface("hello", hello).Interface("status", status).Msg("Peering messages received")
+
+		// Handshake completed, now proceed to query headers
+		if err = conn.QueryHeaders(start, amount); err != nil {
+			log.Error().Err(err).Msg("Failed to request header(s)")
+			return
+		}
+
+		headers, err := conn.ListenHeaders()
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to listen for header(s)")
+			return
+		}
+
+		// Verify requested headers
+		if len(headers) != int(amount) {
+			log.Error().Uint64("want", amount).Int("have", len(headers)).Msg("Received less headers than requested")
+			return
+		}
+
+		var (
+			headerStart uint64 = headers[0].Number.Uint64()
+			headerEnd   uint64 = headers[len(headers)-1].Number.Uint64()
+			end         uint64 = start + amount - 1
+		)
+		if headerStart != start || headerEnd != end {
+			log.Error().Uint64("start", start).Uint64("end", end).Uint64("header start", headerStart).Uint64("header end", headerEnd).Msg("Received headers out of range")
+			return
+		}
+
+		print(headers)
+	},
+}
+
+// print simply prints necessary contents of headers assuming they're already verified
+func print(headers eth.BlockHeadersRequest) {
+	for _, header := range headers {
+		log.Info().Uint64("number", header.Number.Uint64()).Str("hash", header.Hash().Hex()).Msg("Header")
+	}
+}
+
+func init() {
+	QueryCmd.Flags().Uint64VarP(&inputQueryParams.StartBlock, "start-block", "s", 0, "Block number to start querying from")
+	QueryCmd.Flags().Uint64VarP(&inputQueryParams.Amount, "amount", "a", 1, "Amount of blocks to query")
+	if err := QueryCmd.MarkFlagRequired("start-block"); err != nil {
+		log.Error().Err(err).Msg("Failed to mark start-block as required persistent flag")
+	}
+}

--- a/doc/polycli_p2p.md
+++ b/doc/polycli_p2p.md
@@ -109,7 +109,7 @@ The command also inherits flags from parent commands.
 
 - [polycli p2p ping](polycli_p2p_ping.md) - Ping node(s) and return the output.
 
-- [polycli p2p query](polycli_p2p_query.md) - Query block header(s) from node and return the output.
+- [polycli p2p query](polycli_p2p_query.md) - Query block header(s) from node and prints the output.
 
 - [polycli p2p sensor](polycli_p2p_sensor.md) - Start a devp2p sensor that discovers other peers and will receive blocks and transactions.
 

--- a/doc/polycli_p2p.md
+++ b/doc/polycli_p2p.md
@@ -109,5 +109,7 @@ The command also inherits flags from parent commands.
 
 - [polycli p2p ping](polycli_p2p_ping.md) - Ping node(s) and return the output.
 
+- [polycli p2p query](polycli_p2p_query.md) - Query block header(s) from node and return the output.
+
 - [polycli p2p sensor](polycli_p2p_sensor.md) - Start a devp2p sensor that discovers other peers and will receive blocks and transactions.
 

--- a/doc/polycli_p2p_query.md
+++ b/doc/polycli_p2p_query.md
@@ -1,0 +1,52 @@
+# `polycli p2p query`
+
+> Auto-generated documentation.
+
+## Table of Contents
+
+- [Description](#description)
+- [Usage](#usage)
+- [Flags](#flags)
+- [See Also](#see-also)
+
+## Description
+
+Query block header(s) from node and return the output.
+
+```bash
+polycli p2p query [enode/enr] [flags]
+```
+
+## Usage
+
+Query header of single block or range of blocks given a single enode/enr.
+	
+This command will initially establish a handshake and exchange status message
+from the peer. Then, it will query the node for block(s) given the start block
+and the amount of blocks to query and print the results.
+## Flags
+
+```bash
+  -a, --amount uint        Amount of blocks to query (default 1)
+  -h, --help               help for query
+  -s, --start-block uint   Block number to start querying from
+```
+
+The command also inherits flags from parent commands.
+
+```bash
+      --config string   config file (default is $HOME/.polygon-cli.yaml)
+      --pretty-logs     Should logs be in pretty format or JSON (default true)
+  -v, --verbosity int   0 - Silent
+                        100 Panic
+                        200 Fatal
+                        300 Error
+                        400 Warning
+                        500 Info
+                        600 Debug
+                        700 Trace (default 500)
+```
+
+## See also
+
+- [polycli p2p](polycli_p2p.md) - Set of commands related to devp2p.

--- a/doc/polycli_p2p_query.md
+++ b/doc/polycli_p2p_query.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-Query block header(s) from node and return the output.
+Query block header(s) from node and prints the output.
 
 ```bash
 polycli p2p query [enode/enr] [flags]


### PR DESCRIPTION
# Description

This PR adds support for `p2p query` which can be used to query headers from a specific peers for a range of block numbers. It takes `start-block` and `amount` values as flags to craft a header request message. For now, the response is minimalistic and only prints number and hash. More support can be added later as and when needed.

# Testing

Query:
```
polycli p2p query <enode> --start-block 55000000 --amount 10
```

Response:
```
1:01PM INF Peering messages received hello={"Caps":[{"Name":"eth","Version":68},{"Name":"snap","Version":1}],"ID":"9VvVHzqY0cDJCkJSy+JLxCVeJH8/Xnan/bTYOTzVrC3cHg1ChsfRJ4XWu1DHVgQje8yzrpHr3UIbuzaFzTqyPg==","ListenPort":0,"Name":"bor/v1.3.0-beta-2/linux-amd64/go1.22.2","Rest":[],"Version":5} status={"ForkID":{"Hash":[240,151,188,19],"Next":0},"Genesis":"0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b","Head":"0x343985db4ac2f8b8250341e6bd8799b1b1c5de915fff11ff341a87e2026a9cd1","NetworkID":137,"ProtocolVersion":68,"TD":1012023464}
1:01PM INF Header hash=0x3a8f5b10d579decdab09e4809fdf37fe9cb1c8a2625adc3c02b0369adc6c0521 number=55000000
1:01PM INF Header hash=0x78a10bf81fa21a4095a653d662dd0e34701ef6a355e6a390f10f4348000b9a96 number=55000001
1:01PM INF Header hash=0x92e89c2d90dfd25d4b234130132758b95a5d79dfb50c15a8596d0c4e78cf5090 number=55000002
1:01PM INF Header hash=0xdd271f4035ef2d6bfcd62d014c7048538f8afd15b912d70d2da2a7acc7a28c91 number=55000003
1:01PM INF Header hash=0x6230684ca688daf98a6a6cbda6bcfd73c5b3a218ac94e27f7b6f8146992af507 number=55000004
1:01PM INF Header hash=0xdb915ca3b70c8cdd9ca346fe3be263572ff2f700cf191ee135f7f2f1b8370947 number=55000005
1:01PM INF Header hash=0xd68b87bdf0e4c00e0d8b7c7fb7bb1f62cfcba2c5e1efacab07da80415a2d0249 number=55000006
1:01PM INF Header hash=0x439fc4712d893023d3c8a0b1992f6a964833034385f5ec91150a6f7d44d35533 number=55000007
1:01PM INF Header hash=0xc648018ff37ce6aaa0bbc44337c6960e0045611e2ab872c2e80945ad4f834cb9 number=55000008
1:01PM INF Header hash=0xf3ae438426f42f6408cf033ec96e28c90e52c7de099f91f642d4af35632a7aca number=55000009
```