### PR TITLE
feat(loadtest): add --send-rpc-url and --rate-limit-ramp-duration

### DIFF
--- a/cmd/loadtest/cmd.go
+++ b/cmd/loadtest/cmd.go
@@ -118,6 +118,7 @@ func initPersistentFlags() {
 	pf.BoolVar(&cfg.PrivateTxs, "private-txs", false, "send transactions via eth_sendRawTransactionPrivate")
 	pf.Uint64Var(&cfg.EthAmountInWei, "eth-amount-in-wei", 0, "amount of ether in wei to send per transaction")
 	pf.Float64Var(&cfg.RateLimit, "rate-limit", 4, "requests per second limit (use negative value to remove limit)")
+	pf.DurationVar(&cfg.RateLimitRampDuration, "rate-limit-ramp-duration", 0, "linearly ramp rate limit from max(1% of --rate-limit, 1 TPS) to full --rate-limit over this duration (e.g. 3m; 0 disables ramp)")
 	pf.BoolVar(&cfg.AdaptiveRateLimit, "adaptive-rate-limit", false, "enable AIMD-style congestion control to automatically adjust request rate")
 	pf.Uint64Var(&cfg.AdaptiveTargetSize, "adaptive-target-size", 1000, "target queue size for adaptive rate limiting (speed up if smaller, back off if larger)")
 	pf.Uint64Var(&cfg.AdaptiveRateLimitIncrement, "adaptive-rate-limit-increment", 50, "size of additive increases for adaptive rate limiting")

--- a/cmd/loadtest/cmd.go
+++ b/cmd/loadtest/cmd.go
@@ -104,6 +104,7 @@ func init() {
 func initPersistentFlags() {
 	pf := LoadtestCmd.PersistentFlags()
 	pf.StringVarP(&cfg.RPCURL, flag.RPCURL, "r", flag.DefaultRPCURL, "the RPC endpoint URL")
+	pf.StringVar(&cfg.SendRPCURL, "send-rpc-url", "", "secondary RPC endpoint used only to broadcast transactions (eth_sendRawTransaction / eth_sendRawTransactionPrivate); all other calls use --rpc-url")
 	pf.Int64VarP(&cfg.Requests, "requests", "n", 1, "number of requests to perform for the benchmarking session (default of 1 leads to non-representative results)")
 	pf.Int64VarP(&cfg.Concurrency, "concurrency", "c", 1, "number of requests to perform concurrently (default: one at a time)")
 	pf.Int64VarP(&cfg.TimeLimit, "time-limit", "t", -1, "maximum seconds to spend benchmarking (default: no limit)")

--- a/cmd/loadtest/loadtestUsage.md
+++ b/cmd/loadtest/loadtestUsage.md
@@ -53,6 +53,19 @@ Here is a simple example that runs 1000 requests at a max rate of 1 request per 
 $ polycli loadtest --verbosity 700 --chain-id 1256 --concurrency 1 --requests 1000 --rate-limit 1 --mode t --rpc-url http://localhost:8888
 ```
 
+### Separate Broadcast Endpoint
+
+By default, all RPC calls (gas estimation, chain ID, nonces, receipts, and transaction broadcast) go to `--rpc-url`. The `--send-rpc-url` flag routes only the transaction broadcast (`eth_sendRawTransaction`, or `eth_sendRawTransactionPrivate` when combined with `--private-txs`) to a secondary endpoint while everything else, including account funding, stays on `--rpc-url`. This is useful for:
+
+- **Private mempools**: an endpoint that only accepts `eth_sendRawTransactionPrivate`.
+- **Gossip-only broadcasters**: a light client connected to the p2p network that can broadcast transactions but has no chain state to answer other queries.
+
+```bash
+$ polycli loadtest --rpc-url http://fullnode:8545 --send-rpc-url http://broadcaster:8545 --mode t
+```
+
+Like `--private-txs`, this flag is only supported by the modes that broadcast transactions explicitly: `transaction`, `blob`, `contract-call`, and `recall`.
+
 ### Gas Manager
 
 The loadtest command includes an optional gas manager for controlling transaction gas limits and pricing. Enable it with `--gas-manager-enabled`, then use the `--gas-manager-*` flags to:

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -74,6 +74,19 @@ Here is a simple example that runs 1000 requests at a max rate of 1 request per 
 $ polycli loadtest --verbosity 700 --chain-id 1256 --concurrency 1 --requests 1000 --rate-limit 1 --mode t --rpc-url http://localhost:8888
 ```
 
+### Separate Broadcast Endpoint
+
+By default, all RPC calls (gas estimation, chain ID, nonces, receipts, and transaction broadcast) go to `--rpc-url`. The `--send-rpc-url` flag routes only the transaction broadcast (`eth_sendRawTransaction`, or `eth_sendRawTransactionPrivate` when combined with `--private-txs`) to a secondary endpoint while everything else, including account funding, stays on `--rpc-url`. This is useful for:
+
+- **Private mempools**: an endpoint that only accepts `eth_sendRawTransactionPrivate`.
+- **Gossip-only broadcasters**: a light client connected to the p2p network that can broadcast transactions but has no chain state to answer other queries.
+
+```bash
+$ polycli loadtest --rpc-url http://fullnode:8545 --send-rpc-url http://broadcaster:8545 --mode t
+```
+
+Like `--private-txs`, this flag is only supported by the modes that broadcast transactions explicitly: `transaction`, `blob`, `contract-call`, and `recall`.
+
 ### Gas Manager
 
 The loadtest command includes an optional gas manager for controlling transaction gas limits and pricing. Enable it with `--gas-manager-enabled`, then use the `--gas-manager-*` flags to:
@@ -183,6 +196,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
   -r, --rpc-url string                                   the RPC endpoint URL (default "http://localhost:8545")
       --seed int                                         a seed for generating random values and addresses (default 123456)
       --send-only                                        alias for --fire-and-forget
+      --send-rpc-url string                              secondary RPC endpoint used only to broadcast transactions (eth_sendRawTransaction / eth_sendRawTransactionPrivate); all other calls use --rpc-url
       --sending-accounts-count uint                      number of sending accounts to use (avoids pool account queue)
       --sending-accounts-file string                     file with sending account private keys, one per line (avoids pool queue and preserves accounts across runs)
       --sequential-nonce-fetch                           fetch nonces sequentially instead of in parallel (use if hitting rate limits)

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -187,6 +187,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --proxy string                                     use the proxy specified
       --random-recipients                                send to random addresses instead of fixed address in transfer tests
       --rate-limit float                                 requests per second limit (use negative value to remove limit) (default 4)
+      --rate-limit-ramp-duration duration                linearly ramp rate limit from max(1% of --rate-limit, 1 TPS) to full --rate-limit over this duration (e.g. 3m; 0 disables ramp)
       --recall-blocks uint                               number of blocks that we'll attempt to fetch for recall (default 50)
       --receipt-retry-initial-delay-ms uint              initial delay in milliseconds for receipt polling (uses exponential backoff with jitter) (default 100)
       --receipt-retry-max uint                           maximum polling attempts for transaction receipt with --wait-for-receipt (default 30)

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -119,6 +119,7 @@ The command also inherits flags from parent commands.
   -r, --rpc-url string                                   the RPC endpoint URL (default "http://localhost:8545")
       --seed int                                         a seed for generating random values and addresses (default 123456)
       --send-only                                        alias for --fire-and-forget
+      --send-rpc-url string                              secondary RPC endpoint used only to broadcast transactions (eth_sendRawTransaction / eth_sendRawTransactionPrivate); all other calls use --rpc-url
       --stop-on-insufficient-funds                       stop sending from account when it encounters insufficient funds error
       --summarize                                        produce execution summary after load test (can take a long time for large tests)
   -t, --time-limit int                                   maximum seconds to spend benchmarking (default: no limit) (default -1)

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -114,6 +114,7 @@ The command also inherits flags from parent commands.
       --private-txs                                      send transactions via eth_sendRawTransactionPrivate
       --random-recipients                                send to random addresses instead of fixed address in transfer tests
       --rate-limit float                                 requests per second limit (use negative value to remove limit) (default 4)
+      --rate-limit-ramp-duration duration                linearly ramp rate limit from max(1% of --rate-limit, 1 TPS) to full --rate-limit over this duration (e.g. 3m; 0 disables ramp)
   -n, --requests int                                     number of requests to perform for the benchmarking session (default of 1 leads to non-representative results) (default 1)
       --rpc-headers string                               custom HTTP headers for RPC requests (format: "key1:value1,key2:value2")
   -r, --rpc-url string                                   the RPC endpoint URL (default "http://localhost:8545")

--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/0xPolygon/polygon-cli/loadtest/uniswapv3"
+	"github.com/0xPolygon/polygon-cli/util"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -38,6 +39,7 @@ const (
 type Config struct {
 	// Network connection
 	RPCURL     string
+	SendRPCURL string
 	ChainID    uint64
 	Proxy      string
 	RPCHeaders string
@@ -207,7 +209,16 @@ func (c *Config) Validate() error {
 	}
 
 	if c.PrivateTxs {
-		if err := c.validatePrivateTxsModes(); err != nil {
+		if err := c.validateModesSupportRawSend("--private-txs"); err != nil {
+			return err
+		}
+	}
+
+	if c.SendRPCURL != "" {
+		if err := util.ValidateURL(c.SendRPCURL); err != nil {
+			return fmt.Errorf("invalid --send-rpc-url %q: %w", c.SendRPCURL, err)
+		}
+		if err := c.validateModesSupportRawSend("--send-rpc-url"); err != nil {
 			return err
 		}
 	}
@@ -233,8 +244,11 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// validatePrivateTxsModes checks that all specified modes support --private-txs.
-func (c *Config) validatePrivateTxsModes() error {
+// validateModesSupportRawSend checks that all specified modes broadcast their
+// transactions explicitly (rather than inside contract bindings), which is
+// required by flags that alter how transactions are sent, such as
+// --private-txs and --send-rpc-url.
+func (c *Config) validateModesSupportRawSend(flagName string) error {
 	supported := map[string]bool{
 		"t": true, "transaction": true,
 		"b": true, "blob": true,
@@ -244,7 +258,7 @@ func (c *Config) validatePrivateTxsModes() error {
 
 	for _, mode := range c.Modes {
 		if !supported[mode] {
-			return fmt.Errorf("--private-txs is not supported for mode %q; supported modes: transaction, blob, contract-call, recall", mode)
+			return fmt.Errorf("%s is not supported for mode %q; supported modes: transaction, blob, contract-call, recall", flagName, mode)
 		}
 	}
 

--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/0xPolygon/polygon-cli/loadtest/uniswapv3"
 	"github.com/0xPolygon/polygon-cli/util"
@@ -79,6 +80,7 @@ type Config struct {
 
 	// Rate limiting
 	RateLimit                  float64
+	RateLimitRampDuration      time.Duration
 	AdaptiveRateLimit          bool
 	AdaptiveTargetSize         uint64
 	AdaptiveRateLimitIncrement uint64
@@ -206,6 +208,18 @@ func (c *Config) Validate() error {
 
 	if c.GasPriceMultiplier == 0 {
 		return errors.New("gas price multiplier should be non-zero")
+	}
+
+	if c.RateLimitRampDuration < 0 {
+		return errors.New("--rate-limit-ramp-duration must be positive")
+	}
+	if c.RateLimitRampDuration > 0 {
+		if c.AdaptiveRateLimit {
+			return errors.New("--rate-limit-ramp-duration and --adaptive-rate-limit are mutually exclusive")
+		}
+		if c.RateLimit <= 0 {
+			return errors.New("--rate-limit-ramp-duration requires a positive --rate-limit to ramp up to")
+		}
 	}
 
 	if c.PrivateTxs {

--- a/loadtest/config/config_test.go
+++ b/loadtest/config/config_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// validConfig returns a minimal config that passes Validate.
+func validConfig() *Config {
+	return &Config{
+		AdaptiveBackoffFactor: 2,
+		GasPriceMultiplier:    1,
+		Modes:                 []string{"t"},
+	}
+}
+
+func TestValidateSendRPCURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		sendRPCURL string
+		privateTxs bool
+		modes      []string
+		wantErr    string
+	}{
+		{
+			name:  "unset send-rpc-url with any mode",
+			modes: []string{"erc20"},
+		},
+		{
+			name:       "supported modes",
+			sendRPCURL: "http://localhost:8546",
+			modes:      []string{"t", "transaction", "b", "blob", "cc", "contract-call", "R", "recall"},
+		},
+		{
+			name:       "unsupported mode",
+			sendRPCURL: "http://localhost:8546",
+			modes:      []string{"erc20"},
+			wantErr:    `--send-rpc-url is not supported for mode "erc20"`,
+		},
+		{
+			name:       "invalid url scheme",
+			sendRPCURL: "localhost:8546",
+			modes:      []string{"t"},
+			wantErr:    "invalid --send-rpc-url",
+		},
+		{
+			name:       "combined with private-txs",
+			sendRPCURL: "https://private.example.com",
+			privateTxs: true,
+			modes:      []string{"t"},
+		},
+		{
+			name:       "private-txs unsupported mode",
+			privateTxs: true,
+			modes:      []string{"uniswapv3"},
+			wantErr:    `--private-txs is not supported for mode "uniswapv3"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.SendRPCURL = tt.sendRPCURL
+			cfg.PrivateTxs = tt.privateTxs
+			cfg.Modes = tt.modes
+
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/loadtest/config/config_test.go
+++ b/loadtest/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // validConfig returns a minimal config that passes Validate.
@@ -10,7 +11,70 @@ func validConfig() *Config {
 	return &Config{
 		AdaptiveBackoffFactor: 2,
 		GasPriceMultiplier:    1,
+		RateLimit:             4,
 		Modes:                 []string{"t"},
+	}
+}
+
+func TestValidateRateLimitRampDuration(t *testing.T) {
+	tests := []struct {
+		name              string
+		rampDuration      time.Duration
+		rateLimit         float64
+		adaptiveRateLimit bool
+		wantErr           string
+	}{
+		{
+			name:      "no ramp",
+			rateLimit: 4,
+		},
+		{
+			name:         "valid ramp",
+			rampDuration: 3 * time.Minute,
+			rateLimit:    100,
+		},
+		{
+			name:         "negative duration",
+			rampDuration: -time.Minute,
+			rateLimit:    100,
+			wantErr:      "--rate-limit-ramp-duration must be positive",
+		},
+		{
+			name:              "mutually exclusive with adaptive",
+			rampDuration:      3 * time.Minute,
+			rateLimit:         100,
+			adaptiveRateLimit: true,
+			wantErr:           "--rate-limit-ramp-duration and --adaptive-rate-limit are mutually exclusive",
+		},
+		{
+			name:         "requires positive rate limit",
+			rampDuration: 3 * time.Minute,
+			rateLimit:    -1,
+			wantErr:      "--rate-limit-ramp-duration requires a positive --rate-limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.RateLimitRampDuration = tt.rampDuration
+			cfg.RateLimit = tt.rateLimit
+			cfg.AdaptiveRateLimit = tt.adaptiveRateLimit
+
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/loadtest/mode/dependencies.go
+++ b/loadtest/mode/dependencies.go
@@ -20,6 +20,11 @@ type Dependencies struct {
 	Client    *ethclient.Client
 	RPCClient *ethrpc.Client
 
+	// SendClient/SendRPCClient are used only to broadcast signed
+	// transactions. They alias Client/RPCClient unless --send-rpc-url is set.
+	SendClient    *ethclient.Client
+	SendRPCClient *ethrpc.Client
+
 	// Contract instances
 	LoadTesterContract *tester.LoadTester
 	LoadTesterAddress  common.Address

--- a/loadtest/modes/blob.go
+++ b/loadtest/modes/blob.go
@@ -114,9 +114,9 @@ func (m *BlobMode) Execute(ctx context.Context, cfg *config.Config, deps *mode.D
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
 	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.RPCClient, stx)
+		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.Client.SendTransaction(ctx, stx)
+		err = deps.SendClient.SendTransaction(ctx, stx)
 	}
 	return
 }

--- a/loadtest/modes/contractcall.go
+++ b/loadtest/modes/contractcall.go
@@ -125,9 +125,9 @@ func (m *ContractCallMode) Execute(ctx context.Context, cfg *config.Config, deps
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
 	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.RPCClient, stx)
+		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.Client.SendTransaction(ctx, stx)
+		err = deps.SendClient.SendTransaction(ctx, stx)
 	}
 	return
 }

--- a/loadtest/modes/recall.go
+++ b/loadtest/modes/recall.go
@@ -105,9 +105,9 @@ func (m *RecallMode) Execute(ctx context.Context, cfg *config.Config, deps *mode
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
 	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.RPCClient, stx)
+		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.Client.SendTransaction(ctx, stx)
+		err = deps.SendClient.SendTransaction(ctx, stx)
 	}
 	return
 }

--- a/loadtest/modes/transaction.go
+++ b/loadtest/modes/transaction.go
@@ -94,9 +94,9 @@ func (m *TransactionMode) Execute(ctx context.Context, cfg *config.Config, deps 
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
 	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.RPCClient, stx)
+		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.Client.SendTransaction(ctx, stx)
+		err = deps.SendClient.SendTransaction(ctx, stx)
 	}
 
 	return

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -548,6 +548,10 @@ func (r *Runner) mainLoop(ctx context.Context) error {
 	if cfg.AdaptiveRateLimit && r.rl != nil {
 		go r.updateRateLimit(rateLimitCtx)
 	}
+	if cfg.RateLimitRampDuration > 0 && r.rl != nil {
+		r.rl.SetLimit(rate.Limit(rampStartRate(cfg.RateLimit)))
+		go r.rampUpRateLimit(rateLimitCtx)
+	}
 
 	tops, err := bind.NewKeyedTransactorWithChainID(privateKey, chainID)
 	if err != nil {
@@ -1191,6 +1195,49 @@ func (r *Runner) updateRateLimit(ctx context.Context) {
 				r.rl.SetLimit(r.rl.Limit() / rate.Limit(cfg.AdaptiveBackoffFactor))
 				log.Info().Float64("New Rate Limit (RPS)", float64(r.rl.Limit())).Uint64("Current Tx Pool Size", txPoolSize).Uint64("Steady State Tx Pool Size", cfg.AdaptiveTargetSize).Msg("Backed off rate limit")
 			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// rampStartRate returns the initial rate for the ramp: 1% of the target,
+// but no lower than 1 TPS and never above the target itself.
+func rampStartRate(targetRate float64) float64 {
+	return min(max(targetRate/100, 1), targetRate)
+}
+
+// rampUpRateLimit linearly increases the rate limit from rampStartRate to the
+// full --rate-limit value over --rate-limit-ramp-duration, then exits,
+// leaving the fixed rate limit in place.
+func (r *Runner) rampUpRateLimit(ctx context.Context) {
+	cfg := r.cfg
+	targetRate := cfg.RateLimit
+	startRate := rampStartRate(targetRate)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	startTime := time.Now()
+	log.Info().
+		Float64("startRateLimit", startRate).
+		Float64("targetRateLimit", targetRate).
+		Dur("rampDuration", cfg.RateLimitRampDuration).
+		Msg("Starting rate limit ramp up")
+
+	for {
+		select {
+		case <-ticker.C:
+			elapsed := time.Since(startTime)
+			if elapsed >= cfg.RateLimitRampDuration {
+				r.rl.SetLimit(rate.Limit(targetRate))
+				log.Info().Float64("rateLimit", targetRate).Msg("Rate limit ramp up complete")
+				return
+			}
+			progress := float64(elapsed) / float64(cfg.RateLimitRampDuration)
+			newLimit := startRate + (targetRate-startRate)*progress
+			r.rl.SetLimit(rate.Limit(newLimit))
+			log.Trace().Float64("rateLimit", newLimit).Msg("Ramping up rate limit")
 		case <-ctx.Done():
 			return
 		}

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -58,9 +58,12 @@ type Runner struct {
 	// Preconf tracker
 	preconfTracker *PreconfTracker
 
-	// Clients
-	client    *ethclient.Client
-	rpcClient *ethrpc.Client
+	// Clients. sendClient/sendRPCClient are used only to broadcast
+	// transactions; they alias client/rpcClient unless --send-rpc-url is set.
+	client        *ethclient.Client
+	rpcClient     *ethrpc.Client
+	sendClient    *ethclient.Client
+	sendRPCClient *ethrpc.Client
 
 	// Gas price caching
 	cachedBlockNumber       *uint64
@@ -81,11 +84,9 @@ func NewRunner(cfg *config.Config) (*Runner, error) {
 	}, nil
 }
 
-// Init sets up the runner, including clients and account pool.
-func (r *Runner) Init(ctx context.Context) error {
-	log.Info().Msg("Initializing load test runner")
-
-	// Configure HTTP transport
+// dialRPC dials an RPC endpoint with its own HTTP transport, applying the
+// configured proxy and custom headers.
+func (r *Runner) dialRPC(ctx context.Context, rpcURL string) (*ethrpc.Client, error) {
 	connLimit := 2 * int(r.cfg.Concurrency)
 	transport := &http.Transport{
 		MaxIdleConns:        connLimit,
@@ -95,7 +96,7 @@ func (r *Runner) Init(ctx context.Context) error {
 	if r.cfg.Proxy != "" {
 		proxyURL, err := url.Parse(r.cfg.Proxy)
 		if err != nil {
-			return errors.New("invalid proxy address: " + r.cfg.Proxy + ": " + err.Error())
+			return nil, errors.New("invalid proxy address: " + r.cfg.Proxy + ": " + err.Error())
 		}
 		transport.Proxy = http.ProxyURL(proxyURL)
 		log.Debug().Stringer("proxyURL", proxyURL).Msg("Transport proxy configured")
@@ -103,23 +104,49 @@ func (r *Runner) Init(ctx context.Context) error {
 
 	goHTTPClient := &http.Client{Transport: transport}
 	rpcOption := ethrpc.WithHTTPClient(goHTTPClient)
-	rpc, err := ethrpc.DialOptions(ctx, r.cfg.RPCURL, rpcOption)
+	rpc, err := ethrpc.DialOptions(ctx, rpcURL, rpcOption)
 	if err != nil {
-		return errors.New("unable to dial rpc: " + err.Error())
+		return nil, errors.New("unable to dial rpc: " + err.Error())
 	}
 	rpc.SetHeader("Accept-Encoding", "identity")
 	for key, value := range r.cfg.Headers {
 		rpc.SetHeader(key, value)
 		log.Debug().Str("header", key).Msg("Custom RPC header configured")
 	}
+	return rpc, nil
+}
+
+// Init sets up the runner, including clients and account pool.
+func (r *Runner) Init(ctx context.Context) error {
+	log.Info().Msg("Initializing load test runner")
+
+	rpc, err := r.dialRPC(ctx, r.cfg.RPCURL)
+	if err != nil {
+		return err
+	}
 	r.rpcClient = rpc
 	r.client = ethclient.NewClient(rpc)
 
+	if r.cfg.SendRPCURL != "" {
+		sendRPC, err := r.dialRPC(ctx, r.cfg.SendRPCURL)
+		if err != nil {
+			return err
+		}
+		r.sendRPCClient = sendRPC
+		r.sendClient = ethclient.NewClient(sendRPC)
+		log.Info().Str("sendRPCURL", r.cfg.SendRPCURL).Msg("Using separate RPC endpoint for transaction broadcast")
+	} else {
+		r.sendRPCClient = r.rpcClient
+		r.sendClient = r.client
+	}
+
 	// Initialize dependencies early so mode parsing can use them.
 	r.deps = &mode.Dependencies{
-		Client:     r.client,
-		RPCClient:  r.rpcClient,
-		RandSource: r.randSrc,
+		Client:        r.client,
+		RPCClient:     r.rpcClient,
+		SendClient:    r.sendClient,
+		SendRPCClient: r.sendRPCClient,
+		RandSource:    r.randSrc,
 	}
 
 	// Initialize load test parameters
@@ -1428,6 +1455,9 @@ func (r *Runner) dumpPrivateKeys() error {
 
 // Close cleans up runner resources.
 func (r *Runner) Close() {
+	if r.sendRPCClient != nil && r.sendRPCClient != r.rpcClient {
+		r.sendRPCClient.Close()
+	}
 	if r.rpcClient != nil {
 		r.rpcClient.Close()
 	}


### PR DESCRIPTION
# Description

Two additions to `polycli loadtest`:

**`--send-rpc-url`** — a secondary RPC endpoint used *only* to broadcast transactions (`eth_sendRawTransaction`, or `eth_sendRawTransactionPrivate` when combined with `--private-txs`). All other calls — gas estimation, chain ID, nonces, receipts, block polling, and account funding — stay on `--rpc-url`. This supports:

- Private mempool endpoints that only accept `eth_sendRawTransactionPrivate`.
- Gossip-only broadcasters (e.g. light clients on the p2p network) that can broadcast transactions but have no chain state to answer other queries.

The send endpoint gets its own HTTP connection pool (sized `2×concurrency`, same as the primary) so broadcasts don't contend with read traffic, and falls back to the primary client when the flag is unset. Like `--private-txs`, it is limited to the modes that broadcast explicitly (`transaction`, `blob`, `contract-call`, `recall`) and rejected at config validation for the binding-based modes.

**`--rate-limit-ramp-duration`** — linearly ramps the rate limit from `max(1% of --rate-limit, 1 TPS)` up to the full `--rate-limit` over the given duration (e.g. `3m`), then holds steady. Useful for warming up a network gradually instead of starting at full load. Mutually exclusive with `--adaptive-rate-limit`, which controls the same limiter based on txpool feedback.

No breaking changes; both flags are opt-in and default to current behavior.

## Jira / Linear Tickets

- N/A

# Testing

- [x] `make build`, `go vet`, `shadow`, `golangci-lint` (0 issues), `go test -race ./loadtest/...`
- [x] New config validation unit tests: `--send-rpc-url` / `--private-txs` mode allowlist, URL validation, ramp duration bounds and mutual exclusion with adaptive rate limiting
- [x] Live traffic-split verification against anvil with a method-logging proxy as the send endpoint: a 5-tx run produced exactly 5 `eth_sendRawTransaction` calls on the send endpoint and nothing else; with `--private-txs`, only `eth_sendRawTransactionPrivate`. Reads (gas, chain ID, nonces) all went to the primary RPC.
- [x] Live ramp verification against anvil: `--rate-limit 300 --rate-limit-ramp-duration 6s` starts at 3 TPS and climbs linearly (52 → 102 → 151 → 201 → 250) to 300, then the ramp goroutine exits.
- [x] Regression run without either flag behaves as before; docs regenerated via docutil

🤖 Generated with [Claude Code](https://claude.com/claude-code)