### PR TITLE
refactor: use the built-in min to simplify the code

### DIFF
--- a/cmd/pos/exitproof/cmd.go
+++ b/cmd/pos/exitproof/cmd.go
@@ -620,11 +620,7 @@ func fetchBlockHashesBatched(ctx context.Context, rpc *ethrpc.Client, start, end
 	}
 
 	for batchStart := uint64(0); batchStart < count; batchStart += headerFetchBatchSize {
-		batchEnd := batchStart + headerFetchBatchSize
-		if batchEnd > count {
-			batchEnd = count
-		}
-		batchLen := batchEnd - batchStart
+		batchLen := min(batchStart+headerFetchBatchSize, count) - batchStart
 
 		elems := make([]ethrpc.BatchElem, batchLen)
 		results := make([]blockHeader, batchLen)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.



## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [ ] Test A
- [ ] Test B
