### PR TITLE
fix(sensor): `getParentBlock` short-circuit

### DIFF
--- a/p2p/database/json.go
+++ b/p2p/database/json.go
@@ -333,7 +333,7 @@ func (j *JSONDatabase) WritePeers(ctx context.Context, peers []*p2p.Peer, tls ti
 
 // HasBlock always returns true to avoid unnecessary parent block fetching for JSON output.
 func (j *JSONDatabase) HasBlock(ctx context.Context, hash common.Hash) bool {
-	return true
+	return false
 }
 
 // MaxConcurrentWrites returns the max concurrency.

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -328,7 +328,7 @@ func (c *conn) getBlockData(hash common.Hash, cache BlockCache, isParent bool) e
 // getParentBlock will send a request to the peer if the parent of the header
 // does not exist in the database.
 func (c *conn) getParentBlock(ctx context.Context, header *types.Header) error {
-	if !c.db.ShouldWriteBlocks() || !c.db.ShouldWriteBlockEvents() {
+	if !c.db.ShouldWriteBlocks() {
 		return nil
 	}
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

- Fixes the `getParentBlock` method to not short-circuit based on the `--write-block-events` flag.
- JSON db now returns false to having a block because the centralized block cache should ideally have it.

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] 👀
- [x] Deployed Amoy
- [x] Deployed Mainnet
