### PR TITLE
fix(wallet): `getFileOrFlag` filename and flag both empty error

### DIFF
--- a/cmd/wallet/wallet.go
+++ b/cmd/wallet/wallet.go
@@ -102,10 +102,6 @@ var WalletCmd = &cobra.Command{
 }
 
 func getFileOrFlag(filename string, flag string) (string, error) {
-	if filename == "" && flag == "" {
-		return "", fmt.Errorf("both filename and flag are empty")
-	}
-
 	if filename == "" {
 		return flag, nil
 	}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

In `v0.1.89` there was this check in `getFlagOrFile`:
```go
func getFileOrFlag(filename *string, flag *string) (string, error) {
	if filename == nil && flag == nil {
		return "", fmt.Errorf("both the filename and the flag pointers are nil")
	}
    ...
}
```

The issue with this was the it was never being evaluated because cobra always initializes the `*string`s which stored the filename and flags to `""`, but when switching to:
```go
	if filename == "" && flag == "" {
		return "", fmt.Errorf("both filename and flag are empty")
	}
```
in `v0.1.90`. This check now returns an error.

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [ ] Test A
- [ ] Test B
