### PR TITLE
fix(p2p/sensor): keep writing when ClickHouse is down at startup

### DIFF
--- a/p2p/database/clickhouse.go
+++ b/p2p/database/clickhouse.go
@@ -3,7 +3,9 @@ package database
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -42,6 +44,11 @@ const (
 	chPeerBatch        = 2000
 	// How often to restate that the backend is unreachable.
 	chUnavailableWarnInterval = 1 * time.Minute
+	// chHasBlockTimeout bounds the HasBlock point lookup. It runs synchronously in
+	// the per-peer message loop, so without a deadline an unreachable backend would
+	// stall that peer for the pool's dial timeout on every block. An indexed lookup
+	// against a healthy backend is far below this.
+	chHasBlockTimeout = 2 * time.Second
 )
 
 // Event sources, so consumers can tell a hash announcement from a delivered
@@ -145,8 +152,10 @@ func NewClickHouse(ctx context.Context, opts ClickHouseOptions) Database {
 		// head and looked entirely healthy. That is exactly what a ClickHouse auth
 		// failure did -- two sensors ran for an hour writing nothing.
 		//
-		// So keep saying so. A dead backend is now visible in the logs for as long as
-		// it is dead, not only in the line that scrolled past at boot.
+		// So keep saying so. Only a malformed DSN reaches this branch now; a backend
+		// that is merely unreachable keeps its connection and reports per flush. Either
+		// way the failure stays in the logs for as long as it lasts, rather than only
+		// in the line that scrolled past at boot.
 		log.Error().Err(err).Msg("Could not initialize ClickHouse connection; ALL WRITES WILL BE DISCARDED")
 		// Its own cancel, stored on c, so Close stops it. Without this Close waits on
 		// a goroutine nothing can stop -- the same defect as the batchers inheriting
@@ -186,8 +195,9 @@ func (c *ClickHouse) Close() error {
 	return nil
 }
 
-// connectClickHouse parses the DSN, opens a connection, and verifies
-// connectivity with a ping.
+// connectClickHouse parses the DSN and opens a connection. It pings only to
+// surface an unreachable backend in the logs; the ping result does not gate the
+// returned connection, so a nil error does not mean ClickHouse is reachable.
 func connectClickHouse(ctx context.Context, dsn string) (driver.Conn, error) {
 	chOpts, err := clickhouse.ParseDSN(dsn)
 	if err != nil {
@@ -205,6 +215,13 @@ func connectClickHouse(ctx context.Context, dsn string) (driver.Conn, error) {
 	}
 	if chOpts.MaxOpenConns == 0 {
 		chOpts.MaxOpenConns = 20
+	}
+	// The driver's 30s default would consume a whole chFlushTimeout window on a
+	// single dial against a down backend, and it is the ceiling on how long any
+	// operation waits for a fresh pool connection. Both callers here would rather
+	// fail fast: flushes retry on the next tick, and HasBlock degrades to true.
+	if chOpts.DialTimeout == 0 {
+		chOpts.DialTimeout = 5 * time.Second
 	}
 
 	conn, err := clickhouse.Open(chOpts)
@@ -661,12 +678,9 @@ func (c *ClickHouse) WritePeers(ctx context.Context, peers []*p2p.Peer, tls time
 	}
 }
 
-// HasBlock reports whether the block already exists. Called once per new block
-// (not per event), so an indexed point lookup is cheap. Without a connection it
-// reports true so the sensor never attempts a backfill it could not persist.
-// startUnavailableWarning re-logs while the backend is unreachable, so the failure
-// keeps showing up in logs and alerting instead of scrolling past once at startup.
-// It does not reconnect, and now only runs for DSN/config failures -- an
+// startUnavailableWarning re-logs while the sensor has no connection at all, so the
+// failure keeps showing up in logs and alerting instead of scrolling past once at
+// startup. It does not reconnect, and now only runs for DSN/config failures -- an
 // unreachable backend keeps its connection and retries per flush instead.
 func (c *ClickHouse) startUnavailableWarning(ctx context.Context) {
 	c.wg.Add(1)
@@ -690,17 +704,32 @@ func (c *ClickHouse) startUnavailableWarning(ctx context.Context) {
 // HasBlock reports whether the block is already stored, which the sensor uses to
 // decide whether to backfill a parent.
 //
-// With no connection it returns true -- "we have it" -- to suppress backfill rather
-// than let every block queue parent requests that can never be satisfied. That is
-// the safer degradation, but it does mean a dead backend is silent in this path
-// specifically; startUnavailableWarning is what makes it visible.
+// When the lookup cannot be answered -- no connection, or a query that fails or
+// exceeds chHasBlockTimeout -- it returns true, "we have it", to suppress backfill
+// rather than let every block queue parent requests that can never be satisfied.
+// That is the safer degradation, but it does mean a dead backend is quiet in this
+// path specifically; the per-flush insert errors are what make it visible.
+//
+// The deadline matters because this runs inline in the per-peer message loop on a
+// context with no deadline of its own: an unreachable backend would otherwise block
+// that peer for the driver's dial timeout on every single block.
 func (c *ClickHouse) HasBlock(ctx context.Context, hash common.Hash) bool {
 	if c.conn == nil {
 		return true
 	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, chHasBlockTimeout)
+	defer cancel()
+
 	var exists uint8
-	err := c.conn.QueryRow(ctx, "SELECT 1 FROM blocks WHERE hash = ? LIMIT 1", hash.Hex()).Scan(&exists)
-	return err == nil && exists == 1
+	if err := c.conn.QueryRow(queryCtx, "SELECT 1 FROM blocks WHERE hash = ? LIMIT 1", hash.Hex()).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+		log.Debug().Err(err).Msg("Could not check whether block is stored; assuming it is to suppress backfill")
+		return true
+	}
+	return exists == 1
 }
 
 // NodeList returns the most recently seen peers' enode URLs, from the narrow

--- a/p2p/database/clickhouse.go
+++ b/p2p/database/clickhouse.go
@@ -212,8 +212,14 @@ func connectClickHouse(ctx context.Context, dsn string) (driver.Conn, error) {
 		return nil, fmt.Errorf("could not connect to ClickHouse: %w", err)
 	}
 
+	// Diagnostic, not fatal. Open does no I/O -- the pool dials lazily and replaces
+	// broken connections, and every flush already retries (newInsertBatcher) -- so a
+	// backend that is not up *yet* recovers once it is. Failing here instead returns
+	// a no-op instance that nothing reconnects, which discarded every row on a whole
+	// sensor fleet that started 12s before ClickHouse finished binding.
 	if err := conn.Ping(ctx); err != nil {
-		return nil, fmt.Errorf("could not ping ClickHouse: %w", err)
+		log.Warn().Err(err).
+			Msg("Could not ping ClickHouse at startup; continuing, the connection pool will retry on first write")
 	}
 	return conn, nil
 }
@@ -660,8 +666,8 @@ func (c *ClickHouse) WritePeers(ctx context.Context, peers []*p2p.Peer, tls time
 // reports true so the sensor never attempts a backfill it could not persist.
 // startUnavailableWarning re-logs while the backend is unreachable, so the failure
 // keeps showing up in logs and alerting instead of scrolling past once at startup.
-// It does not reconnect: a sensor whose database was down at boot needs a restart,
-// and pretending otherwise would hide that.
+// It does not reconnect, and now only runs for DSN/config failures -- an
+// unreachable backend keeps its connection and retries per flush instead.
 func (c *ClickHouse) startUnavailableWarning(ctx context.Context) {
 	c.wg.Add(1)
 	go func() {


### PR DESCRIPTION
# Description

`connectClickHouse` treated a failed startup ping as fatal. `NewClickHouse` then returned a no-op instance that discarded every row for the lifetime of the process and never reconnected — the sensor peered, tracked the head, and looked entirely healthy while writing nothing.

Nothing about that was necessary. The recovery path already existed:

- `clickhouse.Open` performs no I/O. The pool dials lazily on first use and replaces broken connections.
- `newInsertBatcher` already retries every flush `chMaxFlushAttempts` times and logs each failure with its table and row count.

The hard failure was the only thing preventing us from ever reaching that machinery. So the ping becomes diagnostic — logged at warn — and the connection is returned regardless.

`c.conn` is still assigned exactly once before any goroutine reads it, so this needs no synchronisation and introduces no reconnect goroutine.

## What prompted it

A sensor fleet and its ClickHouse VM were replaced in a single Terraform apply. The sensors pinged at 18:35:37; ClickHouse finished binding 9000 at 18:35:49 — twelve seconds later. All seven sensors latched "unavailable" and discarded roughly 2.5M rows over ~30 minutes, until every host was restarted by hand. `system.query_log` showed zero INSERTs for the whole window.

Restarting the containers fixed it immediately, which is what confirmed the connection logic, not the environment, was the problem.

## Behaviour change worth reviewing

A genuinely bad DSN or password no longer fails fast. I don't think that is a regression — the pre-existing comment in this file records an auth failure where *"two sensors ran for an hour writing nothing"*, so the old path degraded to the same silent no-op. It now surfaces as a per-flush warning naming the table and error, which says more than the single startup line that used to scroll past. But it does mean a misconfigured DSN presents as repeated flush warnings rather than one fatal error, and reviewers may prefer a different trade-off.

I also updated the `startUnavailableWarning` comment, which claimed *"a sensor whose database was down at boot needs a restart"*. That is no longer true — the path now only runs for DSN/config failures.

## Jira / Linear Tickets

- [DVT-000]()

# Testing

- [x] `go build ./p2p/...`
- [x] `go vet ./p2p/database/`
- [x] `go test ./p2p/database/...` — passes
- [ ] **Not covered by any test, and the passing suite does not demonstrate the fix.** The behaviour that matters is: start a sensor with ClickHouse down, bring ClickHouse up, confirm INSERTs begin without a restart. Worth adding before this merges — happy to write it if you want it in this PR.
- [ ] Verify a deliberately bad password still produces visibly failing flushes rather than silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)