### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -278,7 +278,7 @@ func ParseRPCHeaders(s string) (map[string]string, error) {
 	}
 
 	headers := make(map[string]string)
-	for _, pair := range strings.Split(s, ",") {
+	for pair := range strings.SplitSeq(s, ",") {
 		parts := strings.SplitN(pair, ":", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid header format %q, expected key:value", pair)


### PR DESCRIPTION
# Description

strings.SplitSeq (introduced in Go 1.23) returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

More info: https://github.com/golang/go/issues/61901

Inspired by https://github.com/0xPolygon/polygon-cli/pull/769 and replace all.

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [ ] Test A
- [ ] Test B
