### PR TITLE
ci: build and publish macOS release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,44 @@ jobs:
           file_glob: true
           file: out/*.tar.gz
           overwrite: true
+
+  macos-release:
+    # A CGO-only dependency (vectorized-poseidon-gold) prevents cross-compiling
+    # darwin binaries from linux, so each architecture is built natively on its
+    # own macOS runner: macos-13 (Intel/amd64) and macos-14 (Apple Silicon/arm64).
+    strategy:
+      matrix:
+        runner:
+          - macos-13
+          - macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Install go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Perform darwin build
+        run: make cross-darwin
+
+      - name: Compress binary
+        run: |
+          cd out
+          arch=$(go env GOARCH)
+          tar czf polycli_${GITHUB_REF#refs/tags/}_darwin_${arch}.tar.gz polycli_${GITHUB_REF#refs/tags/}_darwin_${arch}
+
+      - name: Get git tag
+        run: echo "tag=$(git describe --tags --exact-match HEAD)" >> $GITHUB_ENV
+
+      - name: Publish binaries
+        uses: svenstaro/upload-release-action@b98a3b12e86552593f3e4e577ca8a62aa2f3f22b # 2.11.4
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.tag }}
+          release_name: ${{ env.tag }}
+          file_glob: true
+          file: out/*.tar.gz
+          overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,20 @@ cross: $(BUILD_DIR) ## Cross-compile go binaries using CGO.
 			-o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_amd64 \
 			main.go
 
+.PHONY: cross-darwin
+cross-darwin: $(BUILD_DIR) ## Build a darwin release binary for the host architecture (requires CGO, must run on macOS).
+# Notes:
+# - A transitive dependency (vectorized-poseidon-gold) is CGO-only, so darwin
+#   binaries cannot be cross-compiled from linux and must be built natively on a
+#   macOS runner (one per architecture: amd64 on Intel, arm64 on Apple Silicon).
+# - Unlike the linux builds, darwin does not support fully static libc binaries,
+#   so the static external linking flags are omitted here.
+	echo "Building $(BIN_NAME)_$(GIT_TAG)_darwin_$$(go env GOARCH)..."
+	CGO_ENABLED=1 GOOS=darwin go build \
+			-ldflags '$(VERSION_FLAGS) -s -w' \
+			-o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_darwin_$$(go env GOARCH) \
+			main.go
+
 .PHONY: simplecross
 simplecross: $(BUILD_DIR) ## Cross-compile go binaries without using CGO.
 	GOOS=linux  GOARCH=arm64 go build -o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_arm64  main.go


### PR DESCRIPTION
## Summary

Adds macOS binaries to the release, matching the existing Linux ones.

- New `cross-darwin` Makefile target builds a darwin binary for the host arch with the same version ldflags as the Linux builds (CGO enabled; static-linking flags dropped since macOS doesn't support them).
- New `macos-release` workflow job builds natively on a matrix of `macos-13` (Intel → `darwin/amd64`) and `macos-14` (Apple Silicon → `darwin/arm64`), then tars and uploads to the same release.

Why native per-arch instead of cross-compiling from the Linux runner: the transitive `vectorized-poseidon-gold` dependency is CGO-only with no pure-Go fallback, so darwin can't be cross-compiled from Linux and each arch is built on its own runner.

Note: binaries are unsigned/un-notarized, same as the Linux ones.

Made with [Cursor](https://cursor.com)