### PR TITLE
feat: ulxly bridge and claim message

### DIFF
--- a/doc/polycli_ulxly_deposit-claim.md
+++ b/doc/polycli_ulxly_deposit-claim.md
@@ -19,7 +19,83 @@ polycli ulxly deposit-claim [flags]
 
 ## Usage
 
-Make a uLxLy claim transaction
+This command will attempt to send a claim transaction to the bridge contract.
+
+```solidity
+    /**
+     * @notice Verify merkle proof and withdraw tokens/ether
+     * @param smtProofLocalExitRoot Smt proof to proof the leaf against the network exit root
+     * @param smtProofRollupExitRoot Smt proof to proof the rollupLocalExitRoot against the rollups exit root
+     * @param globalIndex Global index is defined as:
+     * | 191 bits |    1 bit     |   32 bits   |     32 bits    |
+     * |    0     |  mainnetFlag | rollupIndex | localRootIndex |
+     * note that only the rollup index will be used only in case the mainnet flag is 0
+     * note that global index do not assert the unused bits to 0.
+     * This means that when synching the events, the globalIndex must be decoded the same way that in the Smart contract
+     * to avoid possible synch attacks
+     * @param mainnetExitRoot Mainnet exit root
+     * @param rollupExitRoot Rollup exit root
+     * @param originNetwork Origin network
+     * @param originTokenAddress  Origin token address, 0 address is reserved for ether
+     * @param destinationNetwork Network destination
+     * @param destinationAddress Address destination
+     * @param amount Amount of tokens
+     * @param metadata Abi encoded metadata if any, empty otherwise
+     */
+    function claimAsset(
+        bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] calldata smtProofLocalExitRoot,
+        bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] calldata smtProofRollupExitRoot,
+        uint256 globalIndex,
+        bytes32 mainnetExitRoot,
+        bytes32 rollupExitRoot,
+        uint32 originNetwork,
+        address originTokenAddress,
+        uint32 destinationNetwork,
+        address destinationAddress,
+        uint256 amount,
+        bytes calldata metadata
+    )
+
+```
+
+Each transaction will require manual input of parameters. Example usage:
+
+```bash
+polycli ulxly deposit-claim \
+        --bridge-address 0xD71f8F956AD979Cc2988381B8A743a2fE280537D \
+        --private-key 12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625 \
+        --claim-index 0 \
+        --claim-address 0xE34aaF64b29273B7D567FCFc40544c014EEe9970 \
+        --claim-network 0 \
+        --rpc-url http://127.0.0.1:32790 \
+        --bridge-service-url http://127.0.0.1:32804
+```
+
+This command would use the supplied private key and attempt to send a claim transaction to the bridge contract address with the input flags.
+Successful deposit transaction will output logs like below:
+
+```bash
+Claim Transaction Successful: 0x7180201b19e1aa596503d8541137d6f341e682835bf7a54aab6422c89158866b
+```
+
+Upon successful claim, the transferred funds can be queried in the destination network using tools like `cast balance <claim-address> --rpc-url <destination-network-url>`
+
+
+Failed deposit transactions will output logs like below: 
+
+```bash
+Claim Transaction Failed: 0x32ac34797159c79e57ae801c350bccfe5f8105d4dd3b717e31d811397e98036a
+```
+
+The reason for failing may be very difficult to debug. I have personally spun up a bridge-ui and compared the byte data of a successful transaction to the byte data of a failing claim transaction queried using:
+
+```!
+curl http://127.0.0.1:32790 \
+-X POST \
+-H "Content-Type: application/json" \
+--data '{"method":"debug_traceTransaction","params":["0x32ac34797159c79e57ae801c350bccfe5f8105d4dd3b717e31d811397e98036a", {"tracer": "callTracer"}], "id":1,"jsonrpc":"2.0"}' | jq '.'
+```
+
 ## Flags
 
 ```bash
@@ -28,6 +104,8 @@ Make a uLxLy claim transaction
       --chain-id string                      The chainID.
       --claim-address string                 The address that is receiving the bridged asset.
       --claim-index string                   The deposit count, or index to initiate a claim transaction for. (default "0")
+      --claim-message                        Claim a message instead of an asset.
+      --destination-network string           The network ID of the destination network. (default "1")
       --gas-limit uint                       The gas limit for the transaction. (default 300000)
   -h, --help                                 help for deposit-claim
       --origin-network string                The network ID of the origin network. (default "0")

--- a/doc/polycli_ulxly_deposit-claim.md
+++ b/doc/polycli_ulxly_deposit-claim.md
@@ -105,6 +105,7 @@ curl http://127.0.0.1:32790 \
       --claim-address string                 The address that is receiving the bridged asset.
       --claim-index string                   The deposit count, or index to initiate a claim transaction for. (default "0")
       --claim-message                        Claim a message instead of an asset.
+      --claim-weth                           Claim a weth instead of an asset.
       --destination-network string           The network ID of the destination network. (default "1")
       --gas-limit uint                       The gas limit for the transaction. (default 300000)
   -h, --help                                 help for deposit-claim

--- a/doc/polycli_ulxly_deposit-new.md
+++ b/doc/polycli_ulxly_deposit-new.md
@@ -86,6 +86,7 @@ The reason for failing may likely be due to the `out of gas` error. Increasing t
 ```bash
       --amount int                           The amount to send.
       --bridge-address string                The address of the bridge contract.
+      --bridge-message                       Bridge a message instead of an asset.
       --chain-id string                      The chainID.
       --destination-address string           The address of receiver in destination network.
       --destination-network uint32           The destination network number. (default 1)

--- a/doc/polycli_ulxly_deposit-new.md
+++ b/doc/polycli_ulxly_deposit-new.md
@@ -87,13 +87,14 @@ The reason for failing may likely be due to the `out of gas` error. Increasing t
       --amount int                           The amount to send.
       --bridge-address string                The address of the bridge contract.
       --bridge-message                       Bridge a message instead of an asset.
+      --bridge-weth                          Bridge a weth instead of an asset.
+      --call-data permit                     For bridging assets - raw data of the call permit of the token. For bridging messages - the metadata. (default "0x")
       --chain-id string                      The chainID.
       --destination-address string           The address of receiver in destination network.
       --destination-network uint32           The destination network number. (default 1)
       --force-update-root                    Force the update of the Global Exit Root. (default true)
       --gas-limit uint                       The gas limit for the transaction. (default 300000)
   -h, --help                                 help for deposit-new
-      --permit-data permit                   Raw data of the call permit of the token. (default "0x")
       --private-key string                   The private key of the sender account.
       --rpc-url string                       The RPC endpoint of the network (default "http://127.0.0.1:8545")
       --token-address string                 The address of the token to send. (default "0x0000000000000000000000000000000000000000")


### PR DESCRIPTION
# Description

This PR add onto the [previous](https://github.com/maticnetwork/polygon-cli/pull/304) uLxLy deposit and claim features with new:
* `polycli ulxly deposit-new --bridge-message` bool flag to indicate the deposit is a bridgeMessage call:
```!
/**
     * @notice Bridge message and send ETH value
     * note User/UI must be aware of the existing/available networks when choosing the destination network
     * @param destinationNetwork Network destination
     * @param destinationAddress Address destination
     * @param forceUpdateGlobalExitRoot Indicates if the new global exit root is updated or not
     * @param metadata Message metadata
     */
    function bridgeMessage(
        uint32 destinationNetwork,
        address destinationAddress,
        bool forceUpdateGlobalExitRoot,
        bytes calldata metadata
    )
```
* `polycli ulxly deposit-claim --claim-message` bool flag to indicate a claimMessage call:
```!
 /**
     * @notice Verify merkle proof and execute message
     * If the receiving address is an EOA, the call will result as a success
     * Which means that the amount of ether will be transferred correctly, but the message
     * will not trigger any execution
     * @param smtProofLocalExitRoot Smt proof to proof the leaf against the exit root
     * @param smtProofRollupExitRoot Smt proof to proof the rollupLocalExitRoot against the rollups exit root
     * @param globalIndex Global index is defined as:
     * | 191 bits |    1 bit     |   32 bits   |     32 bits    |
     * |    0     |  mainnetFlag | rollupIndex | localRootIndex |
     * note that only the rollup index will be used only in case the mainnet flag is 0
     * note that global index do not assert the unused bits to 0.
     * This means that when synching the events, the globalIndex must be decoded the same way that in the Smart contract
     * to avoid possible synch attacks
     * @param mainnetExitRoot Mainnet exit root
     * @param rollupExitRoot Rollup exit root
     * @param originNetwork Origin network
     * @param originAddress Origin address
     * @param destinationNetwork Network destination
     * @param destinationAddress Address destination
     * @param amount message value
     * @param metadata Abi encoded metadata if any, empty otherwise
     */
    function claimMessage(
        bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] calldata smtProofLocalExitRoot,
        bytes32[_DEPOSIT_CONTRACT_TREE_DEPTH] calldata smtProofRollupExitRoot,
        uint256 globalIndex,
        bytes32 mainnetExitRoot,
        bytes32 rollupExitRoot,
        uint32 originNetwork,
        address originAddress,
        uint32 destinationNetwork,
        address destinationAddress,
        uint256 amount,
        bytes calldata metadata
    )
```

# Testing

Usage is identical to the previous usage of `polycli ulxly deposit-new` and `polycli ulxly despoit-claim` with the addition of `--deposit-message` and `--claim-message` bool flags respectively to indicate that message bridging is triggered instead of asset bridging.
