### PR TITLE
fix(docker): install arm64 target libc headers for the cross build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,15 @@ ARG TARGETARCH
 
 WORKDIR /src
 
-# make reuses the Makefile's version stamping; gcc-aarch64-linux-gnu is the same
-# cross compiler the release workflow (make cross) uses for arm64. amd64 uses the
-# native gcc already in the golang image. NOTE: because vectorized-poseidon-gold
-# compiles the amd64 path with -march=native, the amd64 image must be built on an
-# amd64 host (true on the ubuntu-latest CI runner); arm64 cross-compiles cleanly.
+# make reuses the Makefile's version stamping; gcc-aarch64-linux-gnu +
+# libc6-dev-arm64-cross are the cross compiler and target libc headers for the
+# arm64 CGO build (the slim golang image, unlike the release runner, ships
+# neither). amd64 uses the native gcc already in the golang image. NOTE: because
+# vectorized-poseidon-gold compiles the amd64 path with -march=native, the amd64
+# image must be built on an amd64 host (true on the ubuntu-latest CI runner);
+# arm64 cross-compiles cleanly.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends make gcc-aarch64-linux-gnu \
+  && apt-get install -y --no-install-recommends make gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
   && rm -rf /var/lib/apt/lists/*
 
 # Cache modules first (same cache mount as the build step so they aren't

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /src
 # image must be built on an amd64 host (true on the ubuntu-latest CI runner);
 # arm64 cross-compiles cleanly.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends make gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+  && apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross make \
   && rm -rf /var/lib/apt/lists/*
 
 # Cache modules first (same cache mount as the build step so they aren't


### PR DESCRIPTION
## Summary

The Docker publish workflow added in #963 fails on the **arm64** cross-compile step ([failed run](https://github.com/0xPolygon/polygon-cli/actions/runs/29838886869/job/88662298265)):

```
/usr/include/stdio.h:28:10: fatal error: bits/libc-header-start.h: No such file or directory
```

## Cause

The build stage installs `gcc-aarch64-linux-gnu`, which pulls the arm64 **runtime** libs (`libc6-arm64-cross`, `libgcc-14-dev-arm64-cross`) but **not** the arm64 libc **dev headers**. The CGO cross-compile then can't find `bits/libc-header-start.h` / `bits/wordsize.h`. The release workflow (`make cross`) doesn't hit this because it runs on the full `ubuntu-latest` VM where those headers already exist; the slim `golang` image ships neither.

The amd64 image builds fine (native compile on the amd64 runner), so only the arm64 path was affected.

## Fix

Install `libc6-dev-arm64-cross`, which provides the aarch64 sysroot headers.

## Validation

Reproduced the exact `amd64 → arm64` cross-compile under emulation:

- **Without** `libc6-dev-arm64-cross`: identical `bits/libc-header-start.h: No such file` failure.
- **With** it: `CROSS_OK`.

arm64 image also rebuilt and runs (`polycli version`) locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)