### PR TITLE
fix(rpcfuzz): hide summary output when export modes are specified

### DIFF
--- a/cmd/rpcfuzz/rpcfuzz.go
+++ b/cmd/rpcfuzz/rpcfuzz.go
@@ -281,17 +281,15 @@ func runRpcFuzz(ctx context.Context) error {
 	testResults.GenerateTabularResult()
 	if *testExportJson {
 		testResults.ExportResultToJSON(filepath.Join(*testOutputExportPath, "output.json"))
-	}
-	if *testExportCSV {
+	} else if *testExportCSV {
 		testResults.ExportResultToCSV(filepath.Join(*testOutputExportPath, "output.csv"))
-	}
-	if *testExportMarkdown {
+	} else if *testExportMarkdown {
 		testResults.ExportResultToMarkdown(filepath.Join(*testOutputExportPath, "output.md"))
-	}
-	if *testExportHTML {
+	} else if *testExportHTML {
 		testResults.ExportResultToHTML(filepath.Join(*testOutputExportPath, "output.html"))
+	} else {
+		testResults.PrintTabularResult()
 	}
-	testResults.PrintTabularResult()
 
 	return nil
 }


### PR DESCRIPTION
# Description

This PR updates the `polycli rpcfuzz` command behaviour to suppress the summary output when export modes like `--json` are enabled.

## Test

Before:

```bash
$ polycli version
Polygon CLI Version v0.1.80

$ polycli rpcfuzz --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --json=true --pretty-logs=false
# ❌ Summary is displayed, unexpected when exporting JSON
```

After:

```bash
$ ./out/polycli version
Polygon CLI Version v0.1.81-1-g21f3ff2

$ ./out/polycli rpcfuzz --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --json=true --pretty-logs=false
# ✅ Only JSON logs are shown, no summary

$ ./out/polycli rpcfuzz --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
# ✅ Summary is displayed as expected
```
