### PR TITLE
feat: remove EthCommonaddress

### DIFF
--- a/cmd/fund/fund.go
+++ b/cmd/fund/fund.go
@@ -175,7 +175,7 @@ func deriveHDWallets(n int) ([]common.Address, error) {
 
 	addresses := make([]common.Address, n)
 	for i, wallet := range derivedWallets.Addresses {
-		addresses[i] = wallet.ETHCommonAddress
+		addresses[i] = common.HexToAddress(wallet.ETHAddress)
 		log.Trace().Interface("address", addresses[i]).Str("privateKey", wallet.HexPrivateKey).Str("path", wallet.Path).Msg("New wallet derived")
 	}
 	log.Info().Int("count", n).Msg("Wallet(s) derived")

--- a/hdwallet/hdwallet.go
+++ b/hdwallet/hdwallet.go
@@ -49,19 +49,18 @@ type (
 		multiAddress
 	}
 	multiAddress struct {
-		HexPublicKey       string         `json:",omitempty"`
-		HexFullPublicKey   string         `json:",omitempty"`
-		ETHCommonAddress   common.Address `json:",omitempty"`
-		HexPrivateKey      string         `json:",omitempty"`
-		ETHAddress         string         `json:",omitempty"`
-		BTCAddress         string         `json:",omitempty"`
-		WIF                string         `json:",omitempty"`
-		ECDSAAddress       string         `json:",omitempty"`
-		Sr25519Address     string         `json:",omitempty"`
-		Ed25519Address     string         `json:",omitempty"`
-		ECDSAAddressSS58   string         `json:",omitempty"`
-		Sr25519AddressSS58 string         `json:",omitempty"`
-		Ed25519AddressSS58 string         `json:",omitempty"`
+		HexPublicKey       string `json:",omitempty"`
+		HexFullPublicKey   string `json:",omitempty"`
+		HexPrivateKey      string `json:",omitempty"`
+		ETHAddress         string `json:",omitempty"`
+		BTCAddress         string `json:",omitempty"`
+		WIF                string `json:",omitempty"`
+		ECDSAAddress       string `json:",omitempty"`
+		Sr25519Address     string `json:",omitempty"`
+		Ed25519Address     string `json:",omitempty"`
+		ECDSAAddressSS58   string `json:",omitempty"`
+		Sr25519AddressSS58 string `json:",omitempty"`
+		Ed25519AddressSS58 string `json:",omitempty"`
 	}
 	PolyAddressExport struct {
 		Path string `json:",omitempty"`
@@ -233,7 +232,6 @@ func (p *PolyWallet) ExportRootAddress() (*PolyWalletExport, error) {
 	pwe.WIF = toWIF(rootKey)
 	pwe.BTCAddress = toBTCAddress(rootKey)
 	rootEthAddress := toETHAddress(rootKey)
-	pwe.ETHCommonAddress = rootEthAddress
 	pwe.ETHAddress = rootEthAddress.String()
 	pwe.HexFullPublicKey = hex.EncodeToString(toUncompressedPubKey(rootKey))
 	addr, err := GetPublicKeyFromSeed(p.rawSeed, SignatureSecp256k1, true)
@@ -303,7 +301,6 @@ func (p *PolyWallet) ExportHDAddresses(count int) (*PolyWalletExport, error) {
 		pae.BTCAddress = toBTCAddress(k)
 		ethAddress := toETHAddress(k)
 		pae.ETHAddress = ethAddress.String()
-		pae.ETHCommonAddress = ethAddress
 		pae.HexFullPublicKey = hex.EncodeToString(toUncompressedPubKey(k))
 		pwe.Addresses = append(pwe.Addresses, pae)
 	}


### PR DESCRIPTION
# Description

Remove `ETHCommonAddress` field from `polycli wallet`. This field represents the same value as `ETHAddress`, but has a different type - `common.Address` compared to being a `string`. It does not add new information, and the name may be a potential cause of confusion.

**Any previous code using `ETHCommonAddress` field should now use the variable `ETHAddress` instead.**

## Jira / Linear Tickets

- [DVT-1524](https://polygon.atlassian.net/browse/DVT-1524)

# After

![image](https://github.com/maticnetwork/polygon-cli/assets/125336262/80b21c86-d1a4-4f1b-bedb-0a3e44a1b7c9)


[DVT-1524]: https://polygon.atlassian.net/browse/DVT-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ