### PR TITLE
ci: add a cron job to generate new files daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
     name: Check generated files
     runs-on: ubuntu-latest
     steps:
-      # Dependencies to generate doc, protobuf stubs and go bindings.
       - uses: actions/checkout@v4
+
+      # Dependencies to generate doc, protobuf stubs and go bindings.
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -61,6 +62,7 @@ jobs:
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${{ env.PROTOC_GEN_GO_GRPC_VERSION }}
           protoc-gen-go --version
           protoc-gen-go-grpc --version
+
       # Dependencies to generate go bindings.
       - name: Install abigen
         run: |

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -70,6 +70,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          branch: 'chore/update-submodules'
-          commit-message: 'chore: update submodules'
-          title: 'chore: update submodules'
+          branch: 'cron/generate-new-files'
+          commit-message: 'cron: generate new files'
+          title: 'cron: generate new files'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,75 @@
+name: cron
+
+on:
+  schedule:
+    - cron: '0 5 * * 1' # Run every Monday at 6 AM (UTC+1) - Paris
+  workflow_dispatch: # To debug.
+
+jobs:
+  cron:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Dependencies to generate doc, protobuf stubs and go bindings.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # Dependencies to generate protobuf stubs.
+      - name: Install protoc
+        run: |
+          wget https://github.com/protocolbuffers/protobuf/releases/download/v${{ env.PROTOC_VERSION }}/protoc-${{ env.PROTOC_VERSION }}-${{ env.ARCH }}.zip
+          unzip protoc-${{ env.PROTOC_VERSION }}-${{ env.ARCH }}.zip
+          rm protoc-${{ env.PROTOC_VERSION }}-${{ env.ARCH }}.zip
+          rm readme.txt
+          sudo mv bin/protoc /usr/local/bin/
+          sudo mv include/google /usr/local/include
+          protoc --version
+      - name: Install protoc plugins for go
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v${{ env.PROTOC_GEN_GO_VERSION }}
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${{ env.PROTOC_GEN_GO_GRPC_VERSION }}
+          protoc-gen-go --version
+          protoc-gen-go-grpc --version
+
+      # Dependencies to generate go bindings.
+      - name: Install abigen
+        run: |
+          sudo add-apt-repository ppa:ethereum/ethereum
+          sudo apt-get update
+          sudo apt-get install ethereum
+          abigen --version
+      - name: Install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Get forge version
+        run: forge --version
+      - name: Install contract dependencies
+        working-directory: contracts
+        run: forge install
+
+      # Dependencies to generate loadtest modes strings.
+      - name: Install stringer
+        run: go install golang.org/x/tools/cmd/stringer@v${{ env.STRINGER_VERSION }}
+
+      # Try to generate new files.
+      - name: Try to update generated files
+        run: make gen
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "✅ Changes detected!"
+          else
+            echo "No changes detected."
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: 'chore/update-submodules'
+          commit-message: 'chore: update submodules'
+          title: 'chore: update submodules'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,6 +5,15 @@ on:
     - cron: '0 5 * * *' # Run every day at 6 AM (UTC+1) - Paris
   workflow_dispatch: # To debug.
 
+env:
+  GO_VERSION: "1.21"                  # https://go.dev/dl/
+  STRINGER_VERSION: "0.15.0"          # https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
+  # Protoc dependencies.
+  PROTOC_VERSION: "25.3"              # https://github.com/protocolbuffers/protobuf/releases
+  PROTOC_GEN_GO_VERSION: "1.31.0"     # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions
+  PROTOC_GEN_GO_GRPC_VERSION: "1.3.0" # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc?tab=versions
+  ARCH: "linux-x86_64"
+
 jobs:
   cron:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: cron
 
 on:
   schedule:
-    - cron: '0 5 * * 1' # Run every Monday at 6 AM (UTC+1) - Paris
+    - cron: '0 5 * * *' # Run every day at 6 AM (UTC+1) - Paris
   workflow_dispatch: # To debug.
 
 jobs:


### PR DESCRIPTION
Automatically updates files to generate (e.g. protobuf stubs or JSON rpc types).
Also add a way to trigger the CI job manually.