### PR TITLE
fix: draw each blockinfo section information into separate rows

### DIFF
--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -82,16 +82,6 @@ func GetCurrentBlockInfo(headBlock *big.Int, gasPrice *big.Int, peerCount uint64
 	return formattedInfo.String()
 }
 
-func max(nums ...int) int {
-	maxNum := nums[0]
-	for _, num := range nums[1:] {
-		if num > maxNum {
-			maxNum = num
-		}
-	}
-	return maxNum
-}
-
 func GetBlocksList(blocks []rpctypes.PolyBlock) ([]string, string) {
 	bs := rpctypes.SortableBlocks(blocks)
 	sort.Sort(bs)
@@ -280,35 +270,24 @@ func GetSimpleBlockFields(block rpctypes.PolyBlock) []string {
 	txRoot := fmt.Sprintf("Tx Root: %s", block.TxRoot())
 	nonce := fmt.Sprintf("Nonce: %d", block.Nonce())
 
-	maxWidthCol1 := max(len(blockHeight), len(transactions), len(difficulty), len(size), len(gasUsed), len(baseFee), len(hash), len(stateRoot))
-
-	blockHeight = fmt.Sprintf("%-*s", maxWidthCol1, blockHeight)
-	transactions = fmt.Sprintf("%-*s", maxWidthCol1, transactions)
-	difficulty = fmt.Sprintf("%-*s", maxWidthCol1, difficulty)
-	size = fmt.Sprintf("%-*s", maxWidthCol1, size)
-	gasUsed = fmt.Sprintf("%-*s", maxWidthCol1, gasUsed)
-	baseFee = fmt.Sprintf("%-*s", maxWidthCol1, baseFee)
-	hash = fmt.Sprintf("%-*s", maxWidthCol1, hash)
-	stateRoot = fmt.Sprintf("%-*s", maxWidthCol1, stateRoot)
-
 	lines := []string{
-		fmt.Sprintf("%s", blockHeight),
-		fmt.Sprintf("%s", timestamp),
-		fmt.Sprintf("%s", transactions),
-		fmt.Sprintf("%s", authorInfo),
-		fmt.Sprintf("%s", difficulty),
-		fmt.Sprintf("%s", uncles),
-		fmt.Sprintf("%s", size),
-		fmt.Sprintf("%s", gasLimit),
-		fmt.Sprintf("%s", gasUsed),
-		fmt.Sprintf("%s", extraData),
-		fmt.Sprintf("%s", baseFee),
-		fmt.Sprintf("%s", parentHash),
-		fmt.Sprintf("%s", hash),
-		fmt.Sprintf("%s", uncleHash),
-		fmt.Sprintf("%s", stateRoot),
-		fmt.Sprintf("%s", txRoot),
-		fmt.Sprintf("%s", size),
+		blockHeight,
+		timestamp,
+		transactions,
+		authorInfo,
+		difficulty,
+		uncles,
+		size,
+		gasLimit,
+		gasUsed,
+		extraData,
+		baseFee,
+		parentHash,
+		hash,
+		uncleHash,
+		stateRoot,
+		txRoot,
+		size,
 		nonce,
 	}
 

--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -292,14 +292,23 @@ func GetSimpleBlockFields(block rpctypes.PolyBlock) []string {
 	stateRoot = fmt.Sprintf("%-*s", maxWidthCol1, stateRoot)
 
 	lines := []string{
-		fmt.Sprintf("%s  %s", blockHeight, timestamp),
-		fmt.Sprintf("%s  %s", transactions, authorInfo),
-		fmt.Sprintf("%s  %s", difficulty, uncles),
-		fmt.Sprintf("%s  %s", size, gasLimit),
-		fmt.Sprintf("%s  %s", gasUsed, extraData),
-		fmt.Sprintf("%s  %s", baseFee, parentHash),
-		fmt.Sprintf("%s  %s", hash, uncleHash),
-		fmt.Sprintf("%s  %s", stateRoot, txRoot),
+		fmt.Sprintf("%s", blockHeight),
+		fmt.Sprintf("%s", timestamp),
+		fmt.Sprintf("%s", transactions),
+		fmt.Sprintf("%s", authorInfo),
+		fmt.Sprintf("%s", difficulty),
+		fmt.Sprintf("%s", uncles),
+		fmt.Sprintf("%s", size),
+		fmt.Sprintf("%s", gasLimit),
+		fmt.Sprintf("%s", gasUsed),
+		fmt.Sprintf("%s", extraData),
+		fmt.Sprintf("%s", baseFee),
+		fmt.Sprintf("%s", parentHash),
+		fmt.Sprintf("%s", hash),
+		fmt.Sprintf("%s", uncleHash),
+		fmt.Sprintf("%s", stateRoot),
+		fmt.Sprintf("%s", txRoot),
+		fmt.Sprintf("%s", size),
 		nonce,
 	}
 


### PR DESCRIPTION
# Description

Fix overflowing rows in blockinfo section.

## Jira / Linear Tickets

- [DVT-1511](https://polygon.atlassian.net/browse/DVT-1511)

# Testing

## Before
![Screenshot from 2024-05-28 11-16-43](https://github.com/maticnetwork/polygon-cli/assets/125336262/8664908d-b1a5-4958-a77d-e270d83fc11e)

## After
![Screenshot from 2024-05-28 11-17-05](https://github.com/maticnetwork/polygon-cli/assets/125336262/b7cac2b7-fbac-4198-bc14-66831dff7bd7)


[DVT-1511]: https://polygon.atlassian.net/browse/DVT-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ