### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/cmd/ulxly/common/imt.go
+++ b/cmd/ulxly/common/imt.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/binary"
 	"fmt"
+	"slices"
 
 	"github.com/0xPolygon/polygon-cli/bindings/ulxly"
 	"github.com/ethereum/go-ethereum/common"
@@ -172,8 +173,8 @@ func Check(roots []common.Hash, leaf common.Hash, position uint32, siblings [32]
 	}
 
 	isProofValid := false
-	for i := len(roots) - 1; i >= 0; i-- {
-		if roots[i].Cmp(node) == 0 {
+	for _, v := range slices.Backward(roots) {
+		if v.Cmp(node) == 0 {
 			isProofValid = true
 			break
 		}


### PR DESCRIPTION
# Description

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899



## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [ ] Test A
- [ ] Test B
