### PR TITLE
fix: disable multimode loadtesting for blob transactions

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -282,6 +282,10 @@ func initializeLoadTestParams(ctx context.Context, c *ethclient.Client) error {
 		return errors.New("using call only with adaptive rate limit doesn't make sense")
 	}
 
+	if hasMode(loadTestModeBlob, inputLoadTestParams.ParsedModes) && inputLoadTestParams.MultiMode {
+		return errors.New("Blob mode should only be used by itself. Blob mode will take significantly longer than other transactions to finalize, and the address will be reserved, preventing other transactions form being made.")
+	}
+
 	randSrc = rand.New(rand.NewSource(*inputLoadTestParams.Seed))
 
 	return nil


### PR DESCRIPTION
# Description
This PR disables multimode support for blobs.

Blob transactions take significantly longer than other transactions to be mined. The address sending these transactions will be reserved before these transactions are mined. This means other types of modes will not be processed. 
![image](https://github.com/maticnetwork/polygon-cli/assets/125336262/d58d5ca1-e950-4b21-987b-577c0becd76e)

