### PR TITLE
fix: add error handling for `polycli ulxly bridge` asset and message operations

### DIFF
--- a/cmd/ulxly/ulxly.go
+++ b/cmd/ulxly/ulxly.go
@@ -2148,7 +2148,10 @@ func init() {
 		Long:    bridgeAssetUsage,
 		PreRunE: prepInputs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeAsset(cmd)
+			if err := bridgeAsset(cmd); err != nil {
+				log.Fatal().Err(err).Msg("Received critical error")
+			}
+			return nil
 		},
 		SilenceUsage: true,
 	}
@@ -2158,7 +2161,10 @@ func init() {
 		Long:    bridgeMessageUsage,
 		PreRunE: prepInputs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeMessage(cmd)
+			if err := bridgeMessage(cmd); err != nil {
+				log.Fatal().Err(err).Msg("Received critical error")
+			}
+			return nil
 		},
 		SilenceUsage: true,
 	}
@@ -2168,7 +2174,10 @@ func init() {
 		Long:    bridgeWETHMessageUsage,
 		PreRunE: prepInputs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return bridgeWETHMessage(cmd)
+			if err := bridgeWETHMessage(cmd); err != nil {
+				log.Fatal().Err(err).Msg("Received critical error")
+			}
+			return nil
 		},
 		SilenceUsage: true,
 	}
@@ -2178,7 +2187,10 @@ func init() {
 		Long:    claimAssetUsage,
 		PreRunE: prepInputs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return claimAsset(cmd)
+			if err := claimAsset(cmd); err != nil {
+				log.Fatal().Err(err).Msg("Received critical error")
+			}
+			return nil
 		},
 		SilenceUsage: true,
 	}
@@ -2188,7 +2200,10 @@ func init() {
 		Long:    claimMessageUsage,
 		PreRunE: prepInputs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return claimMessage(cmd)
+			if err := claimMessage(cmd); err != nil {
+				log.Fatal().Err(err).Msg("Received critical error")
+			}
+			return nil
 		},
 		SilenceUsage: true,
 	}
@@ -2197,7 +2212,10 @@ func init() {
 		Short:   "Attempt to claim as many deposits and messages as possible",
 		PreRunE: prepInputs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return claimEverything(cmd)
+			if err := claimEverything(cmd); err != nil {
+				log.Fatal().Err(err).Msg("Received critical error")
+			}
+			return nil
 		},
 		SilenceUsage: true,
 	}


### PR DESCRIPTION
While testing the bridge spammer, I noticed that some errors were logged in plain text, even though `pretty-logs` was set to `false`.

```json
{"level":"info","txHash":"0x325e73098c584d7fa324d0731dd906117d039e86bf0bd5141f000b2a647dd432","time":"2025-06-18T12:29:07Z","message":"Deposit transaction successful"}
{"info": "Bridging from L1 to L2"}
{"level":"error","error":"Post \"http://el-1-geth-lighthouse:8545\": dial tcp: lookup el-1-geth-lighthouse on 127.0.0.11:53: no such host","message":"","code":0,"data":null,"time":"2025-06-18T12:29:08Z","message":"Unable to interact with bridge contract"}
Error: Post "http://el-1-geth-lighthouse:8545": dial tcp: lookup el-1-geth-lighthouse on 127.0.0.11:53: no such host
{"error": "An error occurred. Continuing execution..."}
```

The issue stems from Cobra, which logs errors returned by `RunE` in plain text. To address this, we should log a fatal error instead, ensuring the program fails with an error message formatted in the right format.

## Test

```bash
polycli ulxly bridge asset --pretty-logs=false --rpc-url http://localhost:8545 --private-key 42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa --bridge-address 0x0 --destination-network 0
```

Before:

```json
{"level":"info","destAddress":"0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6","time":"2025-06-18T14:32:55+02:00","message":"No destination address specified. Using private key's address"}
{"level":"error","error":"Post \"http://localhost:8545\": dial tcp [::1]:8545: connect: connection refused","address":"0x0","time":"2025-06-18T14:32:55+02:00","message":"error getting code at address"}
{"level":"error","error":"bridge code check err: Post \"http://localhost:8545\": dial tcp [::1]:8545: connect: connection refused","time":"2025-06-18T14:32:55+02:00","message":"error generating transaction payload"}
Error: bridge code check err: Post "http://localhost:8545": dial tcp [::1]:8545: connect: connection refused
```

After:

```json
{"level":"info","destAddress":"0x85dA99c8a7C2C95964c8EfD687E95E632Fc533D6","time":"2025-06-18T14:30:55+02:00","message":"No destination address specified. Using private key's address"}
{"level":"error","error":"Post \"http://localhost:8545\": dial tcp [::1]:8545: connect: connection refused","address":"0x0","time":"2025-06-18T14:30:55+02:00","message":"error getting code at address"}
{"level":"error","error":"bridge code check err: Post \"http://localhost:8545\": dial tcp [::1]:8545: connect: connection refused","time":"2025-06-18T14:30:55+02:00","message":"error generating transaction payload"}
{"level":"fatal","error":"bridge code check err: Post \"http://localhost:8545\": dial tcp [::1]:8545: connect: connection refused","time":"2025-06-18T14:30:55+02:00","message":"Received critical error"}
```