### PR TITLE
feat(p2p/sensor): validate block signer before rebroadcast

### DIFF
--- a/cmd/ecrecover/ecrecover.go
+++ b/cmd/ecrecover/ecrecover.go
@@ -68,9 +68,8 @@ var EcRecoverCmd = &cobra.Command{
 				return
 			}
 
-			block := types.NewBlockWithHeader(&header)
 			blockNumber = header.Number.Uint64()
-			signerBytes, err = util.Ecrecover(block)
+			signerBytes, err = util.Ecrecover(&header)
 
 		} else if txData != "" { // transaction signer from data
 
@@ -115,7 +114,7 @@ var EcRecoverCmd = &cobra.Command{
 				log.Error().Err(err).Msg("Unable to retrieve block")
 				return
 			}
-			signerBytes, err = util.Ecrecover(block)
+			signerBytes, err = util.Ecrecover(block.Header())
 		}
 
 		if err != nil {

--- a/cmd/heimdall/wallet/change_password.go
+++ b/cmd/heimdall/wallet/change_password.go
@@ -16,8 +16,8 @@ import (
 // rewritten in-place rather than duplicated.
 func newChangePasswordCmd() *cobra.Command {
 	var (
-		shared         keystoreSharedFlags
-		newPassword    string
+		shared          keystoreSharedFlags
+		newPassword     string
 		newPasswordFile string
 	)
 	cmd := &cobra.Command{

--- a/cmd/heimdall/wallet/import.go
+++ b/cmd/heimdall/wallet/import.go
@@ -14,11 +14,12 @@ import (
 // the polycli/cast-shared keystore directory.
 //
 // Accepts three mutually-exclusive sources:
-//   --private-key HEX             : 32-byte secp256k1 private key
-//   --keystore-file PATH          : a v3 JSON keystore (asks for its
-//                                   password, then re-encrypts under
-//                                   the new password)
-//   --mnemonic MNEMONIC (with optional --path / --index)
+//
+//	--private-key HEX             : 32-byte secp256k1 private key
+//	--keystore-file PATH          : a v3 JSON keystore (asks for its
+//	                                password, then re-encrypts under
+//	                                the new password)
+//	--mnemonic MNEMONIC (with optional --path / --index)
 func newImportCmd() *cobra.Command {
 	var (
 		shared       keystoreSharedFlags

--- a/cmd/heimdall/wallet/new_mnemonic.go
+++ b/cmd/heimdall/wallet/new_mnemonic.go
@@ -15,12 +15,12 @@ import (
 // prominent warning.
 func newNewMnemonicCmd() *cobra.Command {
 	var (
-		shared     keystoreSharedFlags
-		words      int
-		bipPass    string
-		path       string
-		index      uint32
-		printOnly  bool
+		shared    keystoreSharedFlags
+		words     int
+		bipPass   string
+		path      string
+		index     uint32
+		printOnly bool
 	)
 	cmd := &cobra.Command{
 		Use:   "new-mnemonic",

--- a/cmd/heimdall/wallet/pubkey.go
+++ b/cmd/heimdall/wallet/pubkey.go
@@ -20,9 +20,9 @@ import (
 // Source precedence: <address> positional > --private-key > --keystore-file.
 func newPublicKeyCmd() *cobra.Command {
 	var (
-		shared        keystoreSharedFlags
-		privateKey    string
-		compressedOnly bool
+		shared           keystoreSharedFlags
+		privateKey       string
+		compressedOnly   bool
 		uncompressedOnly bool
 	)
 	cmd := &cobra.Command{

--- a/cmd/monitorv2/renderer/tview_renderer.go
+++ b/cmd/monitorv2/renderer/tview_renderer.go
@@ -180,10 +180,10 @@ type TviewRenderer struct {
 	homeStatusPane   *tview.TextView // Left pane: Status information (1/3 width)
 	homeMetricsPane  *tview.Table    // Right pane: Metrics table (2/3 width)
 	homeTable        *tview.Table
-	homeTableCache   [][]string // Cached table cell values for incremental redraw
-	homeTableRows    int        // Number of cached data rows
-	homeTableInnerW  int        // Cached inner width to detect resize-driven redraw invalidation
-	homeTableInnerH  int        // Cached inner height to detect resize-driven redraw invalidation
+	homeTableCache   [][]string      // Cached table cell values for incremental redraw
+	homeTableRows    int             // Number of cached data rows
+	homeTableInnerW  int             // Cached inner width to detect resize-driven redraw invalidation
+	homeTableInnerH  int             // Cached inner height to detect resize-driven redraw invalidation
 	blockDetailPage  *tview.Flex     // Changed to Flex for side-by-side layout
 	blockDetailLeft  *tview.Table    // Left pane: Transaction table
 	blockDetailRight *tview.TextView // Right pane: Raw JSON
@@ -620,7 +620,6 @@ func (t *TviewRenderer) Start(ctx context.Context) error {
 
 	return nil
 }
-
 
 // getCachedSigner gets the signer for a block, using LRU cache to avoid expensive Ecrecover calls
 func (t *TviewRenderer) getCachedSigner(block rpctypes.PolyBlock) string {

--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -61,6 +61,8 @@ type (
 		TxBroadcastQueueSize             int
 		MaxTxPacketSize                  int
 		MaxQueuedTxs                     int
+		ValidateBlockSigner              bool
+		CacheOnlyValidatedBlocks         bool
 		HeimdallURL                      string
 		ValidatorSetRefresh              time.Duration
 		ShouldRunPprof                   bool
@@ -179,6 +181,18 @@ var SensorCmd = &cobra.Command{
 			return err
 		}
 
+		// Signer validation only runs when rebroadcasting blocks, so the
+		// heimdall flags are only required in that case.
+		if inputSensorParams.ValidateBlockSigner &&
+			(inputSensorParams.ShouldBroadcastBlocks || inputSensorParams.ShouldBroadcastBlockHashes) {
+			if inputSensorParams.HeimdallURL == "" {
+				return errors.New("--heimdall-url is required when --validate-block-signer is enabled with block broadcasting")
+			}
+			if inputSensorParams.ValidatorSetRefresh <= 0 {
+				return errors.New("--validator-set-refresh must be greater than zero when --validate-block-signer is enabled with block broadcasting")
+			}
+		}
+
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -206,12 +220,13 @@ var SensorCmd = &cobra.Command{
 		peersGauge := p2p.NewPeersGauge()
 		metrics := p2p.NewBlockMetrics(head.Block)
 
-		// When block rebroadcasting is enabled, load the validator signer set
-		// from Heimdall so we only rebroadcast blocks signed by a known
-		// validator. The initial fetch is blocking and fatal on failure so we
-		// never rebroadcast against an empty signer set.
+		// When block rebroadcasting is enabled and signer validation is on, load
+		// the validator set from Heimdall so we only rebroadcast blocks signed
+		// by a known validator. The initial fetch is blocking and fatal on
+		// failure so we never rebroadcast against an empty validator set.
 		var validators *p2p.ValidatorSet
-		if inputSensorParams.ShouldBroadcastBlocks || inputSensorParams.ShouldBroadcastBlockHashes {
+		if inputSensorParams.ValidateBlockSigner &&
+			(inputSensorParams.ShouldBroadcastBlocks || inputSensorParams.ShouldBroadcastBlockHashes) {
 			validators = p2p.NewValidatorSet(inputSensorParams.HeimdallURL, inputSensorParams.ValidatorSetRefresh)
 			if err = validators.Start(ctx); err != nil {
 				return fmt.Errorf("failed to load validator set from %s: %w", inputSensorParams.HeimdallURL, err)
@@ -236,6 +251,7 @@ var SensorCmd = &cobra.Command{
 			MaxTxPacketSize:            inputSensorParams.MaxTxPacketSize,
 			MaxQueuedTxs:               inputSensorParams.MaxQueuedTxs,
 			ValidatorSet:               validators,
+			CacheOnlyValidatedBlocks:   inputSensorParams.CacheOnlyValidatedBlocks,
 		})
 
 		opts := p2p.EthProtocolOptions{
@@ -518,8 +534,10 @@ will result in less chance of missing data but can significantly increase memory
 	f.IntVar(&inputSensorParams.TxBroadcastQueueSize, "tx-broadcast-queue-size", 100_000, "capacity of transaction broadcast queue")
 	f.IntVar(&inputSensorParams.MaxTxPacketSize, "max-tx-packet-size", 100*1024, "target size in bytes for transaction broadcast packets")
 	f.IntVar(&inputSensorParams.MaxQueuedTxs, "max-queued-txs", 4096, "maximum transaction announcements to queue per peer")
-	f.StringVar(&inputSensorParams.HeimdallURL, "heimdall-url", "https://heimdall-api.polygon.technology", "heimdall REST URL for the validator signer set (used to validate blocks before rebroadcast)")
-	f.DurationVar(&inputSensorParams.ValidatorSetRefresh, "validator-set-refresh", 5*time.Minute, "interval to refresh the validator signer set from heimdall")
+	f.BoolVar(&inputSensorParams.ValidateBlockSigner, "validate-block-signer", true, "only rebroadcast blocks signed by a validator in the heimdall validator set")
+	f.BoolVar(&inputSensorParams.CacheOnlyValidatedBlocks, "cache-only-validated-blocks", true, "only cache and serve blocks signed by a known validator (unknown-signer blocks are still recorded to the database); has no effect without --validate-block-signer")
+	f.StringVar(&inputSensorParams.HeimdallURL, "heimdall-url", "https://heimdall-api.polygon.technology", "heimdall REST URL for the validator set (used to validate blocks before rebroadcast)")
+	f.DurationVar(&inputSensorParams.ValidatorSetRefresh, "validator-set-refresh", 5*time.Minute, "interval to refresh the validator set from heimdall")
 	f.BoolVar(&inputSensorParams.ShouldRunPprof, "pprof", false, "run pprof server")
 	f.UintVar(&inputSensorParams.PprofPort, "pprof-port", 6060, "port pprof runs on")
 	f.BoolVar(&inputSensorParams.ShouldRunPrometheus, "prom", true, "run Prometheus server")

--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -61,6 +61,8 @@ type (
 		TxBroadcastQueueSize             int
 		MaxTxPacketSize                  int
 		MaxQueuedTxs                     int
+		HeimdallURL                      string
+		ValidatorSetRefresh              time.Duration
 		ShouldRunPprof                   bool
 		PprofPort                        uint
 		ShouldRunPrometheus              bool
@@ -204,6 +206,18 @@ var SensorCmd = &cobra.Command{
 		peersGauge := p2p.NewPeersGauge()
 		metrics := p2p.NewBlockMetrics(head.Block)
 
+		// When block rebroadcasting is enabled, load the validator signer set
+		// from Heimdall so we only rebroadcast blocks signed by a known
+		// validator. The initial fetch is blocking and fatal on failure so we
+		// never rebroadcast against an empty signer set.
+		var validators *p2p.ValidatorSet
+		if inputSensorParams.ShouldBroadcastBlocks || inputSensorParams.ShouldBroadcastBlockHashes {
+			validators = p2p.NewValidatorSet(inputSensorParams.HeimdallURL, inputSensorParams.ValidatorSetRefresh)
+			if err = validators.Start(ctx); err != nil {
+				return fmt.Errorf("failed to load validator set from %s: %w", inputSensorParams.HeimdallURL, err)
+			}
+		}
+
 		// Create peer connection manager for broadcasting transactions
 		// and managing the global blocks cache
 		conns := p2p.NewConns(p2p.ConnsOptions{
@@ -221,6 +235,7 @@ var SensorCmd = &cobra.Command{
 			TxBroadcastQueueSize:       inputSensorParams.TxBroadcastQueueSize,
 			MaxTxPacketSize:            inputSensorParams.MaxTxPacketSize,
 			MaxQueuedTxs:               inputSensorParams.MaxQueuedTxs,
+			ValidatorSet:               validators,
 		})
 
 		opts := p2p.EthProtocolOptions{
@@ -503,6 +518,8 @@ will result in less chance of missing data but can significantly increase memory
 	f.IntVar(&inputSensorParams.TxBroadcastQueueSize, "tx-broadcast-queue-size", 100_000, "capacity of transaction broadcast queue")
 	f.IntVar(&inputSensorParams.MaxTxPacketSize, "max-tx-packet-size", 100*1024, "target size in bytes for transaction broadcast packets")
 	f.IntVar(&inputSensorParams.MaxQueuedTxs, "max-queued-txs", 4096, "maximum transaction announcements to queue per peer")
+	f.StringVar(&inputSensorParams.HeimdallURL, "heimdall-url", "https://heimdall-api.polygon.technology", "heimdall REST URL for the validator signer set (used to validate blocks before rebroadcast)")
+	f.DurationVar(&inputSensorParams.ValidatorSetRefresh, "validator-set-refresh", 5*time.Minute, "interval to refresh the validator signer set from heimdall")
 	f.BoolVar(&inputSensorParams.ShouldRunPprof, "pprof", false, "run pprof server")
 	f.UintVar(&inputSensorParams.PprofPort, "pprof-port", 6060, "port pprof runs on")
 	f.BoolVar(&inputSensorParams.ShouldRunPrometheus, "prom", true, "run Prometheus server")

--- a/cmd/p2p/sensor/usage.md
+++ b/cmd/p2p/sensor/usage.md
@@ -43,6 +43,24 @@ The sensor exposes Prometheus metrics at `http://localhost:2112/metrics`
 (configurable via `--prom-port`). For a complete list of available metrics, see
 [polycli_p2p_sensor_metrics.md](polycli_p2p_sensor_metrics.md).
 
+## Rebroadcasting
+
+The sensor can rebroadcast the transactions and blocks it receives back to its
+peers via `--broadcast-txs`, `--broadcast-tx-hashes`, `--broadcast-blocks`, and
+`--broadcast-block-hashes`.
+
+When block rebroadcasting is enabled (`--broadcast-blocks` or
+`--broadcast-block-hashes`), the sensor validates the block signer before
+rebroadcasting: it recovers the signer from the block header and only
+rebroadcasts blocks signed by an address in the current Heimdall validator set.
+Blocks from unknown signers are still persisted and their bodies are still
+requested (so the sensor can record and serve them) — they are simply not
+rebroadcast to peers.
+
+The validator set is fetched from `--heimdall-url` at startup (the sensor aborts
+if this initial fetch fails) and refreshed on the `--validator-set-refresh`
+interval.
+
 ## Examples
 
 ### Mainnet

--- a/cmd/p2p/sensor/usage.md
+++ b/cmd/p2p/sensor/usage.md
@@ -51,11 +51,17 @@ peers via `--broadcast-txs`, `--broadcast-tx-hashes`, `--broadcast-blocks`, and
 
 When block rebroadcasting is enabled (`--broadcast-blocks` or
 `--broadcast-block-hashes`), the sensor validates the block signer before
-rebroadcasting: it recovers the signer from the block header and only
-rebroadcasts blocks signed by an address in the current Heimdall validator set.
-Blocks from unknown signers are still persisted and their bodies are still
-requested (so the sensor can record and serve them) — they are simply not
-rebroadcast to peers.
+rebroadcasting by default (`--validate-block-signer`, enabled by default): it
+recovers the signer from the block header and only rebroadcasts blocks signed by
+an address in the current Heimdall validator set. Set
+`--validate-block-signer=false` to rebroadcast every block regardless of signer.
+
+By default (`--cache-only-validated-blocks`), blocks from unknown signers are
+still recorded to the database and their headers/bodies are still requested, but
+they are not kept in the in-memory serving cache — so the sensor neither
+rebroadcasts them nor serves them to peers on request, and they cannot evict
+legitimate blocks from the cache. Set `--cache-only-validated-blocks=false` to
+cache every block while still gating rebroadcast by signer.
 
 The validator set is fetched from `--heimdall-url` at startup (the sensor aborts
 if this initial fetch fails) and refreshed on the `--validator-set-refresh`

--- a/doc/polycli_p2p_sensor.md
+++ b/doc/polycli_p2p_sensor.md
@@ -72,11 +72,17 @@ peers via `--broadcast-txs`, `--broadcast-tx-hashes`, `--broadcast-blocks`, and
 
 When block rebroadcasting is enabled (`--broadcast-blocks` or
 `--broadcast-block-hashes`), the sensor validates the block signer before
-rebroadcasting: it recovers the signer from the block header and only
-rebroadcasts blocks signed by an address in the current Heimdall validator set.
-Blocks from unknown signers are still persisted and their bodies are still
-requested (so the sensor can record and serve them) — they are simply not
-rebroadcast to peers.
+rebroadcasting by default (`--validate-block-signer`, enabled by default): it
+recovers the signer from the block header and only rebroadcasts blocks signed by
+an address in the current Heimdall validator set. Set
+`--validate-block-signer=false` to rebroadcast every block regardless of signer.
+
+By default (`--cache-only-validated-blocks`), blocks from unknown signers are
+still recorded to the database and their headers/bodies are still requested, but
+they are not kept in the in-memory serving cache — so the sensor neither
+rebroadcasts them nor serves them to peers on request, and they cannot evict
+legitimate blocks from the cache. Set `--cache-only-validated-blocks=false` to
+cache every block while still gating rebroadcast by signer.
 
 The validator set is fetched from `--heimdall-url` at startup (the sensor aborts
 if this initial fetch fails) and refreshed on the `--validator-set-refresh`
@@ -145,6 +151,7 @@ polycli p2p sensor amoy-nodes.json \
       --broadcast-tx-hashes              broadcast transaction hashes to peers
       --broadcast-txs                    broadcast full transactions to peers
       --broadcast-workers int            number of concurrent broadcast workers (default 4)
+      --cache-only-validated-blocks      only cache and serve blocks signed by a known validator (unknown-signer blocks are still recorded to the database); has no effect without --validate-block-signer (default true)
       --database string                  which database to persist data to, options are:
                                            - datastore (GCP Datastore)
                                            - json (output to stdout)
@@ -155,7 +162,7 @@ polycli p2p sensor amoy-nodes.json \
       --discovery-port int               UDP P2P discovery port (default 30303)
       --fork-id bytesHex                 hex encoded fork ID (omit 0x) (default 22D523B2)
       --genesis-hash string              genesis block hash (default "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b")
-      --heimdall-url string              heimdall REST URL for the validator signer set (used to validate blocks before rebroadcast) (default "https://heimdall-api.polygon.technology")
+      --heimdall-url string              heimdall REST URL for the validator set (used to validate blocks before rebroadcast) (default "https://heimdall-api.polygon.technology")
   -h, --help                             help for sensor
       --key string                       hex-encoded private key (cannot be set with --key-file)
   -k, --key-file string                  private key file (cannot be set with --key)
@@ -194,7 +201,8 @@ polycli p2p sensor amoy-nodes.json \
       --tx-batch-timeout duration        timeout for batching transactions before broadcast (default 500ms)
       --tx-broadcast-queue-size int      capacity of transaction broadcast queue (default 100000)
       --txs-cache-ttl duration           time to live for transaction cache entries (0 for no expiration) (default 10m0s)
-      --validator-set-refresh duration   interval to refresh the validator signer set from heimdall (default 5m0s)
+      --validate-block-signer            only rebroadcast blocks signed by a validator in the heimdall validator set (default true)
+      --validator-set-refresh duration   interval to refresh the validator set from heimdall (default 5m0s)
       --write-block-events               write block events to database (default true)
   -B, --write-blocks                     write blocks to database (default true)
       --write-first-block-event          write one block event on first-seen only (requires --write-block-events=false)

--- a/doc/polycli_p2p_sensor.md
+++ b/doc/polycli_p2p_sensor.md
@@ -64,6 +64,24 @@ The sensor exposes Prometheus metrics at `http://localhost:2112/metrics`
 (configurable via `--prom-port`). For a complete list of available metrics, see
 [polycli_p2p_sensor_metrics.md](polycli_p2p_sensor_metrics.md).
 
+## Rebroadcasting
+
+The sensor can rebroadcast the transactions and blocks it receives back to its
+peers via `--broadcast-txs`, `--broadcast-tx-hashes`, `--broadcast-blocks`, and
+`--broadcast-block-hashes`.
+
+When block rebroadcasting is enabled (`--broadcast-blocks` or
+`--broadcast-block-hashes`), the sensor validates the block signer before
+rebroadcasting: it recovers the signer from the block header and only
+rebroadcasts blocks signed by an address in the current Heimdall validator set.
+Blocks from unknown signers are still persisted and their bodies are still
+requested (so the sensor can record and serve them) — they are simply not
+rebroadcast to peers.
+
+The validator set is fetched from `--heimdall-url` at startup (the sensor aborts
+if this initial fetch fails) and refreshed on the `--validator-set-refresh`
+interval.
+
 ## Examples
 
 ### Mainnet
@@ -119,69 +137,71 @@ polycli p2p sensor amoy-nodes.json \
 ## Flags
 
 ```bash
-      --api-port uint                 port API server will listen on (default 8080)
-      --blocks-cache-ttl duration     time to live for block cache entries (0 for no expiration) (default 10m0s)
-  -b, --bootnodes string              comma separated nodes used for bootstrapping
-      --broadcast-block-hashes        broadcast block hashes to peers
-      --broadcast-blocks              broadcast full blocks to peers
-      --broadcast-tx-hashes           broadcast transaction hashes to peers
-      --broadcast-txs                 broadcast full transactions to peers
-      --broadcast-workers int         number of concurrent broadcast workers (default 4)
-      --database string               which database to persist data to, options are:
-                                        - datastore (GCP Datastore)
-                                        - json (output to stdout)
-                                        - none (no persistence) (default "none")
-  -d, --database-id string            datastore database ID
-      --dial-ratio int                ratio of inbound to dialed connections (dial ratio of 2 allows 1/2 of connections to be dialed, setting to 0 defaults to 3)
-      --discovery-dns string          DNS discovery ENR tree URL
-      --discovery-port int            UDP P2P discovery port (default 30303)
-      --fork-id bytesHex              hex encoded fork ID (omit 0x) (default 22D523B2)
-      --genesis-hash string           genesis block hash (default "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b")
-  -h, --help                          help for sensor
-      --key string                    hex-encoded private key (cannot be set with --key-file)
-  -k, --key-file string               private key file (cannot be set with --key)
-      --known-txs-bloom-hashes uint   number of hash functions for known txs bloom filter (default 7)
-      --known-txs-bloom-size uint     bloom filter size in bits for tracking known transactions per peer (default ~40KB per filter,
-                                      optimized for ~32K elements with ~1% false positive rate) (default 327680)
-      --max-blocks int                maximum blocks to track across all peers (0 for no limit) (default 1024)
-  -D, --max-db-concurrency int        maximum number of concurrent database operations to perform (increasing this
-                                      will result in less chance of missing data but can significantly increase memory usage) (default 10000)
-      --max-known-blocks int          maximum block hashes to track per peer (0 for no limit) (default 1024)
-      --max-parents int               maximum parent block hashes to track per peer (0 for no limit) (default 1024)
-  -m, --max-peers int                 maximum number of peers to connect to (default 2000)
-      --max-queued-txs int            maximum transaction announcements to queue per peer (default 4096)
-      --max-requests int              maximum request IDs to track per peer (0 for no limit) (default 2048)
-      --max-tx-packet-size int        target size in bytes for transaction broadcast packets (default 102400)
-      --max-txs int                   maximum transactions to cache for serving to peers (0 for no limit) (default 32768)
-      --nat string                    NAT port mapping mechanism (any|none|upnp|pmp|pmp:<IP>|extip:<IP>) (default "any")
-  -n, --network-id uint               filter discovered nodes by this network ID
-      --no-discovery                  disable P2P peer discovery
-      --parents-cache-ttl duration    time to live for parent hash cache entries (0 for no expiration) (default 5m0s)
-      --port int                      TCP network listening port (default 30303)
-      --pprof                         run pprof server
-      --pprof-port uint               port pprof runs on (default 6060)
-  -p, --project-id string             GCP project ID
-      --prom                          run Prometheus server (default true)
-      --prom-port uint                port Prometheus runs on (default 2112)
-      --proxy-rpc                     proxy unsupported RPC methods to the --rpc endpoint
-      --proxy-rpc-timeout duration    timeout for proxied RPC requests (default 30s)
-      --requests-cache-ttl duration   time to live for requests cache entries (0 for no expiration) (default 5m0s)
-      --rpc string                    RPC endpoint used to fetch latest block (default "https://polygon-rpc.com")
-      --rpc-port uint                 port for JSON-RPC server to receive transactions (default 8545)
-  -s, --sensor-id string              sensor ID when writing block/tx events
-      --static-nodes string           static nodes file
-      --trusted-nodes string          trusted nodes file
-      --ttl duration                  time to live (default 336h0m0s)
-      --tx-batch-timeout duration     timeout for batching transactions before broadcast (default 500ms)
-      --tx-broadcast-queue-size int   capacity of transaction broadcast queue (default 100000)
-      --txs-cache-ttl duration        time to live for transaction cache entries (0 for no expiration) (default 10m0s)
-      --write-block-events            write block events to database (default true)
-  -B, --write-blocks                  write blocks to database (default true)
-      --write-first-block-event       write one block event on first-seen only (requires --write-block-events=false)
-      --write-first-tx-event          write one transaction event on first-seen only (requires --write-tx-events=false)
-      --write-peers                   write peers to database (default true)
-      --write-tx-events               write transaction events to database (this option can significantly increase CPU and memory usage) (default true)
-  -t, --write-txs                     write transactions to database (this option can significantly increase CPU and memory usage) (default true)
+      --api-port uint                    port API server will listen on (default 8080)
+      --blocks-cache-ttl duration        time to live for block cache entries (0 for no expiration) (default 10m0s)
+  -b, --bootnodes string                 comma separated nodes used for bootstrapping
+      --broadcast-block-hashes           broadcast block hashes to peers
+      --broadcast-blocks                 broadcast full blocks to peers
+      --broadcast-tx-hashes              broadcast transaction hashes to peers
+      --broadcast-txs                    broadcast full transactions to peers
+      --broadcast-workers int            number of concurrent broadcast workers (default 4)
+      --database string                  which database to persist data to, options are:
+                                           - datastore (GCP Datastore)
+                                           - json (output to stdout)
+                                           - none (no persistence) (default "none")
+  -d, --database-id string               datastore database ID
+      --dial-ratio int                   ratio of inbound to dialed connections (dial ratio of 2 allows 1/2 of connections to be dialed, setting to 0 defaults to 3)
+      --discovery-dns string             DNS discovery ENR tree URL
+      --discovery-port int               UDP P2P discovery port (default 30303)
+      --fork-id bytesHex                 hex encoded fork ID (omit 0x) (default 22D523B2)
+      --genesis-hash string              genesis block hash (default "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b")
+      --heimdall-url string              heimdall REST URL for the validator signer set (used to validate blocks before rebroadcast) (default "https://heimdall-api.polygon.technology")
+  -h, --help                             help for sensor
+      --key string                       hex-encoded private key (cannot be set with --key-file)
+  -k, --key-file string                  private key file (cannot be set with --key)
+      --known-txs-bloom-hashes uint      number of hash functions for known txs bloom filter (default 7)
+      --known-txs-bloom-size uint        bloom filter size in bits for tracking known transactions per peer (default ~40KB per filter,
+                                         optimized for ~32K elements with ~1% false positive rate) (default 327680)
+      --max-blocks int                   maximum blocks to track across all peers (0 for no limit) (default 1024)
+  -D, --max-db-concurrency int           maximum number of concurrent database operations to perform (increasing this
+                                         will result in less chance of missing data but can significantly increase memory usage) (default 10000)
+      --max-known-blocks int             maximum block hashes to track per peer (0 for no limit) (default 1024)
+      --max-parents int                  maximum parent block hashes to track per peer (0 for no limit) (default 1024)
+  -m, --max-peers int                    maximum number of peers to connect to (default 2000)
+      --max-queued-txs int               maximum transaction announcements to queue per peer (default 4096)
+      --max-requests int                 maximum request IDs to track per peer (0 for no limit) (default 2048)
+      --max-tx-packet-size int           target size in bytes for transaction broadcast packets (default 102400)
+      --max-txs int                      maximum transactions to cache for serving to peers (0 for no limit) (default 32768)
+      --nat string                       NAT port mapping mechanism (any|none|upnp|pmp|pmp:<IP>|extip:<IP>) (default "any")
+  -n, --network-id uint                  filter discovered nodes by this network ID
+      --no-discovery                     disable P2P peer discovery
+      --parents-cache-ttl duration       time to live for parent hash cache entries (0 for no expiration) (default 5m0s)
+      --port int                         TCP network listening port (default 30303)
+      --pprof                            run pprof server
+      --pprof-port uint                  port pprof runs on (default 6060)
+  -p, --project-id string                GCP project ID
+      --prom                             run Prometheus server (default true)
+      --prom-port uint                   port Prometheus runs on (default 2112)
+      --proxy-rpc                        proxy unsupported RPC methods to the --rpc endpoint
+      --proxy-rpc-timeout duration       timeout for proxied RPC requests (default 30s)
+      --requests-cache-ttl duration      time to live for requests cache entries (0 for no expiration) (default 5m0s)
+      --rpc string                       RPC endpoint used to fetch latest block (default "https://polygon-rpc.com")
+      --rpc-port uint                    port for JSON-RPC server to receive transactions (default 8545)
+  -s, --sensor-id string                 sensor ID when writing block/tx events
+      --static-nodes string              static nodes file
+      --trusted-nodes string             trusted nodes file
+      --ttl duration                     time to live (default 336h0m0s)
+      --tx-batch-timeout duration        timeout for batching transactions before broadcast (default 500ms)
+      --tx-broadcast-queue-size int      capacity of transaction broadcast queue (default 100000)
+      --txs-cache-ttl duration           time to live for transaction cache entries (0 for no expiration) (default 10m0s)
+      --validator-set-refresh duration   interval to refresh the validator signer set from heimdall (default 5m0s)
+      --write-block-events               write block events to database (default true)
+  -B, --write-blocks                     write blocks to database (default true)
+      --write-first-block-event          write one block event on first-seen only (requires --write-block-events=false)
+      --write-first-tx-event             write one transaction event on first-seen only (requires --write-tx-events=false)
+      --write-peers                      write peers to database (default true)
+      --write-tx-events                  write transaction events to database (this option can significantly increase CPU and memory usage) (default true)
+  -t, --write-txs                        write transactions to database (this option can significantly increase CPU and memory usage) (default true)
 ```
 
 The command also inherits flags from parent commands.

--- a/internal/heimdall/client/errors.go
+++ b/internal/heimdall/client/errors.go
@@ -84,4 +84,3 @@ func ExitCode(err error) int {
 	}
 	return config.ExitNodeErr
 }
-

--- a/internal/heimdall/config/config.go
+++ b/internal/heimdall/config/config.go
@@ -230,13 +230,13 @@ func resolveNetworkName(f *Flags) (string, error) {
 }
 
 type fileConfig struct {
-	DefaultNetwork string                    `toml:"default_network"`
-	RESTURL        string                    `toml:"rest_url"`
-	RPCURL         string                    `toml:"rpc_url"`
-	ChainID        string                    `toml:"chain_id"`
-	Denom          string                    `toml:"denom"`
-	TimeoutSec     int                       `toml:"timeout"`
-	Networks       map[string]fileConfigNet  `toml:"networks"`
+	DefaultNetwork string                   `toml:"default_network"`
+	RESTURL        string                   `toml:"rest_url"`
+	RPCURL         string                   `toml:"rpc_url"`
+	ChainID        string                   `toml:"chain_id"`
+	Denom          string                   `toml:"denom"`
+	TimeoutSec     int                      `toml:"timeout"`
+	Networks       map[string]fileConfigNet `toml:"networks"`
 }
 
 type fileConfigNet struct {

--- a/internal/heimdall/render/render_test.go
+++ b/internal/heimdall/render/render_test.go
@@ -272,8 +272,8 @@ func TestStringifyFloatBounds(t *testing.T) {
 		// digits; the key property is no int64 wraparound.
 		{float64(1 << 63), "9223372036854776000"},
 		{-(float64(1 << 63)), "-9223372036854776000"},
-		{1e20, "100000000000000000000"},               // large but under the 1e21 cap
-		{1e21, "1e+21"},                               // at the cap: exponent form
+		{1e20, "100000000000000000000"}, // large but under the 1e21 cap
+		{1e21, "1e+21"},                 // at the cap: exponent form
 		{1e22, "1e+22"},
 		{-1e30, "-1e+30"},
 	}

--- a/internal/heimdall/tx/builder_test.go
+++ b/internal/heimdall/tx/builder_test.go
@@ -37,9 +37,9 @@ func fixedECDSAKey(t *testing.T) *ecdsa.PrivateKey {
 // fakeAccountFetcher returns fixed account info and records the
 // calls it received.
 type fakeAccountFetcher struct {
-	calls  []string
+	calls   []string
 	return_ Account
-	err    error
+	err     error
 }
 
 func (f *fakeAccountFetcher) FetchAccount(_ context.Context, addr string) (*Account, error) {

--- a/internal/heimdall/tx/guard.go
+++ b/internal/heimdall/tx/guard.go
@@ -13,21 +13,21 @@ import "fmt"
 //
 // Wording is taken verbatim from HEIMDALLCAST_REQUIREMENTS.md §3.3.
 var L1MirroringMsgTypes = map[string]struct{}{
-	"MsgTopupTx":           {},
-	"MsgCheckpointAck":     {},
-	"MsgCpAck":             {},
-	"MsgCheckpointNoAck":   {},
-	"MsgCpNoAck":           {},
+	"MsgTopupTx":            {},
+	"MsgCheckpointAck":      {},
+	"MsgCpAck":              {},
+	"MsgCheckpointNoAck":    {},
+	"MsgCpNoAck":            {},
 	"MsgEventRecordRequest": {},
-	"MsgEventRecord":       {},
-	"MsgClerkRecord":       {},
-	"MsgValidatorJoin":     {},
-	"MsgStakeJoin":         {},
-	"MsgValidatorUpdate":   {},
-	"MsgStakeUpdate":       {},
-	"MsgSignerUpdate":      {},
-	"MsgValidatorExit":     {},
-	"MsgStakeExit":         {},
+	"MsgEventRecord":        {},
+	"MsgClerkRecord":        {},
+	"MsgValidatorJoin":      {},
+	"MsgStakeJoin":          {},
+	"MsgValidatorUpdate":    {},
+	"MsgStakeUpdate":        {},
+	"MsgSignerUpdate":       {},
+	"MsgValidatorExit":      {},
+	"MsgStakeExit":          {},
 }
 
 // RequireForce returns an error if msgType is an L1-mirroring type and

--- a/internal/heimdall/tx/guard_test.go
+++ b/internal/heimdall/tx/guard_test.go
@@ -65,11 +65,11 @@ func TestRequireForceAllowsSafeTypes(t *testing.T) {
 
 func TestShortMsgName(t *testing.T) {
 	cases := map[string]string{
-		"MsgTopupTx":                       "MsgTopupTx",
-		"/heimdallv2.topup.MsgTopupTx":     "MsgTopupTx",
-		"heimdallv2.topup.MsgTopupTx":      "MsgTopupTx",
-		"":                                  "",
-		"no/path":                           "path",
+		"MsgTopupTx":                   "MsgTopupTx",
+		"/heimdallv2.topup.MsgTopupTx": "MsgTopupTx",
+		"heimdallv2.topup.MsgTopupTx":  "MsgTopupTx",
+		"":                             "",
+		"no/path":                      "path",
 	}
 	for in, want := range cases {
 		if got := shortMsgName(in); got != want {

--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -96,14 +96,14 @@ type Config struct {
 	ERC721Address           string
 
 	// Mode-specific options
-	StoreDataSize       uint64
-	RecallLength        uint64
-	BlockBatchSize      uint64
+	StoreDataSize        uint64
+	RecallLength         uint64
+	BlockBatchSize       uint64
 	ContractAddress      string
 	ContractCallData     string
 	ContractCallDataFile string
 	ContractCallPayable  bool
-	BlobFeeCap          uint64
+	BlobFeeCap           uint64
 
 	// Account pool options
 	SendingAccountsCount      uint64

--- a/p2p/conns.go
+++ b/p2p/conns.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	ds "github.com/0xPolygon/polygon-cli/p2p/datastructures"
+	"github.com/0xPolygon/polygon-cli/util"
 )
 
 // BlockCache stores the actual block data to avoid duplicate fetches and database queries.
@@ -41,6 +42,10 @@ type ConnsOptions struct {
 	TxBroadcastQueueSize       int
 	MaxTxPacketSize            int
 	MaxQueuedTxs               int
+
+	// ValidatorSet, when non-nil, restricts block rebroadcasting to blocks
+	// whose recovered signer is a known validator.
+	ValidatorSet *ValidatorSet
 }
 
 // Conns manages a collection of active peer connections for transaction broadcasting.
@@ -82,6 +87,10 @@ type Conns struct {
 	maxTxPacketSize int
 	// maxQueuedTxs is the maximum number of transactions to queue for announcement
 	maxQueuedTxs int
+
+	// validators, when non-nil, is the validator set used to gate block
+	// rebroadcasting by signer.
+	validators *ValidatorSet
 
 	// metrics tracks broadcast-related Prometheus metrics
 	metrics *metrics
@@ -137,6 +146,7 @@ func NewConns(opts ConnsOptions) *Conns {
 		txBatchTimeout:             opts.TxBatchTimeout,
 		maxTxPacketSize:            opts.MaxTxPacketSize,
 		maxQueuedTxs:               opts.MaxQueuedTxs,
+		validators:                 opts.ValidatorSet,
 		metrics:                    newMetrics(),
 	}
 
@@ -502,6 +512,23 @@ func (c *Conns) BroadcastBlockHashes(hashes []common.Hash, numbers []uint64) int
 	}
 
 	return count
+}
+
+// IsKnownSigner reports whether the block header was signed by a known
+// validator. When signer validation is disabled (no signer set configured),
+// it returns true so all blocks are eligible for rebroadcast. A header whose
+// signature cannot be recovered is treated as unknown.
+func (c *Conns) IsKnownSigner(header *types.Header) bool {
+	if c.validators == nil {
+		return true
+	}
+
+	sig, err := util.Ecrecover(header)
+	if err != nil {
+		return false
+	}
+
+	return c.validators.IsAuthorized(common.BytesToAddress(sig))
 }
 
 // Nodes returns all currently connected peer nodes.

--- a/p2p/conns.go
+++ b/p2p/conns.go
@@ -46,6 +46,11 @@ type ConnsOptions struct {
 	// ValidatorSet, when non-nil, restricts block rebroadcasting to blocks
 	// whose recovered signer is a known validator.
 	ValidatorSet *ValidatorSet
+
+	// CacheOnlyValidatedBlocks, when true, keeps only validator-signed blocks
+	// in the serving cache. Unknown-signer blocks are still persisted to the
+	// database but their header/body are not cached or served to peers.
+	CacheOnlyValidatedBlocks bool
 }
 
 // Conns manages a collection of active peer connections for transaction broadcasting.
@@ -91,6 +96,10 @@ type Conns struct {
 	// validators, when non-nil, is the validator set used to gate block
 	// rebroadcasting by signer.
 	validators *ValidatorSet
+
+	// cacheOnlyValidated, when true, keeps only validator-signed blocks in the
+	// serving cache (unknown-signer blocks are recorded to the database only).
+	cacheOnlyValidated bool
 
 	// metrics tracks broadcast-related Prometheus metrics
 	metrics *metrics
@@ -147,6 +156,7 @@ func NewConns(opts ConnsOptions) *Conns {
 		maxTxPacketSize:            opts.MaxTxPacketSize,
 		maxQueuedTxs:               opts.MaxQueuedTxs,
 		validators:                 opts.ValidatorSet,
+		cacheOnlyValidated:         opts.CacheOnlyValidatedBlocks,
 		metrics:                    newMetrics(),
 	}
 
@@ -514,21 +524,40 @@ func (c *Conns) BroadcastBlockHashes(hashes []common.Hash, numbers []uint64) int
 	return count
 }
 
-// IsKnownSigner reports whether the block header was signed by a known
-// validator. When signer validation is disabled (no signer set configured),
-// it returns true so all blocks are eligible for rebroadcast. A header whose
-// signature cannot be recovered is treated as unknown.
-func (c *Conns) IsKnownSigner(header *types.Header) bool {
+// ValidatesSigners reports whether block signer validation is enabled (i.e. a
+// validator set is configured). When false, blocks are rebroadcast without
+// checking the signer.
+func (c *Conns) ValidatesSigners() bool {
+	return c.validators != nil
+}
+
+// ShouldCachePayload reports whether a block whose signer-known status is
+// `known` should have its header/body retained in the serving cache. When
+// cache-only-validated is disabled, all blocks are cached. When enabled, only
+// blocks with a known validator signer are cached; unknown-signer blocks are
+// recorded to the database only.
+func (c *Conns) ShouldCachePayload(known bool) bool {
+	return !c.cacheOnlyValidated || known
+}
+
+// RecoverSigner recovers the block signer from the header and reports whether
+// it is the signer of a known validator. When signer validation is disabled
+// (no validator set configured) it returns (zero address, true, nil) so all
+// blocks are eligible for rebroadcast. If the signature cannot be recovered it
+// returns (zero address, false, err). The recovered address is returned so
+// callers can log it when a block is not rebroadcast.
+func (c *Conns) RecoverSigner(header *types.Header) (common.Address, bool, error) {
 	if c.validators == nil {
-		return true
+		return common.Address{}, true, nil
 	}
 
 	sig, err := util.Ecrecover(header)
 	if err != nil {
-		return false
+		return common.Address{}, false, err
 	}
 
-	return c.validators.IsAuthorized(common.BytesToAddress(sig))
+	addr := common.BytesToAddress(sig)
+	return addr, c.validators.HasSigner(addr), nil
 }
 
 // Nodes returns all currently connected peer nodes.

--- a/p2p/database/json.go
+++ b/p2p/database/json.go
@@ -403,4 +403,3 @@ func (j *JSONDatabase) ShouldWritePeers() bool {
 func (j *JSONDatabase) NodeList(ctx context.Context, limit int) ([]string, error) {
 	return []string{}, nil
 }
-

--- a/p2p/database/nodb.go
+++ b/p2p/database/nodb.go
@@ -98,4 +98,3 @@ func (n *nodb) ShouldWritePeers() bool {
 func (n *nodb) NodeList(ctx context.Context, limit int) ([]string, error) {
 	return []string{}, nil
 }
-

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -964,53 +964,15 @@ func (c *conn) handleBlockHeaders(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.db.WriteBlockHeaders(ctx, headers, tfs, isParent)
 
-	// Cache and possibly rebroadcast each header. Recovering the signer once
-	// per header lets us both decide whether to retain the payload in the
-	// serving cache and whether to rebroadcast the announced hash.
+	// Cache each header and, for the announced header, perform the deferred
+	// signer-validated hash rebroadcast.
 	var head *types.Header
 	for i, header := range headers {
-		signer, known, rerr := c.conns.RecoverSigner(header)
-
-		// Only retain validator-signed headers in the serving cache (unless
-		// caching is unrestricted). Unknown-signer headers are still written to
-		// the database above.
-		if c.conns.ShouldCachePayload(known) {
-			c.conns.Blocks().Update(header.Hash(), func(cache BlockCache) BlockCache {
-				cache.Header = header
-				return cache
-			})
-		}
+		c.cacheAndAnnounceHeader(header, isParent, i == 0)
 
 		if head == nil || header.Number.Cmp(head.Number) > 0 {
 			head = header
 		}
-
-		// When signer validation is enabled, the announced hash rebroadcast was
-		// deferred until now so the fetched header could be validated first.
-		// Only the announced header (getBlockData uses Amount:1) is considered;
-		// parent fetches are not announcements. When validation is disabled,
-		// handleNewBlockHashes already rebroadcast the hash immediately.
-		if !c.conns.ValidatesSigners() || isParent || i != 0 {
-			continue
-		}
-
-		if known {
-			go c.conns.BroadcastBlockHashes(
-				[]common.Hash{header.Hash()},
-				[]uint64{header.Number.Uint64()},
-			)
-			continue
-		}
-
-		c.logger.Debug().
-			Str("hash", header.Hash().Hex()).
-			Uint64("number", header.Number.Uint64()).
-			Str("signer", signer.Hex()).
-			Str("peer_id", c.node.ID().String()).
-			Uint("eth_version", c.version).
-			Time("peer_connected_at", c.connectedAt).
-			AnErr("recover_err", rerr).
-			Msg("Skipping block hash rebroadcast, signer not in validator set")
 	}
 
 	if head != nil {
@@ -1021,6 +983,45 @@ func (c *conn) handleBlockHeaders(ctx context.Context, msg ethp2p.Msg) error {
 	}
 
 	return nil
+}
+
+// cacheAndAnnounceHeader recovers the signer of a fetched header and, when its
+// signer is a known validator (or caching is unrestricted), retains it in the
+// serving cache. For the announced header (not a parent fetch) it performs the
+// deferred hash rebroadcast when signer validation is enabled — rebroadcasting
+// validator-signed blocks and logging the rest. When validation is disabled the
+// hash was already rebroadcast in handleNewBlockHashes.
+func (c *conn) cacheAndAnnounceHeader(header *types.Header, isParent, announce bool) {
+	signer, known, rerr := c.conns.RecoverSigner(header)
+
+	if c.conns.ShouldCachePayload(known) {
+		c.conns.Blocks().Update(header.Hash(), func(cache BlockCache) BlockCache {
+			cache.Header = header
+			return cache
+		})
+	}
+
+	if !announce || isParent || !c.conns.ValidatesSigners() {
+		return
+	}
+
+	if known {
+		go c.conns.BroadcastBlockHashes(
+			[]common.Hash{header.Hash()},
+			[]uint64{header.Number.Uint64()},
+		)
+		return
+	}
+
+	c.logger.Debug().
+		Str("hash", header.Hash().Hex()).
+		Uint64("number", header.Number.Uint64()).
+		Str("signer", signer.Hex()).
+		Str("peer_id", c.node.ID().String()).
+		Uint("eth_version", c.version).
+		Time("peer_connected_at", c.connectedAt).
+		AnErr("recover_err", rerr).
+		Msg("Skipping block hash rebroadcast, signer not in validator set")
 }
 
 func (c *conn) handleGetBlockBodies(msg ethp2p.Msg) error {
@@ -1082,36 +1083,10 @@ func (c *conn) handleBlockBodies(ctx context.Context, msg ethp2p.Msg) error {
 		return nil
 	}
 
-	var decoded rawBlockBody
-	if err := rlp.DecodeBytes(packet.BlockBodiesRLPResponse[0], &decoded); err != nil {
-		c.logger.Warn().Err(err).Msg("Failed to decode block body")
-		return nil
-	}
-
-	txs := c.decodeTxs(decoded.Transactions)
-	txList, err := rlp.EncodeToRawList(txs)
+	body, err := c.buildBlockBody(packet.BlockBodiesRLPResponse[0])
 	if err != nil {
-		c.logger.Warn().Err(err).Msg("Failed to encode transactions")
+		c.logger.Warn().Err(err).Msg("Failed to build block body")
 		return nil
-	}
-	uncleList, err := rlp.EncodeToRawList(decoded.Uncles)
-	if err != nil {
-		c.logger.Warn().Err(err).Msg("Failed to encode uncles")
-		return nil
-	}
-	var withdrawalList *rlp.RawList[*types.Withdrawal]
-	if decoded.Withdrawals != nil {
-		wl, err := rlp.EncodeToRawList(decoded.Withdrawals)
-		if err != nil {
-			c.logger.Warn().Err(err).Msg("Failed to encode withdrawals")
-			return nil
-		}
-		withdrawalList = &wl
-	}
-	body := &eth.BlockBody{
-		Transactions: txList,
-		Uncles:       uncleList,
-		Withdrawals:  withdrawalList,
 	}
 
 	c.db.WriteBlockBody(ctx, body, hash, tfs)
@@ -1155,6 +1130,39 @@ func (c *conn) handleBlockBodies(ctx context.Context, msg ethp2p.Msg) error {
 	}
 
 	return nil
+}
+
+// buildBlockBody decodes a raw RLP block body and re-encodes it into an
+// eth.BlockBody of raw lists.
+func (c *conn) buildBlockBody(raw []byte) (*eth.BlockBody, error) {
+	var decoded rawBlockBody
+	if err := rlp.DecodeBytes(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("failed to decode block body: %w", err)
+	}
+
+	txList, err := rlp.EncodeToRawList(c.decodeTxs(decoded.Transactions))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode transactions: %w", err)
+	}
+	uncleList, err := rlp.EncodeToRawList(decoded.Uncles)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode uncles: %w", err)
+	}
+
+	var withdrawalList *rlp.RawList[*types.Withdrawal]
+	if decoded.Withdrawals != nil {
+		wl, err := rlp.EncodeToRawList(decoded.Withdrawals)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode withdrawals: %w", err)
+		}
+		withdrawalList = &wl
+	}
+
+	return &eth.BlockBody{
+		Transactions: txList,
+		Uncles:       uncleList,
+		Withdrawals:  withdrawalList,
+	}, nil
 }
 
 func (c *conn) handleNewBlock(ctx context.Context, msg ethp2p.Msg) error {
@@ -1211,37 +1219,13 @@ func (c *conn) handleNewBlock(ctx context.Context, msg ethp2p.Msg) error {
 	// retained in the serving cache nor rebroadcast.
 	signer, known, rerr := c.conns.RecoverSigner(packet.Block.Header())
 
-	if c.conns.ShouldCachePayload(known) {
-		// Create BlockBody with encoded RawLists
-		blockBody, encErr := encodeBlockBody(packet.Block)
-		if encErr != nil {
-			return fmt.Errorf("failed to encode block body: %w", encErr)
-		}
-
-		// Atomically check and add to cache to prevent duplicate writes from
-		// concurrent peers receiving the same block.
-		var exists bool
-		ok := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
-			if cache.TD != nil {
-				exists = true
-				return cache
-			}
-
-			return BlockCache{
-				Header: packet.Block.Header(),
-				Body:   blockBody,
-				TD:     packet.TD,
-			}
-		})
-
-		if exists {
-			return nil
-		}
-
-		// Write first-seen event for blocks arriving directly (not announced via hash first)
-		if !ok {
-			c.db.WriteBlockHashFirstSeen(ctx, c.node, hash, tfs)
-		}
+	cached, err := c.cacheFullBlock(ctx, packet, hash, known, tfs)
+	if err != nil {
+		return err
+	}
+	if cached {
+		// Already fully cached by a concurrent peer; nothing more to do.
+		return nil
 	}
 
 	c.db.WriteBlock(ctx, c.node, packet.Block, packet.TD, tfs)
@@ -1271,6 +1255,45 @@ func (c *conn) handleNewBlock(ctx context.Context, msg ethp2p.Msg) error {
 	)
 
 	return nil
+}
+
+// cacheFullBlock retains a full block in the serving cache when its signer is a
+// known validator (or caching is unrestricted). It returns cached=true if the
+// block was already fully cached (by a concurrent peer), so the caller can stop
+// early. Unknown-signer blocks are skipped here and recorded to the database by
+// the caller instead.
+func (c *conn) cacheFullBlock(ctx context.Context, packet *NewBlockPacket, hash common.Hash, known bool, tfs time.Time) (cached bool, err error) {
+	if !c.conns.ShouldCachePayload(known) {
+		return false, nil
+	}
+
+	blockBody, err := encodeBlockBody(packet.Block)
+	if err != nil {
+		return false, fmt.Errorf("failed to encode block body: %w", err)
+	}
+
+	// Atomically check and add to cache to prevent duplicate writes from
+	// concurrent peers receiving the same block.
+	existed := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
+		if cache.TD != nil {
+			cached = true
+			return cache
+		}
+		return BlockCache{
+			Header: packet.Block.Header(),
+			Body:   blockBody,
+			TD:     packet.TD,
+		}
+	})
+	if cached {
+		return true, nil
+	}
+
+	// Write first-seen event for blocks arriving directly (not announced via hash first).
+	if !existed {
+		c.db.WriteBlockHashFirstSeen(ctx, c.node, hash, tfs)
+	}
+	return false, nil
 }
 
 func (c *conn) handleGetPooledTransactions(msg ethp2p.Msg) error {

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -528,8 +528,10 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.countMsgReceived(packet.Name(), float64(len(packet)))
 
-	// Collect unique hashes for the database write.
+	// Collect unique hashes (and their numbers) for the database write and,
+	// when signer validation is disabled, for immediate rebroadcast.
 	uniqueHashes := make([]common.Hash, 0, len(packet))
+	uniqueNumbers := make([]uint64, 0, len(packet))
 
 	for _, entry := range packet {
 		hash := entry.Hash
@@ -545,16 +547,13 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 		// Mark as known from this peer
 		c.addKnownBlock(hash)
 
-		// Atomically check and add to cache to prevent duplicate writes from
-		// concurrent peers receiving the same block hash.
-		ok := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
-			if cache != (BlockCache{}) {
-				return cache
-			}
-			return BlockCache{}
+		// Atomically reserve the cache slot to prevent duplicate writes from
+		// concurrent peers receiving the same block hash. The value is left
+		// unchanged; we only care whether the entry already existed.
+		existed := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
+			return cache
 		})
-
-		if ok {
+		if existed {
 			continue
 		}
 
@@ -567,6 +566,7 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 		}
 
 		uniqueHashes = append(uniqueHashes, hash)
+		uniqueNumbers = append(uniqueNumbers, entry.Number)
 	}
 
 	// Write only unique hashes to the database.
@@ -576,9 +576,13 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.db.WriteBlockHashes(ctx, c.node, uniqueHashes, tfs)
 
-	// Rebroadcast of announced block hashes is deferred to handleBlockHeaders,
-	// where the fetched header lets us validate the block signer first. Body
-	// requests (getBlockData above) are intentionally not gated.
+	// When signer validation is enabled, defer the hash rebroadcast to
+	// handleBlockHeaders so the fetched header can be validated first. Body
+	// requests (getBlockData above) are intentionally not gated. When
+	// validation is disabled, rebroadcast the announced hashes immediately.
+	if !c.conns.ValidatesSigners() {
+		go c.conns.BroadcastBlockHashes(uniqueHashes, uniqueNumbers)
+	}
 
 	return nil
 }
@@ -960,17 +964,53 @@ func (c *conn) handleBlockHeaders(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.db.WriteBlockHeaders(ctx, headers, tfs, isParent)
 
-	// Update cache to store headers
+	// Cache and possibly rebroadcast each header. Recovering the signer once
+	// per header lets us both decide whether to retain the payload in the
+	// serving cache and whether to rebroadcast the announced hash.
 	var head *types.Header
-	for _, header := range headers {
-		c.conns.Blocks().Update(header.Hash(), func(cache BlockCache) BlockCache {
-			cache.Header = header
-			return cache
-		})
+	for i, header := range headers {
+		signer, known, rerr := c.conns.RecoverSigner(header)
+
+		// Only retain validator-signed headers in the serving cache (unless
+		// caching is unrestricted). Unknown-signer headers are still written to
+		// the database above.
+		if c.conns.ShouldCachePayload(known) {
+			c.conns.Blocks().Update(header.Hash(), func(cache BlockCache) BlockCache {
+				cache.Header = header
+				return cache
+			})
+		}
 
 		if head == nil || header.Number.Cmp(head.Number) > 0 {
 			head = header
 		}
+
+		// When signer validation is enabled, the announced hash rebroadcast was
+		// deferred until now so the fetched header could be validated first.
+		// Only the announced header (getBlockData uses Amount:1) is considered;
+		// parent fetches are not announcements. When validation is disabled,
+		// handleNewBlockHashes already rebroadcast the hash immediately.
+		if !c.conns.ValidatesSigners() || isParent || i != 0 {
+			continue
+		}
+
+		if known {
+			go c.conns.BroadcastBlockHashes(
+				[]common.Hash{header.Hash()},
+				[]uint64{header.Number.Uint64()},
+			)
+			continue
+		}
+
+		c.logger.Debug().
+			Str("hash", header.Hash().Hex()).
+			Uint64("number", header.Number.Uint64()).
+			Str("signer", signer.Hex()).
+			Str("peer_id", c.node.ID().String()).
+			Uint("eth_version", c.version).
+			Time("peer_connected_at", c.connectedAt).
+			AnErr("recover_err", rerr).
+			Msg("Skipping block hash rebroadcast, signer not in validator set")
 	}
 
 	if head != nil {
@@ -978,17 +1018,6 @@ func (c *conn) handleBlockHeaders(ctx context.Context, msg ethp2p.Msg) error {
 			Block: types.NewBlockWithHeader(head),
 			TD:    c.conns.HeadBlock().TD,
 		})
-	}
-
-	// Rebroadcast the announced block hash now that the header is available,
-	// but only if the block was signed by a known validator. Parent fetches
-	// are not announcements, so they are not rebroadcast. (getBlockData uses
-	// Amount:1, so each response is a single announced header.)
-	if !isParent && c.conns.IsKnownSigner(headers[0]) {
-		go c.conns.BroadcastBlockHashes(
-			[]common.Hash{headers[0].Hash()},
-			[]uint64{headers[0].Number.Uint64()},
-		)
 	}
 
 	return nil
@@ -1087,13 +1116,24 @@ func (c *conn) handleBlockBodies(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.db.WriteBlockBody(ctx, body, hash, tfs)
 
-	// Update cache and try to update head block if we now have complete block data.
+	// When cache-only-validated is enabled, only retain the body if we already
+	// hold a (validator-signed) header for this block. Unknown-signer blocks
+	// have no cached header, so their body is written to the database above but
+	// not cached or served. When disabled, cache the body unconditionally.
+	retainBody := true
+	if c.conns.cacheOnlyValidated {
+		cache, _ := c.conns.Blocks().Peek(hash)
+		retainBody = cache.Header != nil
+	}
+
 	var header *types.Header
-	c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
-		cache.Body = body
-		header = cache.Header
-		return cache
-	})
+	if retainBody {
+		c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
+			cache.Body = body
+			header = cache.Header
+			return cache
+		})
+	}
 
 	if header != nil {
 		// Decode RawLists back to slices for creating types.Block
@@ -1166,43 +1206,60 @@ func (c *conn) handleNewBlock(ctx context.Context, msg ethp2p.Msg) error {
 		return err
 	}
 
-	// Create BlockBody with encoded RawLists
-	blockBody, err := encodeBlockBody(packet.Block)
-	if err != nil {
-		return fmt.Errorf("failed to encode block body: %w", err)
-	}
+	// Recover the block signer up front. Unknown-signer blocks are recorded to
+	// the database below but, when cache-only-validated is enabled, are neither
+	// retained in the serving cache nor rebroadcast.
+	signer, known, rerr := c.conns.RecoverSigner(packet.Block.Header())
 
-	// Atomically check and add to cache to prevent duplicate writes from
-	// concurrent peers receiving the same block.
-	var exists bool
-	ok := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
-		if cache.TD != nil {
-			exists = true
-			return cache
+	if c.conns.ShouldCachePayload(known) {
+		// Create BlockBody with encoded RawLists
+		blockBody, encErr := encodeBlockBody(packet.Block)
+		if encErr != nil {
+			return fmt.Errorf("failed to encode block body: %w", encErr)
 		}
 
-		return BlockCache{
-			Header: packet.Block.Header(),
-			Body:   blockBody,
-			TD:     packet.TD,
+		// Atomically check and add to cache to prevent duplicate writes from
+		// concurrent peers receiving the same block.
+		var exists bool
+		ok := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
+			if cache.TD != nil {
+				exists = true
+				return cache
+			}
+
+			return BlockCache{
+				Header: packet.Block.Header(),
+				Body:   blockBody,
+				TD:     packet.TD,
+			}
+		})
+
+		if exists {
+			return nil
 		}
-	})
 
-	if exists {
-		return nil
-	}
-
-	// Write first-seen event for blocks arriving directly (not announced via hash first)
-	if !ok {
-		c.db.WriteBlockHashFirstSeen(ctx, c.node, hash, tfs)
+		// Write first-seen event for blocks arriving directly (not announced via hash first)
+		if !ok {
+			c.db.WriteBlockHashFirstSeen(ctx, c.node, hash, tfs)
+		}
 	}
 
 	c.db.WriteBlock(ctx, c.node, packet.Block, packet.TD, tfs)
 
 	// Only rebroadcast blocks signed by a known validator. Persistence above is
-	// unconditional; signer validation gates rebroadcast only.
-	if !c.conns.IsKnownSigner(packet.Block.Header()) {
-		c.logger.Debug().Str("hash", hash.Hex()).Msg("Skipping rebroadcast: unknown block signer")
+	// unconditional; signer validation gates rebroadcast (and caching) only.
+	if !known {
+		c.logger.Debug().
+			Str("hash", hash.Hex()).
+			Uint64("number", packet.Block.NumberU64()).
+			Str("signer", signer.Hex()).
+			Str("peer_id", c.node.ID().String()).
+			Uint("eth_version", c.version).
+			Str("td", packet.TD.String()).
+			Int("tx_count", len(packet.Block.Transactions())).
+			Time("peer_connected_at", c.connectedAt).
+			AnErr("recover_err", rerr).
+			Msg("Skipping full block rebroadcast, signer not in validator set")
 		return nil
 	}
 

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -547,26 +547,34 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 		// Mark as known from this peer
 		c.addKnownBlock(hash)
 
-		// Atomically reserve the cache slot to prevent duplicate writes from
-		// concurrent peers receiving the same block hash. The value is left
-		// unchanged; we only care whether the entry already existed.
-		existed := c.conns.Blocks().Update(hash, func(cache BlockCache) BlockCache {
-			return cache
-		})
-		if existed {
+		// Skip only if we already hold the complete block. A hash-only or
+		// partial cache entry must still (re-)fetch: other peers announcing the
+		// same hash give additional fetch attempts, so a single peer that never
+		// serves the header/body no longer strands the block as a hash-only
+		// marker.
+		cache, ok := c.conns.Blocks().Peek(hash)
+		if ok && cache.Header != nil && cache.Body != nil {
 			continue
 		}
 
-		// Write hash first seen time immediately for new blocks
-		c.db.WriteBlockHashFirstSeen(ctx, c.node, hash, tfs)
-
-		// Request only the parts we don't have
-		if err := c.getBlockData(hash, BlockCache{}, false); err != nil {
-			return err
+		// Reserve the cache slot atomically. existed marks first-seen so the
+		// hash-first-seen event and block-event write happen exactly once, even
+		// across re-announcements from multiple peers.
+		existed := c.conns.Blocks().Update(hash, func(v BlockCache) BlockCache {
+			return v
+		})
+		if !existed {
+			// Write hash first seen time immediately for new blocks.
+			c.db.WriteBlockHashFirstSeen(ctx, c.node, hash, tfs)
+			uniqueHashes = append(uniqueHashes, hash)
+			uniqueNumbers = append(uniqueNumbers, entry.Number)
 		}
 
-		uniqueHashes = append(uniqueHashes, hash)
-		uniqueNumbers = append(uniqueNumbers, entry.Number)
+		// Request only the parts we don't have yet (getBlockData inspects the
+		// cache entry and asks for the missing header and/or body).
+		if err := c.getBlockData(hash, cache, false); err != nil {
+			return err
+		}
 	}
 
 	// Write only unique hashes to the database.

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -528,9 +528,8 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.countMsgReceived(packet.Name(), float64(len(packet)))
 
-	// Collect unique hashes and numbers for database write and broadcasting.
+	// Collect unique hashes for the database write.
 	uniqueHashes := make([]common.Hash, 0, len(packet))
-	uniqueNumbers := make([]uint64, 0, len(packet))
 
 	for _, entry := range packet {
 		hash := entry.Hash
@@ -568,7 +567,6 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 		}
 
 		uniqueHashes = append(uniqueHashes, hash)
-		uniqueNumbers = append(uniqueNumbers, entry.Number)
 	}
 
 	// Write only unique hashes to the database.
@@ -578,8 +576,9 @@ func (c *conn) handleNewBlockHashes(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.db.WriteBlockHashes(ctx, c.node, uniqueHashes, tfs)
 
-	// Broadcast block hashes to other peers asynchronously
-	go c.conns.BroadcastBlockHashes(uniqueHashes, uniqueNumbers)
+	// Rebroadcast of announced block hashes is deferred to handleBlockHeaders,
+	// where the fetched header lets us validate the block signer first. Body
+	// requests (getBlockData above) are intentionally not gated.
 
 	return nil
 }
@@ -981,6 +980,17 @@ func (c *conn) handleBlockHeaders(ctx context.Context, msg ethp2p.Msg) error {
 		})
 	}
 
+	// Rebroadcast the announced block hash now that the header is available,
+	// but only if the block was signed by a known validator. Parent fetches
+	// are not announcements, so they are not rebroadcast. (getBlockData uses
+	// Amount:1, so each response is a single announced header.)
+	if !isParent && c.conns.IsKnownSigner(headers[0]) {
+		go c.conns.BroadcastBlockHashes(
+			[]common.Hash{headers[0].Hash()},
+			[]uint64{headers[0].Number.Uint64()},
+		)
+	}
+
 	return nil
 }
 
@@ -1188,6 +1198,13 @@ func (c *conn) handleNewBlock(ctx context.Context, msg ethp2p.Msg) error {
 	}
 
 	c.db.WriteBlock(ctx, c.node, packet.Block, packet.TD, tfs)
+
+	// Only rebroadcast blocks signed by a known validator. Persistence above is
+	// unconditional; signer validation gates rebroadcast only.
+	if !c.conns.IsKnownSigner(packet.Block.Header()) {
+		c.logger.Debug().Str("hash", hash.Hex()).Msg("Skipping rebroadcast: unknown block signer")
+		return nil
+	}
 
 	// Broadcast block or block hash to other peers asynchronously
 	go c.conns.BroadcastBlock(packet.Block, packet.TD)

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -999,6 +999,11 @@ func (c *conn) cacheAndAnnounceHeader(header *types.Header, isParent, announce b
 			cache.Header = header
 			return cache
 		})
+	} else {
+		// Unknown-signer block under cache-only-validated: drop the entry so any
+		// body cached provisionally (before this header arrived) is evicted and
+		// never served. The block is still recorded to the database elsewhere.
+		c.conns.Blocks().Remove(header.Hash())
 	}
 
 	if !announce || isParent || !c.conns.ValidatesSigners() {
@@ -1032,10 +1037,12 @@ func (c *conn) handleGetBlockBodies(msg ethp2p.Msg) error {
 
 	c.countMsgReceived(request.Name(), float64(len(request.GetBlockBodiesRequest)))
 
-	// Try to serve from cache
+	// Try to serve from cache. Require the header to be cached too: we only
+	// cache validated headers, so this ensures we never serve a body that is
+	// only held provisionally (its signer not yet validated).
 	var bodies []*eth.BlockBody
 	for _, hash := range request.GetBlockBodiesRequest {
-		if cache, ok := c.conns.Blocks().Peek(hash); ok && cache.Body != nil {
+		if cache, ok := c.conns.Blocks().Peek(hash); ok && cache.Header != nil && cache.Body != nil {
 			bodies = append(bodies, cache.Body)
 		}
 	}
@@ -1091,14 +1098,18 @@ func (c *conn) handleBlockBodies(ctx context.Context, msg ethp2p.Msg) error {
 
 	c.db.WriteBlockBody(ctx, body, hash, tfs)
 
-	// When cache-only-validated is enabled, only retain the body if we already
-	// hold a (validator-signed) header for this block. Unknown-signer blocks
-	// have no cached header, so their body is written to the database above but
-	// not cached or served. When disabled, cache the body unconditionally.
+	// When cache-only-validated is enabled, only retain the body if the block
+	// already has a cache entry (the announcement marker, or a cached header).
+	// The header and body responses can arrive in any order, so we do NOT gate
+	// on the header being present yet: a body that arrives first is held
+	// provisionally and completed once the validated header arrives. If the
+	// header turns out to be from an unknown signer, cacheAndAnnounceHeader
+	// evicts the entry, and a provisional body is never served before its header
+	// is cached (see handleGetBlockBodies). When disabled, cache the body
+	// unconditionally. The body is written to the database above regardless.
 	retainBody := true
 	if c.conns.cacheOnlyValidated {
-		cache, _ := c.conns.Blocks().Peek(hash)
-		retainBody = cache.Header != nil
+		_, retainBody = c.conns.Blocks().Peek(hash)
 	}
 
 	var header *types.Header

--- a/p2p/protocol_test.go
+++ b/p2p/protocol_test.go
@@ -1,0 +1,278 @@
+package p2p
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	ethp2p "github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/rs/zerolog"
+
+	"github.com/0xPolygon/polygon-cli/p2p/database"
+	ds "github.com/0xPolygon/polygon-cli/p2p/datastructures"
+)
+
+// recordRW is a minimal ethp2p.MsgReadWriter that records written messages
+// (code + payload), so tests can assert which requests/responses a handler sent.
+type recordRW struct {
+	codes    []uint64
+	payloads [][]byte
+}
+
+func (r *recordRW) ReadMsg() (ethp2p.Msg, error) { return ethp2p.Msg{}, io.EOF }
+
+func (r *recordRW) WriteMsg(m ethp2p.Msg) error {
+	var buf []byte
+	if m.Payload != nil {
+		buf, _ = io.ReadAll(m.Payload)
+	}
+	r.codes = append(r.codes, m.Code)
+	r.payloads = append(r.payloads, buf)
+	return nil
+}
+
+func (r *recordRW) reset() {
+	r.codes = nil
+	r.payloads = nil
+}
+
+// encodeMsg RLP-encodes val and wraps it in an ethp2p.Msg with the given code.
+func encodeMsg(t *testing.T, code uint64, val any) ethp2p.Msg {
+	t.Helper()
+	enc, err := rlp.EncodeToBytes(val)
+	if err != nil {
+		t.Fatalf("encode msg (code %d): %v", code, err)
+	}
+	return ethp2p.Msg{Code: code, Size: uint32(len(enc)), Payload: bytes.NewReader(enc)}
+}
+
+func makeAnnounce(t *testing.T, hash common.Hash, number uint64) ethp2p.Msg {
+	t.Helper()
+	return encodeMsg(t, eth.NewBlockHashesMsg, NewBlockHashesPacket{{Hash: hash, Number: number}})
+}
+
+// makeBodies builds a BlockBodies response for one (empty) body under the given
+// request id.
+func makeBodies(t *testing.T, reqID uint64) ethp2p.Msg {
+	t.Helper()
+	bodyRLP, err := rlp.EncodeToBytes(rawBlockBody{})
+	if err != nil {
+		t.Fatalf("encode body: %v", err)
+	}
+	return encodeMsg(t, eth.BlockBodiesMsg, &eth.BlockBodiesRLPPacket{
+		RequestId:              reqID,
+		BlockBodiesRLPResponse: eth.BlockBodiesRLPResponse{rlp.RawValue(bodyRLP)},
+	})
+}
+
+// newTestConn builds a minimal conn wired to a recording MsgReadWriter, a no-op
+// database, and the given connection manager, sufficient to drive the block
+// message handlers in unit tests.
+func newTestConn(rw ethp2p.MsgReadWriter, conns *Conns) *conn {
+	return &conn{
+		sensorID:    "test",
+		logger:      zerolog.Nop(),
+		rw:          rw,
+		db:          database.NoDatabase(),
+		requests:    ds.NewLRU[uint64, common.Hash](ds.LRUOptions{MaxSize: 1024}),
+		parents:     ds.NewLRU[common.Hash, struct{}](ds.LRUOptions{MaxSize: 1024}),
+		conns:       conns,
+		messages:    NewPeerMessages(),
+		latestBlock: &ds.Locked[latestBlock]{},
+		version:     68,
+	}
+}
+
+// sharedTestConns returns a single Conns for the whole test binary. NewConns
+// registers Prometheus collectors on the default registry, so it can only be
+// called once per process; tests set cacheOnlyValidated directly and use
+// distinct block hashes to stay independent.
+var (
+	testConnsOnce sync.Once
+	testConns     *Conns
+)
+
+func sharedTestConns(t *testing.T, cacheOnlyValidated bool) *Conns {
+	t.Helper()
+	testConnsOnce.Do(func() {
+		testConns = NewConns(ConnsOptions{
+			Head:        NewBlockPacket{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)}), TD: big.NewInt(1)},
+			BlocksCache: ds.LRUOptions{MaxSize: 1024},
+		})
+	})
+	testConns.cacheOnlyValidated = cacheOnlyValidated
+	return testConns
+}
+
+// TestHandleNewBlockHashesRefetch verifies that an announced hash is (re-)fetched
+// until we hold the full block: the first announcer triggers a fetch, later
+// announcers still fetch while the block is incomplete, and once the full block
+// is cached further announcements do not fetch.
+func TestHandleNewBlockHashesRefetch(t *testing.T) {
+	rw := &recordRW{}
+	conns := sharedTestConns(t, false)
+	c := newTestConn(rw, conns)
+
+	ctx := context.Background()
+	hash := common.HexToHash("0xabc123")
+
+	// 1. First announcement of an unknown hash -> fetch header + body.
+	if err := c.handleNewBlockHashes(ctx, makeAnnounce(t, hash, 100)); err != nil {
+		t.Fatalf("first announce: %v", err)
+	}
+	if got := len(rw.codes); got != 2 {
+		t.Fatalf("first announce: want 2 requests (headers+bodies), got %d %v", got, rw.codes)
+	}
+	assertContains(t, rw.codes, eth.GetBlockHeadersMsg, eth.GetBlockBodiesMsg)
+
+	// 2. Re-announcement (e.g. from another peer) while the block is still only a
+	//    hash marker -> fetch AGAIN. This is the fix: previously the marker caused
+	//    an unconditional skip, stranding the block if the first peer never served it.
+	rw.reset()
+	if err := c.handleNewBlockHashes(ctx, makeAnnounce(t, hash, 100)); err != nil {
+		t.Fatalf("re-announce (incomplete): %v", err)
+	}
+	if got := len(rw.codes); got != 2 {
+		t.Fatalf("re-announce while incomplete: want 2 re-fetch requests, got %d %v", got, rw.codes)
+	}
+
+	// 3. Once the full block is cached, a re-announcement must NOT fetch.
+	conns.Blocks().Update(hash, func(bc BlockCache) BlockCache {
+		bc.Header = &types.Header{Number: big.NewInt(100)}
+		bc.Body = &eth.BlockBody{}
+		bc.TD = big.NewInt(1)
+		return bc
+	})
+	rw.reset()
+	if err := c.handleNewBlockHashes(ctx, makeAnnounce(t, hash, 100)); err != nil {
+		t.Fatalf("re-announce (complete): %v", err)
+	}
+	if got := len(rw.codes); got != 0 {
+		t.Fatalf("re-announce with full block cached: want 0 requests, got %d %v", got, rw.codes)
+	}
+}
+
+// TestHandleBlockBodiesRetainsBodyBeforeHeader is a regression test for the
+// body-before-header race under cache-only-validated-blocks: the body response
+// can arrive before the header response. Previously the body was retained only
+// if a header was already cached, so a body-first response was dropped and the
+// entry stayed header-only even for a valid block (unservable on GetBlockBodies).
+// Now the body is retained whenever the block already has a cache entry (the
+// announcement marker), and completed when the header later arrives.
+func TestHandleBlockBodiesRetainsBodyBeforeHeader(t *testing.T) {
+	rw := &recordRW{}
+	conns := sharedTestConns(t, true) // cache-only-validated enabled
+	c := newTestConn(rw, conns)
+
+	ctx := context.Background()
+	hash := common.HexToHash("0xdef456")
+
+	// The announcement created a hash-only marker; the header has NOT arrived yet.
+	conns.Blocks().Update(hash, func(bc BlockCache) BlockCache { return bc })
+	const reqID = 7
+	c.requests.Add(reqID, hash)
+
+	// Body response arrives before the header.
+	if err := c.handleBlockBodies(ctx, makeBodies(t, reqID)); err != nil {
+		t.Fatalf("handleBlockBodies: %v", err)
+	}
+
+	cache, ok := conns.Blocks().Peek(hash)
+	if !ok {
+		t.Fatal("cache entry vanished")
+	}
+	if cache.Body == nil {
+		t.Fatal("body was dropped when it arrived before the header (regression)")
+	}
+	if cache.Header != nil {
+		t.Fatal("header should still be absent at this point")
+	}
+}
+
+// makeGetBodies builds a GetBlockBodies request for the given hashes.
+func makeGetBodies(t *testing.T, reqID uint64, hashes ...common.Hash) ethp2p.Msg {
+	t.Helper()
+	return encodeMsg(t, eth.GetBlockBodiesMsg, &eth.GetBlockBodiesPacket{
+		RequestId:             reqID,
+		GetBlockBodiesRequest: eth.GetBlockBodiesRequest(hashes),
+	})
+}
+
+// servedBodies decodes the BlockBodies response the handler sent and returns the
+// number of bodies it served.
+func servedBodies(t *testing.T, rw *recordRW) int {
+	t.Helper()
+	for i, code := range rw.codes {
+		if code != eth.BlockBodiesMsg {
+			continue
+		}
+		var pkt eth.BlockBodiesRLPPacket
+		if err := rlp.DecodeBytes(rw.payloads[i], &pkt); err != nil {
+			t.Fatalf("decode block bodies response: %v", err)
+		}
+		return len(pkt.BlockBodiesRLPResponse)
+	}
+	t.Fatal("no BlockBodies response was sent")
+	return 0
+}
+
+// TestHandleGetBlockBodiesServesOnlyComplete verifies the serve-gate half of the
+// reorder fix: a body is served to peers only when its (validated) header is also
+// cached. A provisional body-only entry must not be served.
+func TestHandleGetBlockBodiesServesOnlyComplete(t *testing.T) {
+	rw := &recordRW{}
+	conns := sharedTestConns(t, true)
+	c := newTestConn(rw, conns)
+
+	// An empty body built the same way the body handler would, so it encodes
+	// cleanly on the serve path.
+	emptyRawBody, err := rlp.EncodeToBytes(rawBlockBody{})
+	if err != nil {
+		t.Fatalf("encode raw body: %v", err)
+	}
+	body, err := c.buildBlockBody(emptyRawBody)
+	if err != nil {
+		t.Fatalf("build body: %v", err)
+	}
+
+	// Provisional: body present but no header -> must NOT be served.
+	bodyOnly := common.HexToHash("0x1111")
+	conns.Blocks().Update(bodyOnly, func(bc BlockCache) BlockCache {
+		bc.Body = body
+		return bc
+	})
+	// Complete: header + body -> must be served.
+	complete := common.HexToHash("0x2222")
+	conns.Blocks().Update(complete, func(bc BlockCache) BlockCache {
+		bc.Header = &types.Header{Number: big.NewInt(5)}
+		bc.Body = body
+		return bc
+	})
+
+	if err := c.handleGetBlockBodies(makeGetBodies(t, 1, bodyOnly, complete)); err != nil {
+		t.Fatalf("handleGetBlockBodies: %v", err)
+	}
+	if n := servedBodies(t, rw); n != 1 {
+		t.Fatalf("want 1 served body (only the complete block), got %d", n)
+	}
+}
+
+func assertContains(t *testing.T, codes []uint64, want ...uint64) {
+	t.Helper()
+	set := make(map[uint64]bool, len(codes))
+	for _, c := range codes {
+		set[c] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			t.Errorf("want a message with code %d in %v", w, codes)
+		}
+	}
+}

--- a/p2p/validators.go
+++ b/p2p/validators.go
@@ -106,8 +106,8 @@ func (v *ValidatorSet) refreshLoop(ctx context.Context) {
 	}
 }
 
-// IsAuthorized reports whether addr is the signer address of a known validator.
-func (v *ValidatorSet) IsAuthorized(addr common.Address) bool {
+// HasSigner reports whether addr is the signer address of a known validator.
+func (v *ValidatorSet) HasSigner(addr common.Address) bool {
 	signers := v.signers.Get()
 	_, ok := signers[addr]
 	return ok

--- a/p2p/validators.go
+++ b/p2p/validators.go
@@ -1,0 +1,114 @@
+package p2p
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rs/zerolog/log"
+
+	"github.com/0xPolygon/polygon-cli/internal/heimdall/client"
+	ds "github.com/0xPolygon/polygon-cli/p2p/datastructures"
+)
+
+// validatorSetResponse is the subset of GET /stake/validators-set we need.
+type validatorSetResponse struct {
+	ValidatorSet struct {
+		Validators []struct {
+			Signer string `json:"signer"`
+		} `json:"validators"`
+	} `json:"validator_set"`
+}
+
+// ValidatorSet maintains the set of authorized block signers by periodically
+// fetching the Heimdall validator set. It is used to decide whether a received
+// block should be rebroadcast to peers.
+type ValidatorSet struct {
+	rest    *client.RESTClient
+	refresh time.Duration
+	signers ds.Locked[map[common.Address]struct{}]
+}
+
+// NewValidatorSet creates a ValidatorSet that fetches the validator set from
+// the Heimdall REST gateway at restURL, refreshing every refresh interval.
+func NewValidatorSet(restURL string, refresh time.Duration) *ValidatorSet {
+	return &ValidatorSet{
+		rest:    client.NewRESTClient(restURL, 30*time.Second, nil, false),
+		refresh: refresh,
+	}
+}
+
+// fetch retrieves the current validator set from Heimdall and returns the set
+// of authorized signer addresses. It fails if no validators are parsed so we
+// never operate on an empty/partial set.
+func (v *ValidatorSet) fetch(ctx context.Context) (map[common.Address]struct{}, error) {
+	body, _, err := v.rest.Get(ctx, "/stake/validators-set", nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching validator set: %w", err)
+	}
+
+	var resp validatorSetResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decoding validator set: %w", err)
+	}
+
+	signers := make(map[common.Address]struct{}, len(resp.ValidatorSet.Validators))
+	for _, val := range resp.ValidatorSet.Validators {
+		if val.Signer == "" {
+			continue
+		}
+		signers[common.HexToAddress(val.Signer)] = struct{}{}
+	}
+	if len(signers) == 0 {
+		return nil, fmt.Errorf("validator set contained no signers")
+	}
+
+	return signers, nil
+}
+
+// Start performs a blocking initial fetch of the validator set and then
+// launches a background goroutine that refreshes it on the configured
+// interval until ctx is cancelled. It returns an error if the initial fetch
+// fails so the caller can abort startup rather than serve with no validators.
+func (v *ValidatorSet) Start(ctx context.Context) error {
+	signers, err := v.fetch(ctx)
+	if err != nil {
+		return err
+	}
+	v.signers.Set(signers)
+	log.Info().Int("validators", len(signers)).Msg("Loaded validator set")
+
+	go v.refreshLoop(ctx)
+	return nil
+}
+
+// refreshLoop periodically refreshes the validator set. On a fetch error it
+// logs a warning and keeps the previous set rather than wiping it.
+func (v *ValidatorSet) refreshLoop(ctx context.Context) {
+	ticker := time.NewTicker(v.refresh)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			signers, err := v.fetch(ctx)
+			if err != nil {
+				log.Warn().Err(err).Msg("Failed to refresh validator set, keeping previous set")
+				continue
+			}
+			v.signers.Set(signers)
+			log.Debug().Int("validators", len(signers)).Msg("Refreshed validator set")
+		}
+	}
+}
+
+// IsAuthorized reports whether addr is the signer address of a known validator.
+func (v *ValidatorSet) IsAuthorized(addr common.Address) bool {
+	signers := v.signers.Get()
+	_, ok := signers[addr]
+	return ok
+}

--- a/p2p/validators_test.go
+++ b/p2p/validators_test.go
@@ -1,0 +1,172 @@
+package p2p
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/clique"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+const validatorSetFixture = "../internal/heimdall/client/testdata/rest/stake_validators_set.json"
+
+// knownSigner is the first signer in the validator-set fixture.
+var knownSigner = common.HexToAddress("0x02f615e95563ef16f10354dba9e584e58d2d4314")
+
+// readFixture reads the validator-set fixture, failing the test if it cannot.
+func readFixture(t *testing.T) []byte {
+	t.Helper()
+	body, err := os.ReadFile(validatorSetFixture)
+	if err != nil {
+		t.Fatalf("reading fixture: %v", err)
+	}
+	return body
+}
+
+// newFixtureServer serves the given body for /stake/validators-set.
+func newFixtureServer(t *testing.T, status int, body []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/stake/validators-set" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestValidatorSetStartAndHasSigner(t *testing.T) {
+	srv := newFixtureServer(t, http.StatusOK, readFixture(t))
+
+	s := NewValidatorSet(srv.URL, time.Hour)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if !s.HasSigner(knownSigner) {
+		t.Errorf("expected %s to be a known signer", knownSigner)
+	}
+	if s.HasSigner(common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")) {
+		t.Errorf("expected an unknown address to be rejected")
+	}
+}
+
+func TestValidatorSetStartEmptyFails(t *testing.T) {
+	srv := newFixtureServer(t, http.StatusOK, []byte(`{"validator_set":{"validators":[]}}`))
+	if err := NewValidatorSet(srv.URL, time.Hour).Start(context.Background()); err == nil {
+		t.Fatal("expected error when the validator set has no signers")
+	}
+}
+
+func TestValidatorSetStartBadStatusFails(t *testing.T) {
+	srv := newFixtureServer(t, http.StatusInternalServerError, []byte(`{}`))
+	if err := NewValidatorSet(srv.URL, time.Hour).Start(context.Background()); err == nil {
+		t.Fatal("expected error on a non-2xx status")
+	}
+}
+
+func TestValidatorSetRefreshKeepsPreviousSetOnError(t *testing.T) {
+	good := readFixture(t)
+
+	// First request succeeds, later requests fail.
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			_, _ = w.Write(good)
+			return
+		}
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	s := NewValidatorSet(srv.URL, time.Hour)
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// A failed refresh must not wipe the previously loaded set.
+	if _, ferr := s.fetch(context.Background()); ferr == nil {
+		t.Fatal("expected the refresh fetch to fail")
+	}
+	if !s.HasSigner(knownSigner) {
+		t.Error("expected the previous signer set to be retained after a failed refresh")
+	}
+}
+
+func TestValidatorSetRefreshLoopExitsOnCancel(t *testing.T) {
+	srv := newFixtureServer(t, http.StatusOK, readFixture(t))
+
+	s := NewValidatorSet(srv.URL, time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.refreshLoop(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("refreshLoop did not exit on context cancellation")
+	}
+}
+
+func TestConnsRecoverSigner(t *testing.T) {
+	// nil validator set => validation disabled: everything is "known".
+	if _, known, err := (&Conns{}).RecoverSigner(&types.Header{}); !known || err != nil {
+		t.Errorf("nil validator set: want known=true err=nil, got known=%v err=%v", known, err)
+	}
+
+	// Build a header signed by a generated key.
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	signer := crypto.PubkeyToAddress(priv.PublicKey)
+	header := &types.Header{
+		Number:     big.NewInt(1),
+		Difficulty: big.NewInt(1),
+		Extra:      make([]byte, crypto.SignatureLength),
+	}
+	sig, err := crypto.Sign(clique.SealHash(header).Bytes(), priv)
+	if err != nil {
+		t.Fatalf("signing header: %v", err)
+	}
+	copy(header.Extra[len(header.Extra)-crypto.SignatureLength:], sig)
+
+	// Signer in the set => known, and the recovered address is returned.
+	inSet := &Conns{validators: &ValidatorSet{}}
+	inSet.validators.signers.Set(map[common.Address]struct{}{signer: {}})
+	if addr, known, err := inSet.RecoverSigner(header); !known || err != nil || addr != signer {
+		t.Errorf("known signer: want known=true err=nil addr=%s, got known=%v err=%v addr=%s", signer, known, err, addr)
+	}
+
+	// Signer not in the set => not known, but the address is still recovered.
+	notInSet := &Conns{validators: &ValidatorSet{}}
+	notInSet.validators.signers.Set(map[common.Address]struct{}{
+		common.HexToAddress("0x1111111111111111111111111111111111111111"): {},
+	})
+	if addr, known, err := notInSet.RecoverSigner(header); known || err != nil || addr != signer {
+		t.Errorf("unknown signer: want known=false err=nil addr=%s, got known=%v err=%v addr=%s", signer, known, err, addr)
+	}
+
+	// Header with no recoverable signature => not known, with an error.
+	if _, known, err := notInSet.RecoverSigner(&types.Header{}); known || err == nil {
+		t.Errorf("unrecoverable header: want known=false err!=nil, got known=%v err=%v", known, err)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -39,8 +39,9 @@ type (
 	}
 )
 
-func Ecrecover(block *types.Block) ([]byte, error) {
-	header := block.Header()
+// Ecrecover recovers the signer address from a block header's seal
+// (the last SignatureLength bytes of Extra) using the clique seal hash.
+func Ecrecover(header *types.Header) ([]byte, error) {
 	sigStart := len(header.Extra) - crypto.SignatureLength
 	if sigStart < 0 || sigStart > len(header.Extra) {
 		return nil, fmt.Errorf("unable to recover signature")


### PR DESCRIPTION
# Description

When block rebroadcasting is enabled, the sensor now only rebroadcasts blocks whose recovered signer is in the current Heimdall validator set. Blocks from unknown signers are still persisted and their bodies are still requested; they are simply not propagated to peers.

- Add `ValidatorSet` (p2p/validators.go): fetches `/stake/validators-set` from Heimdall, blocking initial load + periodic refresh, IsAuthorized.
- Add `Conns.IsKnownSigner` to gate rebroadcast by recovered signer.
- Gate `handleNewBlock`; defer block-hash rebroadcast from `handleNewBlockHashes` to `handleBlockHeaders` so the fetched header can be validated first (body requests stay ungated).
- Consolidate `util.Ecrecover` to take `*types.Header`.
- Add `--heimdall-url` and `--validator-set-refresh` sensor flags.

## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [x] 👀
- [x] Deployed Amoy
- [x] Deployed Mainnet
